### PR TITLE
FIREFLY-1883: Migrate Redis client from Jedis to Lettuce

### DIFF
--- a/buildScript/dependencies.gradle
+++ b/buildScript/dependencies.gradle
@@ -46,8 +46,8 @@ dependencies {
 
     implementation ('com.googlecode.json-simple:json-simple:1.1.1') { transitive = false }
 
-    // jedis; support redis versions: 5.0 to 7.2 Family of releases
-    implementation ('redis.clients:jedis:4.4.8') { exclude group: 'org.slf4j' }
+    // Lettuce(Redis client); support Redis server version 2.6+ up to Redis 8.x
+    implementation 'io.lettuce:lettuce-core:7.0.0.RELEASE'
 
     // ehcache
     implementation ('net.sf.ehcache:ehcache:2.10.9.2')

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
@@ -441,7 +441,9 @@ public class RedisService {
             stats.add("hits", map.getOrDefault("keyspace_hits", "?"));
             stats.add("misses", map.getOrDefault("keyspace_misses", "?"));
             stats.add("evicted", map.getOrDefault("evicted_keys", "?"));
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            LOG.error(e, "RedisService getStats failed");
+        }
         return stats;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
@@ -10,30 +10,33 @@ import edu.caltech.ipac.firefly.server.events.ServerEventManager;
 import edu.caltech.ipac.firefly.server.servlets.ServerStatus;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.AppProperties;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.JedisPoolConfig;
-import redis.clients.jedis.Protocol;
+import edu.caltech.ipac.util.cache.Cache;
+import edu.caltech.ipac.util.cache.CacheKey;
+import edu.caltech.ipac.util.cache.CacheManager;
+import edu.caltech.ipac.util.cache.StringKey;
+import io.lettuce.core.*;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
+import io.lettuce.core.event.EventBus;
+import io.lettuce.core.event.connection.ConnectionActivatedEvent;
+import io.lettuce.core.event.connection.ConnectionDeactivatedEvent;
+import io.lettuce.core.resource.DefaultClientResources;
 import redis.embedded.RedisServer;
 
 import java.io.File;
-import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
-import static edu.caltech.ipac.firefly.core.Util.Try;
-import static edu.caltech.ipac.firefly.core.background.JobManager.ALL_JOB_CACHE_KEY;
+import static edu.caltech.ipac.firefly.core.background.JobManager.*;
 import static edu.caltech.ipac.firefly.server.cache.DistributedCache.DEF_TTL;
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
 import static edu.caltech.ipac.util.StringUtils.isUUID;
-
 
 /**
  * RedisService provides a connection management interface for interacting with a Redis server.
@@ -45,6 +48,10 @@ import static edu.caltech.ipac.util.StringUtils.isUUID;
  *
  * <p>Common use cases include checking the availability of the Redis server, monitoring
  * connection health, and ensuring proper connectivity before performing Redis operations.</p>
+ * Connections:
+ *  • mainConn     – regular GET/SET/HGET/HSET operations
+ *  • scanConn     – long-running SCAN/HSCAN operations
+ *  • subPubConn   – one-time subscription for Pub/Sub messaging.  Do not use for anything else.
  *
  * Date: 2024-11-18
  *
@@ -52,21 +59,177 @@ import static edu.caltech.ipac.util.StringUtils.isUUID;
  * @version $Id: $
  */
 public class RedisService {
-    public static final String REDIS_HOST = "redis.host";
-    public static final String MAX_POOL_SIZE = "redis.max.poolsize";
-    private static final int REDIS_PORT = AppProperties.getIntProperty("redis.port", 6379);
-    private static final String MAX_MEM = AppProperties.getProperty("redis.max.mem", "128M");
-    private static final String DB_DIR = AppProperties.getProperty("redis.db.dir", System.getProperty("java.io.tmpdir")+ "/redis");
-    private static final String REDIS_PASSWORD = getRedisPassword();
-    private static final Logger.LoggerImpl LOG = Logger.getLogger();
 
-    // message broker..  Jedis
-    private static final String redisHost = AppProperties.getProperty(REDIS_HOST, "localhost");
-    public static final int maxPoolSize = AppProperties.getIntProperty(MAX_POOL_SIZE, 100);
-    private static JedisPool jedisPool;
+    public static final long SCAN_BATCH_SIZE = AppProperties.getLongProperty("redis.scan.batch.size", 10_000);      // batch size for scanning keys in Redis.  Default to 10,000.  Larger value return more keys per call but use more CPU and memory per iteration.  this is a good size for larger redis store.
+    private static final String REDIS_HOST = AppProperties.getProperty("redis.host", "localhost");
+    private static final int REDIS_PORT = AppProperties.getIntProperty("redis.port", 6379);
+    private static final String DB_DIR = AppProperties.getProperty("redis.db.dir", System.getProperty("java.io.tmpdir") + "/redis");
+    private static final String REDIS_PASSWORD = getRedisPassword();
+    private static final String LOCAL_MAX_MEM = AppProperties.getProperty("local.redis.max.mem", "128M");
+    private static final Logger.LoggerImpl LOG = Logger.getLogger();
+    private static final CacheKey VersionKey = new StringKey(SchemaVersion.class.getSimpleName());
+    private enum SchemaVersion { V1_0, V1_1 }
+
+
     private static Instant failSince;
 
-    private static List<String> RESERVED_KEYS = List.of(ALL_JOB_CACHE_KEY);
+    private static RedisClient client;
+    private static StatefulRedisConnection<String, String> mainConn;
+    private static StatefulRedisConnection<String, String> scanConn;
+    private static StatefulRedisPubSubConnection<String, String> subPubConn;
+
+    private static final List<String> RESERVED_KEYS = List.of(ALL_JOB_CACHE_KEY);
+    private static final AtomicBoolean initialized = new AtomicBoolean(false);
+    private static final AtomicBoolean localStartupTriggered = new AtomicBoolean(false);
+
+    // -------------------------------------------------------------------------
+    // Initialization
+    // -------------------------------------------------------------------------
+
+    public static synchronized void init() throws Exception {
+        if (initialized.getAndSet(true)) return;
+
+        LOG.info("Initializing RedisService; waiting for connection to establish...");
+        RedisURI.Builder uriBuilder = RedisURI.builder()
+                .withHost(REDIS_HOST)
+                .withPort(REDIS_PORT);
+        if (REDIS_PASSWORD != null && !REDIS_PASSWORD.isBlank()) {
+            uriBuilder.withPassword(REDIS_PASSWORD.toCharArray());
+        }
+
+        client = RedisClient.create(DefaultClientResources.create(), uriBuilder.build());
+        client.setOptions(ClientOptions.builder()
+                .autoReconnect(true)            // Exponential delay begins with 1s and is capped at 30s
+                .disconnectedBehavior(ClientOptions.DisconnectedBehavior.ACCEPT_COMMANDS) // queue commands while disconnected
+                .pingBeforeActivateConnection(true)
+                .socketOptions(SocketOptions.builder()
+                        .keepAlive(true) // enable TCP keepalive packets
+                        .build())
+                .build());
+
+        // subscribe to Lettuce connection events → update setConnectionOk()
+        EventBus bus = client.getResources().eventBus();
+        bus.get().subscribe(event -> {
+            if (event instanceof ConnectionActivatedEvent ev) {
+                LOG.info("Redis connection established");
+                setConnectionOk(true);
+            } else if (event instanceof ConnectionDeactivatedEvent) {
+                LOG.info("Redis connection lost");
+                setConnectionOk(false);
+            }
+        });
+
+        // Wait until connected; Redis is required for proper operation.
+        // Once connected, Lettuce will auto-reconnect as needed.
+        long delaySec = 1;
+        while (!isConnected()) {
+            try {
+                tryConnect();
+                setConnectionOk(true);
+                LOG.info("Connected to Redis at " + REDIS_HOST + ":" + REDIS_PORT);
+            } catch (Exception e) {
+                LOG.error(e, "Unable to connect to Redis, retrying after a short delay...");
+                Thread.sleep(delaySec);
+                delaySec = Math.min(delaySec * 2, 30); // exponential backoff
+            }
+        }
+
+        // perform data migration when needed
+        dataMigration();
+
+    }
+
+    private static void tryConnect() throws Exception{
+        try {
+            mainConn = client.connect();
+            scanConn = client.connect();
+            subPubConn = client.connectPubSub();
+            LOG.info("Lettuce connections created. Auto-reconnect enabled.");
+        } catch (Exception e) {
+            LOG.error("Error connecting to Redis...");
+            if ("localhost".equals(REDIS_HOST) && !localStartupTriggered.getAndSet(true)) {  // start embedded just once
+                    LOG.warn("Redis not running locally — starting embedded Redis...");
+                    startLocal();
+                    tryConnect();
+            } else {
+                throw e;  // re-throw to trigger retry
+            }
+        }
+    }
+
+    private static void startLocal() throws Exception {
+        new File(DB_DIR).mkdirs();
+        RedisServer localRedis = RedisServer.newRedisServer()
+                .port(REDIS_PORT)
+                .setting("maxmemory %s".formatted(LOCAL_MAX_MEM))
+                .setting("dir %s".formatted(DB_DIR))
+                .setting("dbfilename redis.rdb")
+                .setting("save 600 1")
+                .build();
+        localRedis.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                localRedis.stop();
+                LOG.info("Local Redis stopped.");
+            } catch (Exception e) {
+                LOG.error(e, "Failed to stop local Redis");
+            }
+        }));
+        Thread.sleep(2_000);  // wait a bit for Redis to start
+        LOG.info("Local Redis started on port " + REDIS_PORT);
+    }
+
+    public static boolean isConnected() {
+        return mainConn != null && mainConn.isOpen() &&
+                scanConn != null && scanConn.isOpen() &&
+                subPubConn != null && subPubConn.isOpen();
+    }
+
+    // -------------------------------------------------------------------------
+    // Connection accessors
+    // -------------------------------------------------------------------------
+
+    public static StatefulRedisConnection<String, String> mainConn() throws Exception {
+        return checkConn(mainConn);
+    }
+
+    public static StatefulRedisConnection<String, String> scanConn() throws Exception {
+        return checkConn(scanConn);
+    }
+
+    public static StatefulRedisPubSubConnection<String, String> pubSubConn() throws Exception {
+        return checkConn(subPubConn);
+    }
+
+    private static <T extends StatefulRedisConnection<String, String>> T checkConn(T conn)
+            throws Exception {
+        if (conn == null) init();
+        if (conn != null && conn.isOpen()) return conn;
+        throw new RedisConnectionException("Redis connection not available");
+    }
+
+    // -------------------------------------------------------------------------
+    // Status & cleanup
+    // -------------------------------------------------------------------------
+
+    public static synchronized void teardown() {
+        LOG.info("Disconnecting RedisService...");
+        try {
+            if (subPubConn != null) subPubConn.close();
+            if (scanConn != null) scanConn.close();
+            if (mainConn != null) mainConn.close();
+            if (client != null) client.shutdown();
+        } catch (Exception e) {
+            LOG.error(e, "Error closing Redis connections");
+        } finally {
+            subPubConn = null;
+            scanConn = null;
+            mainConn = null;
+            client = null;
+            initialized.set(false);
+            localStartupTriggered.set(false);
+        }
+    }
 
     private static String getRedisPassword() {
         String passwd = System.getenv("REDIS_PASSWORD");
@@ -74,78 +237,18 @@ public class RedisService {
         return passwd;
     }
 
-    static JedisPool createJedisPool() {
-        try {
-            JedisPoolConfig pconfig = new JedisPoolConfig();
-            pconfig.setTestOnBorrow(true);
-            pconfig.setMaxTotal(maxPoolSize);
-            pconfig.setBlockWhenExhausted(true);                // wait; if needed
-            pconfig.setMaxWait(Duration.of(5, ChronoUnit.SECONDS));
-            JedisPool pool = new JedisPool(pconfig, redisHost, REDIS_PORT, Protocol.DEFAULT_TIMEOUT, REDIS_PASSWORD);
-            pool.getResource().ping();     // test connection
-            return pool;
-        } catch(Exception ignored) {}
-        return null;
-    }
-
-    static void startLocal() {
-        try {
-            new File(DB_DIR).mkdirs();      // ensure the directory exists
-            RedisServer redisServer = RedisServer.newRedisServer()
-                    .port(REDIS_PORT)
-                    .setting("maxmemory %s".formatted(MAX_MEM))
-                    .setting("dir %s".formatted(DB_DIR))            // Directory where redis database files are stored
-                    .setting("dbfilename redis.rdb")                // RDB file name
-                    .setting("save 600 1")                // RDB file name
-                    .build();
-            redisServer.start();
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                Try.it(redisServer::stop).getOrElse((e) -> LOG.error(e,"Failed to stop Redis"));
-            }));
-
-
-        } catch (IOException ignored) {}
-    }
-
-    public static Jedis getConnection() throws Exception {
-        try {
-            if (jedisPool == null) {
-                jedisPool = createJedisPool();
-            }
-            if (jedisPool == null && redisHost.equals("localhost")) {
-                // when running on localhost, startup Redis if it’s not already running.
-                startLocal();
-                jedisPool = createJedisPool();
-            }
-            if (jedisPool == null) {
-                throw new Exception("Failed to connect to Redis at %s:%d".formatted(redisHost, REDIS_PORT));
-            }
-            Jedis jedis = jedisPool.getResource();
-            jedis.ping(); // test connection before returning
-            setConnectionOk(true);
-            return jedis;
-        } catch (Exception e) {
-            setConnectionOk(false);
-            if (jedisPool != null) {
-                Try.it(jedisPool::close);
-                jedisPool = null;
-            }
-            throw e;
-        }
-    }
-
-    // because Redis may be down, we need to use processEvent to directly send it to clients currently connected
-    // to this server and not rely on distributed event messaging.
+    // -------------------------------------------------------------------------
+    // Monitoring / health
+    // -------------------------------------------------------------------------
+    
     public static void setConnectionOk(boolean ok) {
-        if (ok == (failSince == null)) {
-            return; // state unchanged
-        }
+        if (ok == (failSince == null)) return;
         failSince = ok ? null : Instant.now();
         sendConnectionStatus();     // notify clients of the update
     }
 
     public static void sendConnectionStatusIfFailed () {
-        if (failSince != null) sendConnectionStatus();
+        if (failSince != null) sendConnectionStatus();          // probably not needed anymore
     }
 
     public static void sendConnectionStatus() {
@@ -158,46 +261,60 @@ public class RedisService {
         ServerEventManager.processEvent(ServerEventManager.convertTo(action, ServerEvent.Scope.WORLD));
     }
 
-    public static void teardown() {
-        disconnect();
-        File[] files = new File(DB_DIR).listFiles();
-        if (files!= null) Arrays.stream(files).forEach(File::delete);
+    public static String getRedisHostPortDesc() {
+        String status = failSince == null ? "OK" :
+                "Failed since " + DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                        .withZone(ZoneId.systemDefault()).format(failSince);
+        return REDIS_HOST + ":" + REDIS_PORT + " (" + status + ")";
     }
 
-    public static void disconnect() {
-        if (jedisPool != null) {
-            jedisPool.close();
-            jedisPool = null;
-        }
-    }
+    // -------------------------------------------------------------------------
+    // Maintenance utilities
+    // -------------------------------------------------------------------------
 
     public static long cleanupStaleKeys() {
         long deleted = 0;
-        String cursor = "0";
-        try (Jedis redis = getConnection()) {
+
+        try {
+            var redis = scanConn().sync();
+            ScanArgs scanArgs = new ScanArgs().limit(5000); // same as JOB_SCAN_BATCH_SIZE if you want
+            ScanCursor cursor = ScanCursor.INITIAL;
+
             do {
-                var scanResult = redis.scan(cursor);
-                for (String key : scanResult.getResult()) {
+                // Scan synchronously
+                KeyScanCursor<String> scan = redis.scan(cursor, scanArgs);
+                List<String> keys = scan.getKeys();
+
+                for (String key : keys) {
                     if (RESERVED_KEYS.contains(key)) continue; // skip reserved keys
-                    long ttl = redis.ttl(key);
-                    if (ttl == -1) {        // no expiry time
-                        Long idletime = redis.objectIdletime(key);
-                        if (idletime != null && idletime >= DEF_TTL) {      // is older than configured default TTL
-                            redis.del(key);
-                            deleted++;
-                        }
+
+                    Long ttl = redis.ttl(key);
+                    Long idle = redis.objectIdletime(key);
+
+                    // ttl == -1 means no expiry
+                    // idle >= DEF_TTL means stale
+                    if (ttl != null && ttl == -1 && idle != null && idle >= DEF_TTL) {
+                        Long removed = redis.del(key);
+                        deleted += (removed != null ? removed : 0);
                     }
                 }
-                cursor = scanResult.getCursor();
-            } while (!cursor.equals("0"));
-        } catch (Exception ignored) {}
-            return deleted;
+
+                cursor = scan;
+            } while (!cursor.isFinished());
+
+        } catch (Exception e) {
+            LOG.error(e, "cleanupStaleKeys failed");
+        }
+
+        LOG.info("cleanupStaleKeys deleted " + deleted + " stale keys from Redis");
+        return deleted;
     }
 
     public static ServerStatus.EntryList getFullStats() {
-        ServerStatus.EntryList stats = getStats();
+        ServerStatus.EntryList stats = getStats(true);
 
-        try (Jedis redis = getConnection()) {
+        try {
+            var redis = RedisService.scanConn().sync();
 
             // Count keys and TTL stats
             long totalKeys = 0;
@@ -205,97 +322,184 @@ public class RedisService {
             long keysWithoutTTL = 0;
             long sessionKeys = 0;
             long staleKeys = 0;
-            String cursor = "0";
+
+            ScanArgs scanArgs = ScanArgs.Builder.limit(SCAN_BATCH_SIZE);
+            ScanCursor cursor = ScanCursor.INITIAL;
+
             do {
-                var scanResult = redis.scan(cursor);
-                var keys = scanResult.getResult();
+                KeyScanCursor<String> scanResult = redis.scan(cursor, scanArgs);
+                List<String> keys = scanResult.getKeys();
+
                 for (String key : keys) {
                     totalKeys++;
                     if (isUUID(key)) sessionKeys++;
+
                     long ttl = redis.ttl(key);
-                    if (ttl > 0)    keysWithTTL++;
-                    else            keysWithoutTTL++;
+                    if (ttl > 0) {
+                        keysWithTTL++;
+                    } else {
+                        keysWithoutTTL++;
+                    }
 
                     if (ttl == -1) { // Only consider keys without TTL
-                        Long idletime = redis.objectIdletime(key);
-                        if (idletime != null && idletime >= DEF_TTL) {
+                        Long idle = redis.objectIdletime(key);
+                        if (idle != null && idle >= DEF_TTL) {
                             staleKeys++;
                         }
                     }
                 }
-                cursor = scanResult.getCursor();
-            } while (!cursor.equals("0"));
+
+                cursor = scanResult;  // advance cursor
+            } while (!cursor.isFinished());
 
             stats.add(null, "\n> CACHE USAGE SUMMARY :")
-                .add("ALL_JOB_INFOS", redis.hlen(ALL_JOB_CACHE_KEY))
-                .add("Total keys", totalKeys)
-                .add("Session keys", sessionKeys)
-                .add("Keys with TTL", keysWithTTL)
-                .add("Keys without TTL", keysWithoutTTL)
-                .add("Staled keys", staleKeys);
+                 .add("ALL_JOB_INFOS", redis.hlen(ALL_JOB_CACHE_KEY))
+                 .add("Total keys", totalKeys)
+                 .add("Session keys", sessionKeys)
+                 .add("Keys with TTL", keysWithTTL)
+                 .add("Keys without TTL", keysWithoutTTL)
+                 .add("Staled keys", staleKeys);
 
-            // MEMORY STATS
-            stats.add(null, "\n> FULL RAW REDIS MEMORY STATS :");
-            Map<String, Object> memStats = redis.memoryStats();
-            memStats.forEach((stats::add));
+        } catch (Exception e) {
+            stats.add("error", e.getMessage());
+        }
 
-        } catch (Exception ignored) {}
         return stats;
     }
 
-    public static ServerStatus.EntryList getStats() {
-
+    public static ServerStatus.EntryList getStats(boolean detailed) {
         ServerStatus.EntryList stats = new ServerStatus.EntryList();
-        stats.add("status", getRedisHostPortDesc());
+
+        // obfuscate password
         String passwd = "";
         try {
             if (REDIS_PASSWORD != null) {
                 passwd = new String(MessageDigest.getInstance("MD5").digest(REDIS_PASSWORD.getBytes()));
             }
-        } catch (NoSuchAlgorithmException e) {/* ignore */}
-        try (Jedis redis = getConnection()) {
+        } catch (NoSuchAlgorithmException ignore) {}
 
-            var infos = redis.info().split("\r\n");
-            Arrays.stream(infos).filter(s -> s.contains("version")).findFirst()
-                    .ifPresent(s -> stats.add("version", s.split(":")[1].trim()));
+        try {
+            var redis = RedisService.scanConn().sync(); // your wrapper for mainConn.sync()
 
-            stats.add(null, "\n> CONNECTION STATS :");
-            stats.add("active conn", jedisPool.getNumActive())
-                .add("idle conn", jedisPool.getNumIdle())
-                .add("max conn", maxPoolSize)
-                .add("max-wait", jedisPool.getMaxBorrowWaitTimeMillis())
-                .add("avg-wait", jedisPool.getMeanBorrowWaitTimeMillis())
-                .add("db-size", redis.dbSize());
+            String info = redis.info();
+            Map<String, String> map = parseInfo(info);
 
+            stats.add(null, "> REDIS STATUS :");
+            stats.add("status", getRedisHostPortDesc());
+
+            // --- CONFIGURATION ---
+            Map<String, String> configMap = redis.configGet(
+                    "maxmemory",
+                    "save",
+                    "dir",
+                    "dbfilename",
+                    "appendfilename"
+            );
             stats.add(null, "\n> CONFIGURATION :");
-            addStat(stats, redis, "maxmemory");
-            addStat(stats, redis, "save");
-            addStat(stats, redis, "dir");
-            addStat(stats, redis, "dbfilename");
-            addStat(stats, redis, "appendfilename");
+            stats.add("PASSWORD-USED", isEmpty(passwd) ? "no" : "yes");
+            configMap.forEach(stats::add);
 
-            stats.add(null, "\n> MEMORY STATS :");
-            var mem = redis.memoryStats();
-            stats.add("Total memory used", mem.get("dataset.bytes"));
-            stats.add("Total memory allocated", mem.get("allocator.allocated"));
-            stats.add("Fragmented memory", mem.get("fragmentation"));
-            stats.add("Fragmentation ratio", mem.get("allocator-fragmentation.ratio"));
-            stats.add("Number of keys stored", mem.get("keys.count"));
-            stats.add("Avg per key", mem.get("keys.bytes-per-key"));
-            stats.add("Pct of memory used", mem.get("dataset.percentage"));
-            stats.add("Peak memory used", mem.get("peak.allocated"));
+            // --- Connection health ---
+            stats.add(null, "\n> CONNECTION :");
+            stats.add("connection ok", RedisService.isConnected());
+            stats.add("client name", redis.clientGetname() != null ? "connected" : "unknown");
+            stats.add("db size", redis.dbsize());
+
+            if (detailed) {     // dump all info
+                map.forEach(stats::add);
+                return stats;
+            }
+
+            // --- Basic server info ---
+            stats.add("version", map.getOrDefault("redis_version", "unknown"));
+            stats.add("mode", map.getOrDefault("redis_mode", "standalone"));
+            stats.add("uptime", map.getOrDefault("uptime_in_days", "?") + " days");
+
+
+            // --- Memory summary ---
+            stats.add(null, "\n> MEMORY :");
+            stats.add("used memory", map.getOrDefault("used_memory_human", "?"));
+            stats.add("peak memory", map.getOrDefault("used_memory_peak_human", "?"));
+            stats.add("fragmentation", map.getOrDefault("mem_fragmentation_ratio", "?"));
+            stats.add("max memory", map.getOrDefault("maxmemory_human", "unlimited"));
+            stats.add("policy", map.getOrDefault("maxmemory_policy", "noeviction"));
+
+            // --- Clients ---
+            stats.add(null, "\n> CLIENTS :");
+            stats.add("connected clients", map.getOrDefault("connected_clients", "?"));
+            stats.add("blocked clients", map.getOrDefault("blocked_clients", "?"));
+
+            // --- Keyspace & dataset ---
+            stats.add(null, "\n> KEYSPACE :");
+            stats.add("db0 keys", extractKeyspaceValue(map, "keys"));
+            stats.add("expires", extractKeyspaceValue(map, "expires"));
+            stats.add("dataset size", map.getOrDefault("used_memory_dataset_perc", "?") + "%");
+
+            // --- Performance ---
+            stats.add(null, "\n> PERFORMANCE :");
+            stats.add("ops/sec", map.getOrDefault("instantaneous_ops_per_sec", "?"));
+            stats.add("hits", map.getOrDefault("keyspace_hits", "?"));
+            stats.add("misses", map.getOrDefault("keyspace_misses", "?"));
+            stats.add("evicted", map.getOrDefault("evicted_keys", "?"));
         } catch (Exception ignored) {}
         return stats;
     }
 
-    public static void addStat(ServerStatus.EntryList stats, Jedis redis, String key) {
-        var c = redis.configGet(key);
-        if (c.size() > 1) stats.add(key, c.get(1));
+    private static String extractKeyspaceValue(Map<String, String> map, String key) {
+        // Keyspace line looks like: db0:keys=4,expires=3,avg_ttl=1156410888
+        return map.entrySet().stream()
+                .filter(e -> e.getKey().startsWith("db"))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .map(val -> {
+                    for (String kv : val.split(",")) {
+                        if (kv.startsWith(key + "=")) return kv.split("=")[1];
+                    }
+                    return "?";
+                })
+                .orElse("?");
     }
 
-    public static String getRedisHostPortDesc() {
-        String status = failSince == null ? "OK" :
-                "Failed since " + DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault()).format(failSince);
-        return redisHost + ":" + REDIS_PORT + " (%s)".formatted(status);
+    private static Map<String, String> parseInfo(String info) {
+        return Arrays.stream(info.split("\r\n"))
+                .filter(line -> line.contains(":") && !line.startsWith("#"))
+                .map(line -> line.split(":", 2))
+                .collect(Collectors.toMap(
+                        parts -> parts[0],
+                        parts -> parts[1],
+                        (a, b) -> b,  // handle duplicate keys (keep last)
+                        LinkedHashMap::new
+                ));
     }
+
+    //====================================================================
+    //  Redis Data Structure Migration
+    //====================================================================
+
+    private static void dataMigration() {
+        LOG.info("Ensure Redis data structure is up to date");
+        Cache<String> redisCache = CacheManager.getDistributed();
+        String cVersion = redisCache.get(VersionKey);
+
+        // pre-versioned to 1.0:
+        // switch to composite job key; jobId:userKey
+        String jobCacheVersion = redisCache.get(JOB_CACHE_VERSION_KEY);
+        if (isEmpty(cVersion) && isEmpty(jobCacheVersion)) {
+            LOG.info("Migrating unversioned Redis data schema to version 1.0");
+            LOG.info("  - change to composite job key; jobId:userKey");
+            int count = migrateRedisKeys();
+            LOG.info("Migrated " + count + " job keys to new format");
+            CacheManager.getDistributed().put(JOB_CACHE_VERSION_KEY, "1.0");
+        }
+
+        // moving 1.0 to V1_1:
+        // Rename key to SchemaVersion.  Apply version to the full Redis data structure and not just JobInfo.
+        if (!isEmpty(jobCacheVersion)) {
+            LOG.info("Updating Redis data structure version from 1.0 to V1.1");
+            redisCache.remove(JOB_CACHE_VERSION_KEY);
+            redisCache.put(VersionKey, SchemaVersion.V1_1.name());
+        }
+    }
+
+
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/RedisService.java
@@ -388,16 +388,28 @@ public class RedisService {
             stats.add("status", getRedisHostPortDesc());
 
             // --- CONFIGURATION ---
-            Map<String, String> configMap = redis.configGet(
-                    "maxmemory",
-                    "save",
-                    "dir",
-                    "dbfilename",
-                    "appendfilename"
-            );
+            Map<String, String> configMap = null;
+            try {
+                configMap = redis.configGet(
+                        "maxmemory",
+                        "save",
+                        "dir",
+                        "dbfilename",
+                        "appendfilename"
+                );
+            } catch (Exception e) {
+                // fallback for restricted servers
+                String memoryInfo = redis.info("memory");
+                String serverInfo = redis.info("server");
+                configMap = new LinkedHashMap<>();
+                configMap.put("maxmemory", extract(memoryInfo, "maxmemory"));
+                configMap.put("dir", extract(serverInfo, "dir"));
+                configMap.put("dbfilename", extract(serverInfo, "dbfilename"));
+                configMap.put("appendfilename", extract(serverInfo, "appendfilename"));
+            }
             stats.add(null, "\n> CONFIGURATION :");
             stats.add("PASSWORD-USED", isEmpty(passwd) ? "no" : "yes");
-            configMap.forEach(stats::add);
+            if (configMap != null) configMap.forEach(stats::add);
 
             // --- Connection health ---
             stats.add(null, "\n> CONNECTION :");
@@ -445,6 +457,15 @@ public class RedisService {
             LOG.error(e, "RedisService getStats failed");
         }
         return stats;
+    }
+
+    private static String extract(String info, String key) {
+        for (String line : info.split("\\r?\\n")) {
+            if (line.startsWith(key + ":")) {
+                return line.substring(key.length() + 1).trim();
+            }
+        }
+        return null;
     }
 
     private static String extractKeyspaceValue(Map<String, String> map, String key) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -5,7 +5,6 @@
 package edu.caltech.ipac.firefly.core.background;
 
 import edu.caltech.ipac.firefly.api.Async;
-import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.core.Util.Try;
 import edu.caltech.ipac.firefly.data.ServerEvent;
 import edu.caltech.ipac.firefly.data.userdata.UserInfo;
@@ -23,11 +22,10 @@ import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.cache.CacheKey;
 import edu.caltech.ipac.util.cache.CacheManager;
 import edu.caltech.ipac.util.cache.StringKey;
+import io.lettuce.core.ScanArgs;
 import org.apache.commons.lang.text.StrBuilder;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.params.ScanParams;
 
 import javax.annotation.Nonnull;
 import java.io.Serializable;
@@ -46,12 +44,14 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static edu.caltech.ipac.firefly.core.RedisService.SCAN_BATCH_SIZE;
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.firefly.core.background.Job.Type.UWS;
 import static edu.caltech.ipac.firefly.core.background.JobInfo.*;
 import static edu.caltech.ipac.firefly.core.background.JobUtil.*;
 import static edu.caltech.ipac.firefly.data.ServerParams.EMAIL;
+import static edu.caltech.ipac.firefly.server.ServerContext.SCHEDULE_TASK_EXEC;
 import static edu.caltech.ipac.firefly.server.query.UwsJobProcessor.getUwsJobInfo;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 import static edu.caltech.ipac.firefly.core.background.Job.Type.PACKAGE;
@@ -75,7 +75,6 @@ public class JobManager {
     private static final int MAX_PACKAGERS = AppProperties.getIntProperty("job.max.packagers", 10);             // maximum number of simultaneous packaging threads
     private static final int JOB_EXPIRY_HOURS = AppProperties.getIntProperty("job.expiry.hours", 24*14);        // Time in hours to keep a job after it has ended.  Default to 14 days.
     private static final int JOB_ARCHIVED_EXPIRY_HOURS = AppProperties.getIntProperty("job.archived.expiry.hours", 24*14);   // Time in hours to keep an archived job after it has ended.  Default to 14 days.
-    public static final int JOB_SCAN_BATCH_SIZE = AppProperties.getIntProperty("job.scan.batch_size", 10_000);   // batch size for scanning job keys in Redis.  Default to 10,000.  Larger value return more keys per call but use more CPU and memory per iteration.  this is a good size for larger redis store.
 
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
     private static final ExecutorService packagers = Executors.newFixedThreadPool(MAX_PACKAGERS);
@@ -83,41 +82,36 @@ public class JobManager {
     private static final HashMap<String, JobEntry> runningJobs = new HashMap<>();
     private static final DistribMapCache<JobInfo> allJobInfos = new DistribMapCache<>(ALL_JOB_CACHE_KEY, 0, new JobInfoSerializer()); // the all job hash should never expire
     private static final String COMPLETED_HANDLER = AppProperties.getProperty("job.completed.handler");
-    private static final CacheKey JOB_CACHE_VERSION_KEY = new StringKey("job.all.cache.version");
-    private static final String JOB_CACHE_VERSION = "1.0";
+    public static final CacheKey JOB_CACHE_VERSION_KEY = new StringKey("job.all.cache.version");
 
     public static void init() {
+
+        Messenger.subscribe(JobEvent.TOPIC, new JobEventHandler());
+
+        // setup completed handler if configured
         if (!isEmpty(COMPLETED_HANDLER)) {
             Class<?> clz = Try.it(() -> Class.forName(COMPLETED_HANDLER)).get();
             if (clz != null && JobCompletedHandler.class.isAssignableFrom(clz)) {
                 JobCompletedHandler handler = Try.it(() -> (JobCompletedHandler) clz.newInstance()).get();
-                if (handler != null)    Messenger.subscribe(JobCompletedEvent.TOPIC, handler);
+                if (handler != null) Messenger.subscribe(JobCompletedEvent.TOPIC, handler);
             } else {
                 LOG.error("Invalid JobCompletedHandler class: " + COMPLETED_HANDLER);
             }
         }
 
-        Messenger.subscribe(JobEvent.TOPIC, new JobEventHandler());
-        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
-                JobManager::checkJobs, KEEP_ALIVE_INTERVAL, KEEP_ALIVE_INTERVAL, TimeUnit.SECONDS);   // check every 30 seconds
+        // setup cleanup schedule task
+        SCHEDULE_TASK_EXEC.scheduleAtFixedRate(
+                JobManager::cleanup,
+                JobManager.CLEANUP_INTVL_MINS,
+                JobManager.CLEANUP_INTVL_MINS,
+                TimeUnit.MINUTES);
 
-        ScheduledExecutorService migrator = Executors.newSingleThreadScheduledExecutor();
-        migrator.scheduleWithFixedDelay(() -> {
-            try (Jedis jedis = RedisService.getConnection()) {
-                // run migration only when there's connection to Redis
-                LOG.info("Ensure job history is up to date");
-                String jobCacheVersion = (String) CacheManager.getDistributed().get(JOB_CACHE_VERSION_KEY);
-                if (isEmpty(jobCacheVersion) || !jobCacheVersion.equals(JOB_CACHE_VERSION)) {
-                    LOG.info("Migrating job history keys to new format");
-                    int count = migrateRedisKeys();
-                    LOG.info("Migrated "+ count + " job keys to new format");
-                    CacheManager.getDistributed().put(JOB_CACHE_VERSION_KEY, JOB_CACHE_VERSION);
-                }
-                migrator.shutdown(); // stop once successful
-            } catch (Exception e) {
-                LOG.debug("Job history check failed, retrying in 5s");
-            }
-        }, 0, 5, TimeUnit.SECONDS);
+        // setup local running job checker
+        SCHEDULE_TASK_EXEC.scheduleAtFixedRate(
+                JobManager::checkJobs,
+                KEEP_ALIVE_INTERVAL,
+                KEEP_ALIVE_INTERVAL,
+                TimeUnit.SECONDS);   // check every 30 seconds
     }
 
     /**
@@ -405,8 +399,8 @@ public class JobManager {
      * @return a list of all JobInfo in the datastore
      */
     static List<JobInfo> getAllJobs() {
-        ScanParams scanParams = new ScanParams().match("*").count(JOB_SCAN_BATCH_SIZE); // adjust count as needed
-        return allJobInfos.getValuesFor(scanParams);
+        ScanArgs scanArgs = new ScanArgs().match("*").limit(SCAN_BATCH_SIZE);
+        return allJobInfos.getValuesFor(scanArgs);
     }
 
     /**
@@ -415,8 +409,8 @@ public class JobManager {
      */
     static List<JobInfo> getUserJobs() {
         String userKey = ServerContext.getRequestOwner().getUserKey();
-        ScanParams scanParams = new ScanParams().match("*:%s".formatted(userKey)).count(JOB_SCAN_BATCH_SIZE); // adjust count as needed
-        return allJobInfos.getValuesFor(scanParams);
+        ScanArgs scanArgs = new ScanArgs().match("*:%s".formatted(userKey)).limit(SCAN_BATCH_SIZE);
+        return allJobInfos.getValuesFor(scanArgs);
     }
 
 //====================================================================

--- a/src/firefly/java/edu/caltech/ipac/firefly/messaging/Messenger.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/messaging/Messenger.java
@@ -6,18 +6,14 @@ package edu.caltech.ipac.firefly.messaging;
 
 import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.server.util.Logger;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPubSub;
-
-import java.time.Duration;
-import java.time.Instant;
+import io.lettuce.core.pubsub.RedisPubSubAdapter;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
 
 /**
  * An implementation of publish-subscribe messaging pattern based on Jedis client and Redis backend.
@@ -35,7 +31,16 @@ public class Messenger {
     private static Logger.LoggerImpl LOG = Logger.getLogger();
 
     // to limit one thread per topic
-    private static ConcurrentHashMap<String, SubscriberHandler> pubSubHandlers = new ConcurrentHashMap<>();
+    private static ConcurrentHashMap<String, List<Subscriber>> subscribers = new ConcurrentHashMap<>();
+
+    public static void init() {
+        try {
+            RedisService.pubSubConn().addListener(new RedisPubListener());
+            LOG.info("Messenger is ready to use.");
+        } catch (Exception e) {
+            LOG.error(e, "Error initializing Messenger.");
+        }
+    }
 
     /**
      * @param topic         the topic to subscribe to
@@ -43,33 +48,49 @@ public class Messenger {
      * @return the given subscriber.  Useful for functional programming.
      */
     public static Subscriber subscribe(String topic, Subscriber subscriber) {
-        if (pubSubHandlers.containsKey(topic)) {
+
+        if (subscribers.containsKey(topic)) {
             LOG.trace("Add subscriber to existing topic: " + topic);
-            SubscriberHandler pubSub = pubSubHandlers.get(topic);
-            pubSub.addSubscriber(subscriber);
+            subscribers.get(topic).add(subscriber);
         } else {
-            LOG.trace("Add subscriber to new topic: " + topic);
-            SubscriberHandler pubSub = new SubscriberHandler(topic);
-            pubSubHandlers.put(topic, pubSub);
-            pubSub.addSubscriber(subscriber);
+            try {
+                RedisService.pubSubConn().sync().subscribe(topic);
+                List<Subscriber> subsList = new CopyOnWriteArrayList<>();
+                subsList.add(subscriber);
+                subscribers.put(topic, subsList);
+                LOG.trace("Add subscriber to new topic: " + topic);
+            } catch (Exception e) {
+                LOG.error(e, "Error subscribing to topic: " + topic);
+            }
         }
         return subscriber;
-    }
-
-    public static int getSubscribedTopics() {
-        return pubSubHandlers.size();
-    }
-    public static Map<String, SubscriberHandler> getSubscribers() {
-        return Collections.unmodifiableMap(pubSubHandlers);
     }
 
     /**
      * @param subscriber the subscriber to remove
      */
     public static void unSubscribe(Subscriber subscriber) {
-        pubSubHandlers.values().stream()
-                .filter(hdl -> hdl.subscribers.contains(subscriber))
-                .forEach(hdl -> hdl.removeSubscriber(subscriber));
+        subscribers.forEach((topic, subsList) -> {
+            if (subsList.remove(subscriber)) {
+                try {
+                    LOG.info("Removed subscriber from topic: " + topic);
+                    if (subsList.isEmpty()) {
+                        RedisService.pubSubConn().sync().unsubscribe(topic);
+                        LOG.info("No more subscriber; unsubscribe from topic: " + topic);
+                        subscribers.remove(topic);
+                    }
+                } catch (Exception e) {
+                    LOG.error(e, "Error unsubscribing subscriber.");
+                }
+            }
+        });
+    }
+
+    public static int getSubscribedTopics() {
+        return subscribers.size();
+    }
+    public static Map<String, List<Subscriber>> getSubscribers() {
+        return Collections.unmodifiableMap(subscribers);
     }
 
     /**
@@ -78,10 +99,10 @@ public class Messenger {
      * @param msg     message to send
      */
     public static void publish(String topic, Message msg) {
-        try (Jedis jedis = RedisService.getConnection()) {
-            jedis.publish(topic, msg.toJson());
+        try {
+            RedisService.mainConn().async().publish(topic, msg.toJson());
         } catch (Exception e) {
-            LOG.error(e.getMessage());
+            LOG.error(e, "Error publishing message to topic: " + topic);
         }
     }
 
@@ -89,91 +110,39 @@ public class Messenger {
      * Publishes the given message to its topic.
      * @param msg the message to be published
      */
-   public static void publish(Message msg) {
-        applyIfNotEmpty(msg.getTopic(), (topic) -> publish(topic, msg));
+    public static void publish(Message msg) {
+        ifNotEmpty(msg.getTopic()).apply((topic) -> publish(topic, msg));
     }
 
-    /**
-     * Internal handler class used to manage the one-to-many relationship of Messenger's subscriber and
-     * Jedis's subscriber
-     */
-    public static class SubscriberHandler {
+//====================================================================
+// A single Listener that dispatches messages to all subscribers
+//====================================================================
 
-        private final CopyOnWriteArrayList<Subscriber> subscribers = new CopyOnWriteArrayList<>();
-        private final String topic;
-        private final AtomicInteger retries = new AtomicInteger(5);
-        private Instant failSince = Instant.now();
-        private Thread subscriberThread;
-        JedisPubSub jPubSub = new JedisPubSub() {
-            public void onMessage(String channel, String message) {
-                Message msg = Message.parse(message);
-                subscribers.forEach((sub) -> {
-                    try {
-                        sub.onMessage(msg);
-                    } catch (Exception e) {
-                        LOG.error(e, "Error while processing message: " + message);
-                    }
-                });
-            }
-            public void onSubscribe(String channel, int subscribedChannels) {
-                LOG.info("Subscribed to topic: " + topic);
-            }
-            public void onUnsubscribe(String channel, int subscribedChannels) {
-                LOG.info("Unsubscribed from topic: " + channel);
-            }
-
-        };
-
-        SubscriberHandler(String topic) {
-            this.topic = topic;
-        }
-
-        void addSubscriber(Subscriber sub) {
-            subscribers.add(sub);
-            if (subscriberThread == null || !subscriberThread.isAlive()) {
-                // Start the subscriber in a separate thread; use only one thread per topic
-                subscriberThread = new Thread(() -> {
-                    try {
-                        subscribeToRedis();
-                    } catch (Exception e) {
-                        LOG.error(e, "Error while subscribing to topic: " + topic);
-                    } finally {
-                        subscriberThread = null;
-                        LOG.trace("exiting subscribing to topic: " + topic);
-                    }
-                });
-                subscriberThread.start();
-            }
-        }
-
-        void removeSubscriber(Subscriber sub) {
-            subscribers.remove(sub);
-            if (subscribers.isEmpty()) {
-                // no more subscriber; disconnect from redis
-                jPubSub.unsubscribe();
-            }
-        }
-
-        public Instant getFailSince() {
-            return failSince;
-        }
-
-        void subscribeToRedis() throws InterruptedException {
-            LOG.trace("start subscribing to topic: " + topic);
-            try (Jedis jedis = RedisService.getConnection()) {
-                failSince = null;
-                jedis.subscribe(jPubSub, topic); // Blocks here
-            } catch (Exception e) {
-                if (failSince == null) failSince = Instant.now();
-                if (!subscribers.isEmpty()) {
-                    long secSinceFailed = Duration.between(getFailSince(), Instant.now()).toSeconds();
-                    if (secSinceFailed % 5 == 0) {
-                        LOG.info("Subscriber (%s) has been disconnected from Redis for %d seconds".formatted(topic, secSinceFailed));
-                    }
-                    Thread.sleep(1_000);
-                    subscribeToRedis();
+    private static class RedisPubListener extends RedisPubSubAdapter<String, String> {
+        @Override
+        public void message(String channel, String message) {
+            LOG.trace("Received message from channel [" + channel + "]: " + message);
+            List<Subscriber> subs = subscribers.get(channel);
+            if (subs != null) {
+                try {
+                    Message msg = Message.parse(message);
+                    subs.forEach(s -> s.onMessage(msg));
+                } catch (Exception e) {
+                    LOG.error(e, "Error while processing message from channel: " + channel);
                 }
+            } else {
+                LOG.warn("No registered handler for channel: " + channel + ". Message ignored.");
             }
+        }
+
+        @Override
+        public void subscribed(String channel, long count) {
+            LOG.info("Subscribed to channel: " + channel + " (total: " + count + ")");
+        }
+
+        @Override
+        public void unsubscribed(String channel, long count) {
+            LOG.info("Unsubscribed from channel: " + channel + " (total: " + count + ")");
         }
     }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServCommand.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServCommand.java
@@ -23,7 +23,7 @@ public abstract class ServCommand extends ServerCommandAccess.HttpCommand {
     public void processRequest(HttpServletRequest req, HttpServletResponse res, SrvParam sp) throws Exception {
         JSONObject json=new JSONObject();
         String jsonData;
-        RedisService.sendConnectionStatusIfFailed();
+//        RedisService.sendConnectionStatusIfFailed();      should not be needed anymore
         try {
             String result = doCommand(new SrvParam(sp.getParamMap()));
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -9,6 +9,7 @@ import edu.caltech.ipac.firefly.core.background.JobManager;
 import edu.caltech.ipac.firefly.messaging.Messenger;
 import edu.caltech.ipac.firefly.server.cache.EhcacheProvider;
 import edu.caltech.ipac.firefly.server.query.SearchProcessorFactory;
+import edu.caltech.ipac.firefly.server.servlets.AdminShell;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.VersionUtil;
 import edu.caltech.ipac.firefly.server.visualize.VisContext;
@@ -43,6 +44,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 
 /**
  * A static server-centric class used hold server related information.
@@ -867,7 +869,8 @@ public class ServerContext {
 
         public void contextInitialized(ServletContextEvent servletContextEvent) {
             try {
-                System.out.println("contextInitialized...");
+                System.out.println("contextInitializing...");
+                AdminShell.checkAdminShell(servletContextEvent);
                 ServletContext cntx = servletContextEvent.getServletContext();
                 ServerContext.init(cntx.getContextPath(), cntx.getServletContextName(), cntx.getRealPath(WEBAPP_CONFIG_LOC));
                 VersionUtil.initVersion(cntx);  // can be called multiple times, only inits on the first call
@@ -919,4 +922,5 @@ public class ServerContext {
         return new Info(FileUtil.getHostname(), pMem, FileUtil.getIPString(), maxMem, totMem, freeMem);
     }
     public record Info(String host, long pMemory, String ip, long jvmMax, long jvmTotal, long jvmFree) {}
+
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerContext.java
@@ -4,7 +4,9 @@
 package edu.caltech.ipac.firefly.server;
 
 import com.sun.management.OperatingSystemMXBean;
+import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.core.background.JobManager;
+import edu.caltech.ipac.firefly.messaging.Messenger;
 import edu.caltech.ipac.firefly.server.cache.EhcacheProvider;
 import edu.caltech.ipac.firefly.server.query.SearchProcessorFactory;
 import edu.caltech.ipac.firefly.server.util.Logger;
@@ -40,6 +42,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A static server-centric class used hold server related information.
@@ -90,7 +93,7 @@ public class ServerContext {
     private static File appConfigDir;
     private static File webappConfigDir;
     private static File[] visSearchPath = null;
-    private static boolean isInit = false;
+    private static AtomicBoolean isInit = new AtomicBoolean(false);
 
     private volatile static String HIPS_FILE_PATH_STR;
     private volatile static String PERM_FILE_PATH_STR;
@@ -105,12 +108,24 @@ public class ServerContext {
 
     private static final Logger.LoggerImpl log= Logger.getLogger();
 
+    /**
+     * Initialize the ServerContext.  Remember to call shutdown() to clean up
+     * any services started here.
+     * @param contextPath       application context path
+     * @param contextName       application name
+     * @param webappConfigPath  path to the webapp configuration directory
+     */
     public static void init(String contextPath, String contextName, String webappConfigPath) {
-        if (!isInit) {
-            isInit = true;
+        if (!isInit.getAndSet(true)) {
             ServerContext.contextPath = contextPath;
             ServerContext.webappConfigPath = webappConfigPath;
             ServerContext.contextName = contextName;
+
+            try {
+                RedisService.init();    // initialize Redis first because other services depend on it.
+            } catch (Exception e) {
+                log.error(e, "Failed to initialize RedisService: " + e.getMessage());
+            }
 
             configInit();
 
@@ -128,6 +143,8 @@ public class ServerContext {
 
             // initialize search processors
             SearchProcessorFactory.init();
+            Messenger.init();
+            JobManager.init();
 
             // alerts monitoring
             if (AppProperties.getBooleanProperty("alerts.monitorAlerts",true)) AlertsMonitor.startMonitor();
@@ -137,6 +154,13 @@ public class ServerContext {
             FitsFactory.setUseHierarch(true); // this is now the default as of 1.16
             FitsFactory.setLongStringsEnabled(true);
         }
+    }
+
+    public static void shutdown() {
+        log.info("ServerContext shutting down");
+        // shutdown Redis service
+        RedisService.teardown();
+        log.info("ServerContext shutdown complete");
     }
 
     public static void configInit() {
@@ -847,13 +871,6 @@ public class ServerContext {
                 ServletContext cntx = servletContextEvent.getServletContext();
                 ServerContext.init(cntx.getContextPath(), cntx.getServletContextName(), cntx.getRealPath(WEBAPP_CONFIG_LOC));
                 VersionUtil.initVersion(cntx);  // can be called multiple times, only inits on the first call
-                SCHEDULE_TASK_EXEC.scheduleAtFixedRate(
-                        () -> JobManager.cleanup(),
-                        JobManager.CLEANUP_INTVL_MINS,
-                        JobManager.CLEANUP_INTVL_MINS,
-                        TimeUnit.MINUTES);
-
-                JobManager.init();  // initialize JobManager on startup
             } catch (Throwable e) {
                 e.printStackTrace();
             }
@@ -862,7 +879,7 @@ public class ServerContext {
         public void contextDestroyed(ServletContextEvent servletContextEvent) {
             try {
                 System.out.println("contextDestroyed...");
-//                DbMonitor.cleanup(true, false);
+                ServerContext.shutdown();
                 ((EhcacheProvider)CacheManager.getCacheProvider()).shutdown();
                 try {
                     SHORT_TASK_EXEC.shutdownNow();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/UserCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/UserCache.java
@@ -6,11 +6,8 @@ package edu.caltech.ipac.firefly.server;
 import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.server.cache.DistribMapCache;
 import edu.caltech.ipac.firefly.server.util.Logger;
-import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.StringKey;
-import redis.clients.jedis.Jedis;
-
-import static edu.caltech.ipac.firefly.server.RequestOwner.USER_KEY_EXPIRY;
+import io.lettuce.core.api.sync.RedisCommands;
 
 /**
  * Date: Jul 21, 2008
@@ -38,8 +35,9 @@ public class UserCache<T> extends DistribMapCache<T> {
     private UserCache(String userKey) { super(userKey); }  // based on userKey, with the cache data expiring after the default configured time.
 
     public static boolean exists(StringKey userKey) {
-        try(Jedis redis = RedisService.getConnection()) {
-            return redis.exists(userKey.getUniqueString());
+        try {
+            var redis = RedisService.mainConn().sync();
+            return redis.exists(userKey.getUniqueString()) > 0;
         } catch (Exception ex) { LOG.error(ex); }
         return false;
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistribMapCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistribMapCache.java
@@ -4,9 +4,10 @@
 package edu.caltech.ipac.firefly.server.cache;
 
 import edu.caltech.ipac.firefly.core.RedisService;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.params.ScanParams;
-import redis.clients.jedis.resps.ScanResult;
+import io.lettuce.core.MapScanCursor;
+import io.lettuce.core.ScanArgs;
+import io.lettuce.core.ScanCursor;
+import io.lettuce.core.api.StatefulRedisConnection;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,20 +39,24 @@ public class DistribMapCache<T> extends DistributedCache<T> {
         this.ttl = ttl;
     }
 
-    public List<T> getValuesFor(ScanParams scanParams) {
+    public List<T> getValuesFor(ScanArgs scanArgs) {
         List<T> result = new ArrayList<>();
-        try (Jedis jedis = RedisService.getConnection()) {
-            String cursor = ScanParams.SCAN_POINTER_START;
+        try {
+            var redis = RedisService.scanConn().sync();  // use your dedicated scan connection
+            ScanCursor cursor = ScanCursor.INITIAL;
+
             do {
-                ScanResult<Map.Entry<String, String>> scanResult = jedis.hscan(mapKey, cursor, scanParams);
-                for (Map.Entry<String, String> entry : scanResult.getResult()) {
+                MapScanCursor<String, String> scanResult = redis.hscan(mapKey, cursor, scanArgs);
+                for (Map.Entry<String, String> entry : scanResult.getMap().entrySet()) {
                     result.add(deserialize(entry.getValue()));
                 }
-                cursor = scanResult.getCursor();
-            } while (!cursor.equals(ScanParams.SCAN_POINTER_START));
+                cursor = scanResult;   // advance cursor
+            } while (!cursor.isFinished());
+
         } catch (Exception e) {
-            LOG.error(e.getMessage());
+            LOG.error(e, "Error scanning Redis hash {}: {}", mapKey, e.getMessage());
         }
+
         return result;
     }
 
@@ -59,37 +64,38 @@ public class DistribMapCache<T> extends DistributedCache<T> {
 //  override for Redis Map implementation
 //====================================================================
 
-    String get(Jedis redis, String key) {
-        return redis.hget(mapKey, key);
+    String get(StatefulRedisConnection<String, String> redis, String key) {
+        return redis.sync().hget(mapKey, key);
     }
 
-    void del(Jedis redis, String key) {
-        redis.hdel(mapKey, key);
+    void del(StatefulRedisConnection<String, String> redis, String key) {
+        redis.sync().hdel(mapKey, key);
     }
 
-    void set(Jedis redis, String key, String value) {
-        redis.hset(mapKey, key, value);
+    void set(StatefulRedisConnection<String, String> redis, String key, String value) {
+        var sync = redis.sync();
+        sync.hset(mapKey, key, value);
         if (ttl > 0) {
-            redis.expire(mapKey, ttl);  // renew ttl on each update
-        } else if (redis.ttl(mapKey) > 0) {
-            redis.persist(mapKey);      // remove ttl if it was set (only needed for correction)
+            sync.expire(mapKey, ttl);  // renew ttl on each update
+        } else if (sync.ttl(mapKey) > 0) {
+            sync.persist(mapKey);      // remove ttl if it was set (only needed for correction)
         }
     }
 
-    void setex(Jedis redis, String key, String value, long ttl) {
+    void setex(StatefulRedisConnection<String, String> redis, String key, String value, long ttl) {
         set(redis, key, value); // ttl is managed at the map level, not individual keys
     }
 
-    List<String> keys(Jedis redis) {
-        return new ArrayList<>(redis.hkeys(mapKey));
+    List<String> keys(StatefulRedisConnection<String, String> redis) {
+        return new ArrayList<>(redis.sync().hkeys(mapKey));
     }
 
-    boolean exists(Jedis redis, String key) {
-        return redis.hexists(mapKey, key);
+    boolean exists(StatefulRedisConnection<String, String> redis, String key) {
+        return redis.sync().hexists(mapKey, key);
     }
 
-    int size(Jedis redis) {
-        return (int) redis.hlen(mapKey);
+    long size(StatefulRedisConnection<String, String> redis) {
+        return redis.sync().hlen(mapKey);
     }
 
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistributedCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/DistributedCache.java
@@ -10,7 +10,7 @@ import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.cache.Cache;
 import edu.caltech.ipac.util.cache.CacheKey;
 import edu.caltech.ipac.util.cache.StringKey;
-import redis.clients.jedis.Jedis;
+import io.lettuce.core.api.StatefulRedisConnection;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -69,29 +69,30 @@ public class DistributedCache<T> implements Cache<T> {
 
     public void put(CacheKey key, Object value, int lifespanInSecs) {
             String keystr = key.getUniqueString();
-            try(Jedis redis = RedisService.getConnection()) {
-                if (redis != null) {
-                    if (value == null) {
-                        del(redis, keystr);
+            try {
+                var redis = RedisService.mainConn();
+                if (value == null) {
+                    del(redis, keystr);
+                } else {
+                    if (lifespanInSecs > 0) {
+                        setex(redis, keystr, serialize(value), lifespanInSecs);
                     } else {
-                        if (lifespanInSecs > 0) {
-                            setex(redis, keystr, serialize(value), lifespanInSecs);
-                        } else {
-                            set(redis, keystr, serialize(value));
-                        }
+                        set(redis, keystr, serialize(value));
                     }
                 }
             } catch (Exception ex) { LOG.error(ex); }
     }
 
     public void remove(CacheKey key) {
-        try(Jedis redis = RedisService.getConnection()) {
+        try {
+            var redis = RedisService.mainConn();
             del(redis, key.getUniqueString());
         } catch (Exception ex) { LOG.error(ex); }
     }
 
     public T get(CacheKey key) {
-        try(Jedis redis = RedisService.getConnection()) {
+        try {
+            var redis = RedisService.mainConn();
             T v = deserialize( get(redis, key.getUniqueString()) );
             if (v != null && getValidator != null && !getValidator.test(v)) {
                 del(redis, key.getUniqueString());
@@ -107,7 +108,8 @@ public class DistributedCache<T> implements Cache<T> {
     }
 
     public boolean isCached(CacheKey key) {
-        try(Jedis redis = RedisService.getConnection()) {
+        try {
+            var redis = RedisService.mainConn();
             return exists(redis, key.getUniqueString());
         } catch (Exception ex) { LOG.error(ex); }
         return false;
@@ -115,15 +117,15 @@ public class DistributedCache<T> implements Cache<T> {
 
     @Nonnull
     public List<StringKey> getKeys() {
-        try(Jedis redis = RedisService.getConnection()) {
-            return keys(redis).stream().map(StringKey::new).toList();
+        try {
+            return keys(RedisService.scanConn()).stream().map(StringKey::new).toList();
         } catch (Exception ex) { LOG.error(ex); }
         return List.of();
     }
 
-    public int getSize() {
-        try(Jedis redis = RedisService.getConnection()) {
-            return size(redis);
+    public long getSize() {
+        try {
+            return size(RedisService.mainConn());
         } catch (Exception ex) { LOG.error(ex); }
         return -1;
     }
@@ -132,34 +134,34 @@ public class DistributedCache<T> implements Cache<T> {
 // Implementation of redis string;  override for map, list, and set.
 //====================================================================
 
-    String  get(Jedis redis, String key) {
-        return redis.get(key);
+    String  get(StatefulRedisConnection<String, String> redis, String key) {
+        return redis.sync().get(key);
     }
 
-    void del(Jedis redis, String key) {
-        redis.del(key);
+    void del(StatefulRedisConnection<String, String> redis, String key) {
+        redis.sync().del(key);
     }
 
-    void set(Jedis redis, String key, String value) {
-        redis.set(key, value);
+    void set(StatefulRedisConnection<String, String> redis, String key, String value) {
+        redis.sync().set(key, value);
     }
 
-    void setex(Jedis redis, String key, String value, long lifespanInSecs) {
-        redis.setex(key, lifespanInSecs, value);
+    void setex(StatefulRedisConnection<String, String> redis, String key, String value, long lifespanInSecs) {
+        redis.sync().setex(key, lifespanInSecs, value);
     }
 
     @Nonnull
-    List<String> keys(Jedis redis) {
-        var keys = redis.keys("*");
+    List<String> keys(StatefulRedisConnection<String, String> redis) {
+        var keys = redis.sync().keys("*");
         return keys == null ? List.of() : keys.stream().toList();
     }
 
-    boolean exists(Jedis redis, String key) {
-        return redis.exists(key);
+    boolean exists(StatefulRedisConnection<String, String> redis, String key) {
+        return redis.sync().exists(key) > 0;
     }
 
-    int size(Jedis redis) {
-        return Math.toIntExact(redis.dbSize());
+    long size(StatefulRedisConnection<String, String> redis) {
+        return redis.sync().dbsize();
     }
 
 //====================================================================

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheImpl.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheImpl.java
@@ -79,7 +79,7 @@ public class EhcacheImpl<T> implements Cache<T> {
         return cache.getKeys().stream().map(k -> new StringKey(k.toString())).toList();
     }
 
-    public int getSize() {
+    public long getSize() {
         return cache.getSize();
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/LocalMapCache.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/LocalMapCache.java
@@ -70,7 +70,7 @@ public class LocalMapCache<T> implements Cache<T> {
         return new ArrayList<>(keys);
     }
 
-    public int getSize() {
+    public long getSize() {
         return getMappedData().size();
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AdminShell.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AdminShell.java
@@ -1,0 +1,308 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+package edu.caltech.ipac.firefly.server.servlets;
+
+import edu.caltech.ipac.firefly.server.util.Logger;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerContainer;
+import jakarta.websocket.server.ServerEndpointConfig;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * 
+ * Date: 11/8/25
+ *
+ * @author loi
+ * @version : $
+ */
+public class AdminShell {
+    private static Logger.LoggerImpl LOG = Logger.getLogger();
+    
+    public static void checkAdminShell(ServletContextEvent sce) {
+        String enableShell = System.getProperty("ENABLE_ADMIN_SHELL", "false");
+        if (!"true".equalsIgnoreCase(enableShell)) {
+            return;     // silently ignore if not enabled
+        }
+
+        LOG.debug("Admin shell proxy enabled → http://127.0.0.1:8081/");
+        var ctx = sce.getServletContext();
+
+        // Register HTTP proxy servlet
+        try {
+            var reg = ctx.addServlet("AdminShellHttp", HttpProxyServlet.class);
+            reg.setInitParameter("targetUri", "http://127.0.0.1:8081/");
+            reg.addMapping("/admin/shell/*");
+            reg.setLoadOnStartup(1);
+            LOG.debug("   - Registered HTTP Proxy for /admin/shell/*");
+        } catch (Exception e) {
+            System.err.println("Error registering HTTP Proxy Servlet: " + e.getMessage());
+        }
+
+        // Register WebSocket endpoint
+        try {
+            ServerContainer container = (ServerContainer)
+                    ctx.getAttribute(ServerContainer.class.getName());
+
+            if (container != null) {
+                ServerEndpointConfig config = ServerEndpointConfig.Builder
+                        .create(WebSocketProxy.class, "/admin/shell/ws")
+                        .subprotocols(java.util.List.of("tty"))
+                        .build();
+
+                container.addEndpoint(config);
+                LOG.debug("   - Registered WebSocket Endpoint for /admin/shell/ws");
+            } else {
+                System.err.println("WebSocket ServerContainer not found. Tomcat misconfiguration?");
+            }
+        } catch (Exception e) {
+            System.err.println("Error registering WebSocket Endpoint: " + e.getMessage());
+        }
+    }
+
+    //====================================================================
+    //  HTTP Proxy Servlet that forwards /admin/shell/* requests
+    //  ttyd at http://localhost:8081/
+    //====================================================================
+    public static class HttpProxyServlet extends HttpServlet {
+
+        private static final String BACKEND_BASE = "http://localhost:8081";
+
+        private final HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+
+        @Override
+        protected void service(HttpServletRequest req, HttpServletResponse resp)
+                throws ServletException, IOException {
+
+            String targetUrl = getTargetUrl(req);
+
+            LOG.debug("[ShellHttpProxy] → " + req.getMethod() + " " + targetUrl);
+
+            HttpRequest.Builder builder = HttpRequest.newBuilder()
+                    .uri(URI.create(targetUrl))
+                    .timeout(Duration.ofSeconds(30));
+
+            // Copy headers except hop-by-hop ones
+            req.getHeaderNames().asIterator().forEachRemaining(h -> {
+                if (!h.equalsIgnoreCase("host") && !h.equalsIgnoreCase("connection")) {
+                    builder.header(h, req.getHeader(h));
+                }
+            });
+
+            // Forward body if present
+            if (req.getContentLengthLong() > 0) {
+                builder.method(req.getMethod(),
+                        HttpRequest.BodyPublishers.ofInputStream(() -> {
+                            try {
+                                return req.getInputStream();
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }));
+            } else {
+                builder.method(req.getMethod(), HttpRequest.BodyPublishers.noBody());
+            }
+
+            HttpResponse<InputStream> backendResp;
+            try {
+                backendResp = client.send(builder.build(), HttpResponse.BodyHandlers.ofInputStream());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                resp.sendError(500, "Proxy interrupted");
+                return;
+            } catch (IOException e) {
+                resp.sendError(502, "Proxy I/O error: " + e.getMessage());
+                return;
+            }
+
+            resp.setStatus(backendResp.statusCode());
+            backendResp.headers().map().forEach((k, vList) -> {
+                for (String v : vList) {
+                    if (!k.equalsIgnoreCase("transfer-encoding")) {
+                        resp.addHeader(k, v);
+                    }
+                }
+            });
+
+            try (InputStream in = backendResp.body(); OutputStream out = resp.getOutputStream()) {
+                in.transferTo(out);
+            }
+        }
+
+        private static String getTargetUrl(HttpServletRequest req) {
+            String context = req.getContextPath();        // e.g. "/firefly"
+            String uri = req.getRequestURI();             // e.g. "/firefly/admin/shell/token"
+            String prefix = context + "/admin/shell";
+
+            // Strip prefix so backend sees '/' paths
+            String backendPath = uri.startsWith(prefix)
+                    ? uri.substring(prefix.length())
+                    : uri;
+
+            if (backendPath.isEmpty()) backendPath = "/";
+
+            // Construct full backend URL
+            String targetUrl = BACKEND_BASE + backendPath;
+            if (req.getQueryString() != null) {
+                targetUrl += "?" + req.getQueryString();
+            }
+            return targetUrl;
+        }
+    }
+
+    //====================================================================
+    //  WebSocket Proxy Endpoint
+    //====================================================================
+    public static class WebSocketProxy {
+
+        private static final String BACKEND_URL = "ws://localhost:8081/ws";
+
+        private final AtomicReference<WebSocket> backendRef = new AtomicReference<>();
+        private Session clientSession;
+
+        @OnOpen
+        public void onOpen(Session session) {
+            this.clientSession = session;
+            session.setMaxBinaryMessageBufferSize(8192);
+            session.setMaxTextMessageBufferSize(8192);
+
+            LOG.debug("[ShellProxy] Connecting client %s to %s using subprotocol '%s'".formatted(
+                    session.getId(), BACKEND_URL, session.getNegotiatedSubprotocol())
+            );
+
+            HttpClient httpClient = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(5))
+                    .build();
+
+            try {
+                WebSocket backend = httpClient.newWebSocketBuilder()
+                        .subprotocols("tty")
+                        .buildAsync(URI.create(BACKEND_URL), new WebSocket.Listener() {
+
+                            @Override
+                            public void onOpen(WebSocket ws) {
+                                backendRef.set(ws);
+                                LOG.debug("[ShellProxy] Connected to ttyd backend");
+                                ws.request(1);
+                            }
+
+                            @Override
+                            public CompletionStage<?> onText(WebSocket ws, CharSequence data, boolean last) {
+                                LOG.trace("[ShellProxy] ← text from backend: " + data);
+                                sendToClient(() -> clientSession.getBasicRemote().sendText(data.toString()));
+                                ws.request(1);
+                                return null;
+                            }
+
+                            @Override
+                            public CompletionStage<?> onBinary(WebSocket ws, ByteBuffer data, boolean last) {
+                                LOG.trace("[ShellProxy] ← binary from backend: " + data.remaining() + " bytes");
+                                ByteBuffer copy = data.duplicate();
+                                copy.rewind();
+                                sendToClient(() -> clientSession.getBasicRemote().sendBinary(copy));
+                                ws.request(1);
+                                return null;
+                            }
+
+                            @Override
+                            public CompletionStage<?> onClose(WebSocket ws, int code, String reason) {
+                                LOG.debug("[ShellProxy] Backend closed: " + code + " " + reason);
+                                closeClient(code, reason);
+                                return null;
+                            }
+
+                            @Override
+                            public void onError(WebSocket ws, Throwable err) {
+                                LOG.error(err, "[ShellProxy] Backend ERROR: " + err);
+                                closeClient(1011, "Backend error");
+                            }
+
+                        }).join();
+
+                backendRef.set(backend);
+                LOG.debug("[ShellProxy] Backend handshake complete.");
+
+            } catch (Exception e) {
+                System.err.println("[ShellProxy] Backend connect failed: " + e);
+                closeClient(CloseReason.CloseCodes.CANNOT_ACCEPT.getCode(), e.getMessage());
+            }
+        }
+
+        @OnMessage
+        public void onTextMessage(String msg) {
+            LOG.trace("[ShellProxy] → text to backend: " + msg);
+            WebSocket backend = backendRef.get();
+            if (backend != null) backend.sendText(msg, true);
+        }
+
+        @OnMessage
+        public void onBinaryMessage(ByteBuffer data) {
+            LOG.trace("[ShellProxy] → binary to backend: " + data.remaining() + " bytes");
+            WebSocket backend = backendRef.get();
+            if (backend != null) {
+                ByteBuffer copy = data.duplicate();
+                copy.rewind();
+                backend.sendBinary(copy, true);
+            }
+        }
+
+        @OnClose
+        public void onClose(Session session, CloseReason reason) {
+            LOG.debug("[ShellProxy] Client closed: " + reason);
+            WebSocket backend = backendRef.get();
+            if (backend != null) backend.sendClose(WebSocket.NORMAL_CLOSURE, "Client closed");
+        }
+
+        @OnError
+        public void onError(Session session, Throwable error) {
+            LOG.error(error, "[ShellProxy] ERROR: " + error);
+        }
+
+        private void sendToClient(IOSender action) {
+            if (clientSession != null && clientSession.isOpen()) {
+                try {
+                    action.send();
+                } catch (IOException e) {
+                    LOG.error("[ShellProxy] Error sending to client: " + e);
+                }
+            }
+        }
+
+        private void closeClient(int code, String reason) {
+            if (clientSession != null && clientSession.isOpen()) {
+                try {
+                    clientSession.close(new CloseReason(
+                            CloseReason.CloseCodes.getCloseCode(code), reason));
+                } catch (IOException ignored) {}
+            }
+        }
+
+        @FunctionalInterface
+        private interface IOSender { void send() throws IOException; }
+    }
+}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AdminShell.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AdminShell.java
@@ -5,8 +5,14 @@
 package edu.caltech.ipac.firefly.server.servlets;
 
 import edu.caltech.ipac.firefly.server.util.Logger;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -29,8 +35,13 @@ import java.net.http.HttpResponse;
 import java.net.http.WebSocket;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * 
@@ -48,8 +59,12 @@ public class AdminShell {
             return;     // silently ignore if not enabled
         }
 
-        LOG.debug("Admin shell proxy enabled → http://127.0.0.1:8081/");
         var ctx = sce.getServletContext();
+        LOG.debug("Admin shell proxy enabled → http://127.0.0.1:8081/");
+
+        // Pick up IP prefixes from environment or system property
+        String allowedPrefixes = System.getProperty("ALLOWED_IP_PREFIXES", "");
+        LOG.debug("   - Allowed IP prefixes: " + (allowedPrefixes.isBlank() ? "(none)" : allowedPrefixes));
 
         // Register HTTP proxy servlet
         try {
@@ -59,7 +74,19 @@ public class AdminShell {
             reg.setLoadOnStartup(1);
             LOG.debug("   - Registered HTTP Proxy for /admin/shell/*");
         } catch (Exception e) {
-            System.err.println("Error registering HTTP Proxy Servlet: " + e.getMessage());
+            LOG.error(e, "Error registering HTTP Proxy Servlet: " + e.getMessage());
+        }
+
+        // Register IP restriction filter (only if prefixes provided)
+        if (!allowedPrefixes.isBlank()) {
+            try {
+                var ipFilter = ctx.addFilter("AdminShellIpFilter", new IpFilter());
+                ipFilter.setInitParameter("allowedPrefixes", allowedPrefixes);
+                ipFilter.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), false, "/admin/shell/*");
+                LOG.debug("   - Added IP restriction filter for /admin/shell/* → " + allowedPrefixes);
+            } catch (Exception e) {
+                LOG.error(e, "Error registering IP restriction filter: " + e.getMessage());
+            }
         }
 
         // Register WebSocket endpoint
@@ -82,6 +109,7 @@ public class AdminShell {
             System.err.println("Error registering WebSocket Endpoint: " + e.getMessage());
         }
     }
+
 
     //====================================================================
     //  HTTP Proxy Servlet that forwards /admin/shell/* requests
@@ -305,4 +333,58 @@ public class AdminShell {
         @FunctionalInterface
         private interface IOSender { void send() throws IOException; }
     }
+
+    //====================================================================
+    //  IP filtering
+    //====================================================================
+
+    public static class IpFilter implements Filter {
+        private List<String> allowedPrefixes = List.of("127.0.0.1");
+
+        @Override
+        public void init(FilterConfig filterConfig) throws ServletException {
+            // Try init-param first (from web.xml or dynamic registration)
+            String param = filterConfig.getInitParameter("allowedPrefixes");
+            if (param == null || param.isBlank()) {
+                param = System.getProperty("ALLOWED_IP_PREFIXES", "");
+            }
+
+            if (!param.isBlank()) {
+                allowedPrefixes = Arrays.stream(param.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .collect(Collectors.toList());
+            }
+
+            filterConfig.getServletContext().log("[IpRestrictionFilter] Allowed IP prefixes: " + allowedPrefixes);
+        }
+
+        @Override
+        public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+                throws IOException, ServletException {
+
+            HttpServletRequest request = (HttpServletRequest) req;
+            HttpServletResponse response = (HttpServletResponse) res;
+
+            // Try X-Real-IP → X-Forwarded-For → remoteAddr
+            String ip = Optional.ofNullable(request.getHeader("X-Real-IP"))
+                    .orElseGet(() -> Optional.ofNullable(request.getHeader("X-Forwarded-For"))
+                            .map(xff -> xff.split(",")[0].trim())
+                            .orElse(request.getRemoteAddr()));
+
+            boolean allowed = allowedPrefixes.stream().anyMatch(ip::startsWith);
+
+            if (!allowed) {
+                response.sendError(HttpServletResponse.SC_FORBIDDEN,
+                        "Access denied for IP: " + ip);
+                return;
+            }
+
+            chain.doFilter(req, res);
+        }
+
+        @Override
+        public void destroy() { }
+    }
+
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HealthCheck.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/HealthCheck.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.server.servlets;
 
+import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.FileUtil;
@@ -10,6 +11,8 @@ import edu.caltech.ipac.util.StringUtils;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import static edu.caltech.ipac.firefly.core.Util.Try;
 
 /**
  * Check application health by performing a simple task, then return HTTP code 200 if succeed.
@@ -26,12 +29,18 @@ public class HealthCheck extends BaseHttpServlet {
 
     protected void processRequest(HttpServletRequest req, HttpServletResponse res) throws Exception {
         byte[] alloc = null;
+        boolean isConnected= false;
         try {
             // memory check
             int mem = Math.max(Math.min(StringUtils.getInt(req.getParameter("mem"), 5), 1024), 1);
             alloc = new byte[mem * 1024 * 1024];
             // database check
             DbAdapter.getAdapter().execQuery("select 1", null);
+            // Redis check
+            Try.it(RedisService::isConnected).getOrElse(e ->  Logger.info("Redis not connected"));
+            Try.it(() -> RedisService.mainConn().sync().ping()).getOrElse(e ->  Logger.error("Main connection ping failed"));
+            Try.it(() -> RedisService.scanConn().sync().ping()).getOrElse(e ->  Logger.error("Scan connection ping failed"));
+            Try.it(() -> RedisService.pubSubConn().sync().ping()).getOrElse(e ->  Logger.error("PubSub connection ping failed"));
         } catch (OutOfMemoryError oome) {
             Logger.error(oome, "Encountered OutOfMemory during memory check");
             throw oome;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
@@ -15,6 +15,7 @@ import edu.caltech.ipac.firefly.server.db.DbMonitor;
 import edu.caltech.ipac.firefly.server.db.DuckDbAdapter;
 import edu.caltech.ipac.firefly.server.db.HsqlDbAdapter;
 import edu.caltech.ipac.firefly.server.events.ServerEventManager;
+import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.KeyVal;
 import edu.caltech.ipac.util.StringUtils;
@@ -31,8 +32,6 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.rmi.RemoteException;
 import java.text.SimpleDateFormat;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -60,6 +59,7 @@ import static org.apache.commons.lang.StringUtils.isNotEmpty;
  * @version $Id: ServerStatus.java,v 1.1 2009/06/04 00:12:42 loi Exp $
  */
 public class ServerStatus extends BaseHttpServlet {
+    Logger.LoggerImpl LOG = Logger.getLogger();
 
     protected void processRequest(HttpServletRequest req, HttpServletResponse res) throws Exception {
 
@@ -74,14 +74,14 @@ public class ServerStatus extends BaseHttpServlet {
         PrintWriter writer = res.getWriter();
         writer.println("<pre style='font-size: -1'>");
 
-        if (execGC)             System.gc();            // force garbage collection.
-        if (execRedisCleanup)   {
-            long keyCount = RedisService.cleanupStaleKeys();    // manually clean up stale Redis keys
-            writer.println("* Redis cleanup completed. Number of keys removed: " + keyCount);
-            skip(writer);
-        }
-
         try {
+            if (execGC) System.gc();            // force garbage collection.
+            if (execRedisCleanup) {
+                long keyCount = RedisService.cleanupStaleKeys();    // manually clean up stale Redis keys
+                writer.println("* Redis cleanup completed. Number of keys removed: " + keyCount);
+                skip(writer);
+            }
+
             showActions(writer);
 
             // some information may be time-consuming to load, so we should only do it on demand
@@ -100,7 +100,8 @@ public class ServerStatus extends BaseHttpServlet {
             }
 
             writer.println("</pre>");
-
+        }catch (Exception e) {
+            LOG.error(e, "Error generating server status page: " + e.getMessage());
         } finally {
             writer.flush();
             writer.close();

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
@@ -6,6 +6,7 @@ package edu.caltech.ipac.firefly.server.servlets;
 import edu.caltech.ipac.firefly.core.RedisService;
 import edu.caltech.ipac.firefly.core.background.JobManager;
 import edu.caltech.ipac.firefly.messaging.Messenger;
+import edu.caltech.ipac.firefly.messaging.Subscriber;
 import edu.caltech.ipac.firefly.server.Counters;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.cache.EhcacheProvider;
@@ -393,16 +394,14 @@ public class ServerStatus extends BaseHttpServlet {
     private static void showMessagingStatus(PrintWriter w) {
         w.println("Redis information: ");
         w.println("-----------------  ");
-        RedisService.getStats().print(w);
+        RedisService.getStats(false).print(w);
 
         w.println("\nMessenger info: ");
         w.println("-----------------  ");
         w.println("  Subscribed Topics: " + Messenger.getSubscribedTopics());
-        for (Map.Entry<String, Messenger.SubscriberHandler> entry : Messenger.getSubscribers().entrySet()) {
+        for (Map.Entry<String,List<Subscriber>> entry : Messenger.getSubscribers().entrySet()) {
             String topic = entry.getKey();
-            Messenger.SubscriberHandler handler = entry.getValue();
-            w.println("  - Topic: " + "%-20s".formatted(topic) + " Status: " + (String.format(handler.getFailSince() == null ? "OK" :
-                    "Failed since " + DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault()).format(handler.getFailSince()))));
+            w.println("  - Topic: %-20s       Subscribers: %d".formatted(topic, entry.getValue().size()));
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/util/cache/Cache.java
+++ b/src/firefly/java/edu/caltech/ipac/util/cache/Cache.java
@@ -22,7 +22,7 @@ public interface Cache<T> {
     T get(CacheKey key);
     void remove(CacheKey key);
     boolean isCached(CacheKey key);
-    int getSize();
+    long getSize();
 
     /**
      * returns a list of keys in this cache as string.

--- a/src/firefly/java/edu/caltech/ipac/util/cache/CacheManager.java
+++ b/src/firefly/java/edu/caltech/ipac/util/cache/CacheManager.java
@@ -159,7 +159,7 @@ public class CacheManager {
             return false;
         }
 
-        public int getSize() {
+        public long getSize() {
             return 0;
         }
 

--- a/src/firefly/test/edu/caltech/ipac/firefly/ConfigTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/ConfigTest.java
@@ -131,8 +131,8 @@ public class ConfigTest {
 
         requestAgent = requestAgent == null ? new RequestAgent(null, "localhost", "/test", "localhost:8080/", "127.0. 0.1", UUID.randomUUID().toString(), contextPath): requestAgent;
 
-        ServerContext.getRequestOwner().init(requestAgent);
         ServerContext.init(contextPath, contextName, webappConfigPath);
+        ServerContext.getRequestOwner().init(requestAgent);
     }
 
     private static void copy(Path src, Path dstDir) {

--- a/src/firefly/test/edu/caltech/ipac/firefly/core/RedisServiceTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/core/RedisServiceTest.java
@@ -5,20 +5,15 @@
 package edu.caltech.ipac.firefly.core;
 
 import edu.caltech.ipac.firefly.ConfigTest;
+import edu.caltech.ipac.firefly.server.servlets.ServerStatus;
 import edu.caltech.ipac.firefly.server.util.Logger;
-import edu.caltech.ipac.util.AppProperties;
 import org.apache.logging.log4j.Level;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import redis.clients.jedis.Jedis;
 
-import static edu.caltech.ipac.firefly.core.RedisService.MAX_POOL_SIZE;
-import static edu.caltech.ipac.firefly.core.RedisService.REDIS_HOST;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -31,13 +26,14 @@ import static org.junit.Assert.assertEquals;
  */
 public class RedisServiceTest extends ConfigTest {
 
-    @Before
-    public void setup() {
+    @BeforeClass
+    public static void setup() throws Exception {
         if (false) Logger.setLogLevel(Level.TRACE);			// for debugging.
+        RedisService.init();
     }
 
-    @After
-    public void teardown() {
+    @AfterClass
+    public static void teardown() {
         RedisService.teardown();
         LOG.trace("tear down");
     }
@@ -45,7 +41,6 @@ public class RedisServiceTest extends ConfigTest {
     @Ignore("Does not work reliably in CI")
     @Test
     public void testExternalRedis() {
-        AppProperties.setProperty(REDIS_HOST, "localhost");     // setup for external Redis
         testRedis();
     }
 
@@ -57,11 +52,11 @@ public class RedisServiceTest extends ConfigTest {
 
     @Test
     public void testExceedMaxConnections() {
-        AppProperties.setProperty(MAX_POOL_SIZE, "20");
         try {
             for (int i=0; i<25; i++) {
-                Jedis conn = RedisService.getConnection();
-                assertEquals("PONG", conn.ping());
+                assertEquals("PONG", RedisService.mainConn().sync().ping());
+                assertEquals("PONG", RedisService.scanConn().sync().ping());
+                assertEquals("PONG", RedisService.pubSubConn().sync().ping());
             }
             Assert.assertTrue(true);    // should finish with some wait time.
         } catch (Exception e) {
@@ -69,29 +64,38 @@ public class RedisServiceTest extends ConfigTest {
         }
     }
 
+    @Test
+    public void testFullStats() {
+        ServerStatus.EntryList stats = RedisService.getFullStats();
+        Assert.assertNotNull(stats);
+    }
+
     private void testRedis() {
 
         // ping test
-        try (Jedis conn = RedisService.getConnection()) {
-            assertEquals("PONG", conn.ping());
+        try {
+            var redis = RedisService.mainConn().sync();
+            assertEquals("PONG", redis.ping());
         } catch (Exception e) {
             Assert.fail("Can't connect: " + e);
         }
 
-        // set with expiry
-        try (Jedis conn = RedisService.getConnection()) {
-            conn.setex("key1", 1, "val1");
-            assertEquals("val1", conn.get("key1"));
+        try {
+            var redis = RedisService.mainConn().sync();
+            redis.setex("key1", 1, "val1");
+            assertEquals("val1", redis.get("key1"));
             Thread.sleep(3_000);        // should be expired after 3 seconds
-            assertEquals(false, conn.exists("key1"));
+            assertEquals(0, (long) redis.exists("key1"));
         } catch (Exception e) {
             Assert.fail("Can't connect: " + e);
         }
+
 
         // lots of connections test
         for (int i=0; i<100; i++) {
-            try (Jedis conn = RedisService.getConnection()) {
-                assertEquals("PONG", conn.ping());
+            try {
+                var redis = RedisService.mainConn().sync();
+                assertEquals("PONG", redis.ping());
             } catch (Exception e) {
                 Assert.fail("Can't connect: " + e);
             }

--- a/src/firefly/test/edu/caltech/ipac/firefly/core/background/JobManagerTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/core/background/JobManagerTest.java
@@ -30,6 +30,9 @@ public class JobManagerTest extends ConfigTest {
 
     @BeforeClass
     public static void setUp() {
+        // set so JobManager does not wait for results
+        AppProperties.setProperty("job.wait.complete", "0");
+
         // needed when dealing with code running in a server's context, ie  SearchProcessor, RequestOwner, etc.
         setupServerContext(null);
         Logger.setLogLevel(Level.DEBUG);
@@ -38,8 +41,6 @@ public class JobManagerTest extends ConfigTest {
     @Category({TestCategory.Perf.class})
     @Test
     public void testRunAs() throws Exception {
-        // set so JobManager does not wait for results
-        AppProperties.setProperty("job.wait.complete", "0");
 
         /*
             This test submits 20 PACKAGE jobs.  Each one sleeps for 2 seconds, then print completed status.
@@ -85,10 +86,10 @@ public class JobManagerTest extends ConfigTest {
         AppProperties.setProperty("job.wait.complete", "0");
         Logger.setLogLevel(Level.INFO);
 
-        ServerContext.getRequestOwner().setWsConnInfo("test", "test");
-        for(int i =0; i < 100_000; i++) {
-            JobManager.submit(new SleepJob(Job.Type.PACKAGE, ServerContext.getRequestOwner().getEventConnID()));
-        }
+//        ServerContext.getRequestOwner().setWsConnInfo("test", "test");
+//        for(int i =0; i < 100_000; i++) {
+//            JobManager.submit(new SleepJob(Job.Type.PACKAGE, ServerContext.getRequestOwner().getEventConnID()));
+//        }
 
         ServerContext.getRequestOwner().setUserKey("59bac3e4-6dc7-4b74-a83d-a35414629999");      // load 9999 with 100k; extreme
         for(int i =0; i < 100_000; i++) {
@@ -115,7 +116,7 @@ public class JobManagerTest extends ConfigTest {
     @Test
     public void loadTest() throws Exception {
         /*
-          Performance results
+          Performance results using Jedis vs Lettuce are identical with embedded Redis server.
             Cache keys count: 101,104
             All Jobs: 1,165ms with 101,104 jobs
             User Jobs: 936ms with 99,994 jobs       # confirmed only 99,994 jobs for 9999; not sure why 6 missing
@@ -157,7 +158,7 @@ public class JobManagerTest extends ConfigTest {
     }
 
 
-    private static class SleepJob extends ServCmdJob {
+    private static class SleepJob extends ServCmdJob implements Job.Worker {
         Job.Type type;
         String key;
         public SleepJob(Job.Type type, String key) {
@@ -177,6 +178,9 @@ public class JobManagerTest extends ConfigTest {
             return "done";
         }
 
+        public void setJob(Job job) {}
+        public Job getJob() {return null;}
+        public Worker getWorker() {return this;}
     }
 
 }

--- a/src/firefly/test/edu/caltech/ipac/firefly/messaging/MessengerTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/messaging/MessengerTest.java
@@ -12,7 +12,9 @@ import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.util.Ref;
 import org.apache.logging.log4j.Level;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,13 +39,14 @@ import static org.junit.Assert.*;
  */
 public class MessengerTest extends ConfigTest {
 
-    @Before
-    public void setup() {
+    @BeforeClass
+    public static void setup() throws Exception {
         if (false) Logger.setLogLevel(Level.TRACE);			// for debugging.
+        RedisService.init();
     }
 
-    @After
-    public void teardown() {
+    @AfterClass
+    public static void teardown() {
         RedisService.teardown();
         LOG.trace("tear down");
     }
@@ -144,7 +147,7 @@ public class MessengerTest extends ConfigTest {
         Subscriber sub21 = Messenger.subscribe(topic2, msg -> msg = null);
         Subscriber sub22 = Messenger.subscribe(topic2, msg -> msg = null);
 
-        Supplier<List<String>> topics = () -> Util.Try.it(() -> RedisService.getConnection().pubsubChannels())
+        Supplier<List<String>> topics = () -> Util.Try.it(() -> RedisService.mainConn().sync().pubsubChannels())
                                                      .getOrElse(Collections.emptyList());
 
         LOG.debug("2 topics, 2 subs per topic.");
@@ -169,7 +172,7 @@ public class MessengerTest extends ConfigTest {
         assertFalse("has topic1", topics.get().contains(topic1));
         assertFalse("has topic2", topics.get().contains(topic2));
 
-        LOG.debug("Messenger stats: " + RedisService.getStats());
+        LOG.debug("Messenger stats: " + RedisService.getStats(false));
         LOG.debug("testSubscribe.. done!");
 
     }
@@ -188,7 +191,7 @@ public class MessengerTest extends ConfigTest {
             if (numRevc.getCount() == 0) {
                 long stopTime = System.currentTimeMillis();
                 System.out.println("\t elapsed time: " + (stopTime - startTime)/1000.0 + "s");
-                System.out.println("\t Messenger stats: " + RedisService.getStats());
+                System.out.println("\t Messenger stats: " + RedisService.getStats(false));
             }
         });
 

--- a/src/firefly/test/edu/caltech/ipac/util/cache/CachePeerProviderFactoryTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/cache/CachePeerProviderFactoryTest.java
@@ -14,6 +14,7 @@ import net.sf.ehcache.Element;
 import net.sf.ehcache.distribution.CacheManagerPeerProvider;
 import net.sf.ehcache.distribution.CachePeer;
 import org.apache.logging.log4j.Level;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -81,9 +82,10 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
                     "</ehcache>";
 
     @BeforeClass
-    public static void setUp() throws InterruptedException {
+    public static void setUp() throws Exception {
 
         if (false) Logger.setLogLevel(Level.TRACE);			// for debugging.
+        RedisService.init();
 
         LOG.debug("Initial setup for PubSub, creating 3 peers");
         peer1 = createCM("PubSub", "peer1");
@@ -99,6 +101,19 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
         Thread.sleep(5000);
     }
 
+    @AfterClass
+    public static void tearDown() {
+        if (peer1 != null) peer1.shutdown();
+        if (peer2 != null) peer2.shutdown();
+        if (peer3 != null) peer3.shutdown();
+
+        if (mcPeer1 != null) mcPeer1.shutdown();
+        if (mcPeer2 != null) mcPeer2.shutdown();
+        if (mcPeer3 != null) mcPeer3.shutdown();
+
+        RedisService.teardown();
+        LOG.debug("tear down");
+    }
 
     @Test
     public void pubSub_InitialSetup() throws InterruptedException, RemoteException {


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1883
Additional changes: https://github.com/IPAC-SW/irsa-ife/pull/449


Migrate Redis client from Jedis to Lettuce
- Replaced connection pooling with dedicated persistent connections
- Enabled automatic reconnection on connection loss
- Added Redis PING check to healthz endpoint for improved connection reliability
- Enforced Redis connectivity validation during application startup

See https://github.com/IPAC-SW/irsa-ife/pull/449 for test instructions.