### PR TITLE
FIREFLY-1895: Search title improvements 

### DIFF
--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -1631,6 +1631,26 @@ export function ensureEnumVals(tableModel) {
     });
 }
 
+/**
+ * smartly decides the next tbl title given the existing table titles, to avoid duplicates
+ * @param {string} [inTitle] the default title
+ * @return {string} returns a numbered title (if the given title already exists), else return the default title as is
+ */
+export function makeNumberedTitle(inTitle) {
+    if (getTblIdsByGroup().map((tbl_id) => getTblById(tbl_id)?.title).every( (t) => t!==inTitle)) {
+        return inTitle;
+    }
+    const numList = getTblIdsByGroup()
+        .map((tbl_id) => getTblById(tbl_id)?.title)
+        .filter((title) => title && title.startsWith(inTitle))
+        .map((title) => title?.substring(inTitle.length).trim().split('-')?.[1])
+        .map(Number)
+        .filter(Boolean);
+
+    const maxNum = numList?.length ? Math.max(...numList) : 0;
+    return inTitle + ` - ${maxNum + 1}`;
+}
+
 
 /*-------------------------------------private------------------------------------------------*/
 

--- a/src/firefly/js/ui/tap/ResultTitleDialog.jsx
+++ b/src/firefly/js/ui/tap/ResultTitleDialog.jsx
@@ -48,7 +48,7 @@ function ResultTitlePanel({userTitle, defaultTitle, onChange}) {
             display:'flex', flexDirection:'column', overflow:'auto', resize:'both'}}>
             <Stack {...{alignItems:'center', spacing:1, width:1, height:1, pt:1, flex:'1 1 auto' }} >
                 <Stack width={1} height={1} spacing={4} flex='1 1 auto'>
-                    <ValidationField fieldKey={SEARCH_TITLE_KEY} showFeedback={true} label='Search Title'
+                    <ValidationField fieldKey={SEARCH_TITLE_KEY} showFeedback={true} label='Enter Title'
                                      onKeyPress={(ev,currValue) => {
                                          if (ev.key === 'Enter') {
                                              handleSuccess(currValue,defaultTitle,onChange,true);
@@ -86,6 +86,9 @@ function ResultTitlePanel({userTitle, defaultTitle, onChange}) {
                                 }
                             </Box>
                         </Card>
+                        <Typography level='body-sm'>
+                            Tip: This title helps you identify your search later in the Job Monitor tab.
+                        </Typography>
                     </Stack>
                 </Stack>
                 <Stack {...{textAlign:'center', direction:'row', justifyContent:'space-between', width:1, px:1, pb:1}}>

--- a/src/firefly/js/ui/tap/SIASearchRootPanel.jsx
+++ b/src/firefly/js/ui/tap/SIASearchRootPanel.jsx
@@ -23,13 +23,14 @@ import {ConstraintContext} from './Constraints';
 import {ROW_POSITION} from './Cutout';
 import {showResultTitleDialog} from './ResultTitleDialog';
 import {SiaUI} from './SiaUI';
-import {getMaxrecHardLimit, makeNumberedTitle} from './TapUtil';
+import {getMaxrecHardLimit} from './TapUtil';
 import {
     SIA_SERVICE_META, SIA_SERVICE_URL, SIA_USER_ENTERED_TITLE,
     addUserService,
     defSiaBrowserState, deleteUserService, getServiceNamesAsKey, getSiaServiceLabel, getSiaServiceOptions,
     loadSiaV2Meta, siaHelpId, getServiceHiPS
 } from './SiaUtil.js';
+import {makeNumberedTitle} from 'firefly/tables/TableUtil';
 
 const DEFAULT_SIA_PANEL_GROUP_KEY = 'SIAv2_PANEL_GROUP_KEY';
 

--- a/src/firefly/js/ui/tap/TapSearchSubmit.js
+++ b/src/firefly/js/ui/tap/TapSearchSubmit.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
     ADQL_QUERY_KEY, getAsEntryForTableName, getServiceHiPS, getServiceId, getServiceLabel,
-    makeNumberedTitle,
     makeTapSearchTitle,
     maybeQuote, TAP_UPLOAD_SCHEMA,
     USER_ENTERED_TITLE
@@ -22,6 +21,7 @@ import {dispatchHideDropDown} from 'firefly/core/LayoutCntlr';
 import {dispatchHideDialog} from 'firefly/core/ComponentCntlr';
 import {makeColsLines, tableColumnsConstraints} from 'firefly/ui/tap/TableColumnsConstraints';
 import {ROW_POSITION} from './Cutout';
+import {makeNumberedTitle} from 'firefly/tables/TableUtil';
 
 
 export function onTapSearchSubmit({request, serviceUrl, tapBrowserState, additionalClauses = '',

--- a/src/firefly/js/ui/tap/TapUtil.js
+++ b/src/firefly/js/ui/tap/TapUtil.js
@@ -676,21 +676,6 @@ export function makeTapSearchTitle(adql, serviceUrl='', tableName) {
     return tName || simpleHost || host;
 }
 
-export function makeNumberedTitle(inTitle) {
-    if (getTblIdsByGroup().map((tbl_id) => getTblById(tbl_id)?.title).every( (t) => t!==inTitle)) {
-       return inTitle;
-    }
-    const numList = getTblIdsByGroup()
-        .map((tbl_id) => getTblById(tbl_id)?.title)
-        .filter((title) => title && title.startsWith(inTitle))
-        .map((title) => title?.substring(inTitle.length).trim().split('-')?.[1])
-        .map(Number)
-        .filter(Boolean);
-
-    const maxNum = numList?.length ? Math.max(...numList) : 0;
-    return inTitle + ` - ${maxNum + 1}`;
-}
-
 /**
  * Assembles an array of objects with column attributes in the format that ColumnFld accepts
  * @param columnsModel


### PR DESCRIPTION
**Ticket**: [FIREFLY-1895](https://jira.ipac.caltech.edu/browse/FIREFLY-1895)
**IFE PR**: https://github.com/IPAC-SW/irsa-ife/pull/450
- The search title dialog has some improvements:
  - changed `Search Title` to `Enter Title` to make it less confusing for users (as the header of this dialog is `Search Result Title`)
  - Added a note (`Tip`) indicating the purpose of the `Search Result Title` to users. 
    - open to suggestions for alternate text here 
- small refactor, moved `makeNumberedTitle` to `TableUtil`.  


**Testing**
- [Euclid](https://firefly-1895-job-title.irsakubedev.ipac.caltech.edu/applications/euclid) and [Firefly](https://fireflydev.ipac.caltech.edu/firefly-1895-job-title/firefly) 
- On Euclid/Firefly, open the search title dialog and observe the changes described above 
- **Euclid**: Submit a few Image, Inspect Objects and Search by ID searches. For Image / Inspect Objects, change the search title and submit a couple of searches. Notice the automatic table title numbering should be working. 
- **Firefly**: submit 2-3 searches with the same title on TAP, just to ensure table title numbering works like before (regression testing).  
