### PR TITLE
FIREFLY-1832: Make SizeInputField more flexible

### DIFF
--- a/src/firefly/js/ui/QuantityInputField.jsx
+++ b/src/firefly/js/ui/QuantityInputField.jsx
@@ -1,0 +1,251 @@
+/**
+ * Generic Quantity Input Field component and helpers.
+ *
+ * "Quantity" refers to a physical quantity that consists of a scalar (numeric value) and a unit,
+ * for e.g., length, angular size, etc.
+ */
+
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+import {Divider, Stack, FormHelperText, Typography} from '@mui/joy';
+import { ListBoxInputFieldView } from 'firefly/ui/ListBoxInputField';
+import { InputFieldView } from 'firefly/ui/InputFieldView';
+import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
+import Validate from 'firefly/util/Validate';
+
+/**
+ * Generic units picker used by QuantityInputFieldView.
+ *
+ * If there is more than one unit option, it shows a dropdown ListBoxInputFieldView to select the unit otherwise
+ * it just shows the single unit label.
+ *
+ * @param {object} props
+ * @param {string} props.unit
+ * @param {function} props.onChange
+ * @param {Array<{label:string,value:string}>} props.unitOptions
+ */
+const QuantityUnitsPicker = ({ unit, onChange, unitOptions = [], ...props }) => (
+    <Stack direction='row' alignItems='center'>
+        <Divider orientation='vertical' />
+        {unitOptions.length > 1
+            ? <ListBoxInputFieldView
+                value={unit}
+                onChange={onChange}
+                options={unitOptions}
+                multiple={false}
+                slotProps={{
+                    input: {
+                        variant: 'plain',
+                        sx: {minHeight: 'unset'},
+                    },
+                }}
+                {...props}/>
+            : <Typography sx={{px: 1}} {...props}>{unitOptions[0]?.label || unit}</Typography>
+        }
+    </Stack>
+);
+
+/**
+ * Generic component for a Quantity (= Numeric Value + Unit) Input.
+ *
+ * It's a controlled component in which state is sent through `{value, displayValue, unit, valid, message}` props and
+ * is received back through `onChange()` prop.
+ *
+ * @param {object} props
+ * @param {number} props.min
+ * @param {number} props.max
+ * @param {object} props.sx
+ * @param {object} props.slotProps
+ * @param {object} props.inputStyle
+ * @param {string} props.orientation
+ * @param {string} props.label
+ * @param {boolean} props.showFeedback
+ * @param {string} props.placeholder
+ * @param {string} props.tooltip
+ * @param {boolean} props.connectedMarker
+ *
+ * <hr>Stateful props:
+ * @param {string} props.value quantity value in `quantityBaseUnit` (for internal storage)
+ * @param {string} props.displayValue quantity value that is input by user (shown in the UI)
+ * @param {string} props.unit quantity unit input by user (shown in the UI)
+ * @param {boolean} props.valid whether `value` is valid (i.e. satisfies min/max bounds, nullAllowed, etc.)
+ * @param {string} props.message message to display if invalid
+ * @param {function(object, {value: string, displayValue: string, unit: string}): void} props.onChange lifts the updated
+ * value, displayValue, unit to the parent that controls the state.
+ *
+ * <hr>Quantity-specific props (required):
+ * @param {string} props.quantityName the name of the quantity (for display purposes)
+ * @param {function} props.convertQuantityUnits converts numeric value between units. Signature: (valueStr, fromUnit, toUnit) => string
+ * @param {function} props.formatQuantity formats the value (in quantityBaseUnit) to given unit. Signature: (valueInBaseUnit, outputUnit) => string
+ * @param {string} props.quantityBaseUnit the canonical base unit key to use for `value` prop. Must be one of the `quantityUnitOptions` values.
+ * @param {Array} props.quantityUnitOptions options array for the units picker (label and value pairs)
+ */
+export function QuantityInputFieldView({min, max, sx, slotProps, inputStyle = {},
+                                           orientation = 'vertical', label, showFeedback = false, connectedMarker,
+                                           placeholder, tooltip, onChange, valid, message,
+                                           unit, value, displayValue, quantityName,
+                                           convertQuantityUnits, formatQuantity, quantityBaseUnit, quantityUnitOptions}) {
+    const handleValueChange = (ev) => {
+        const newDisplayValue = ev?.target?.value?.trim();
+        const newValue = convertQuantityUnits(newDisplayValue, unit, quantityBaseUnit);
+        const quantityInfoUpdate = { value: newValue, displayValue: newDisplayValue, unit };
+        onChange?.(ev, quantityInfoUpdate);  // pass changes from UI up to parent
+    };
+
+    const handleUnitChange = (ev, newUnit) => {
+        if (unit === newUnit) return;
+        let newValue = value;
+        let newDisplayValue = displayValue;
+
+        if (valid) {
+            newDisplayValue = convertQuantityUnits(value, quantityBaseUnit, newUnit);
+        } else {
+            // maybe the displayValue (user-input number) is valid for new unit
+            // so keep displayValue unchanged but update value (which will be checked for validity by parent component)
+            newValue = convertQuantityUnits(displayValue, newUnit, quantityBaseUnit);
+        }
+
+        const quantityInfoUpdate = { value: newValue, displayValue: newDisplayValue, unit: newUnit };
+        onChange?.(ev, quantityInfoUpdate); // pass changes from UI up to parent
+    };
+
+    const feedback = showFeedback && formatQuantity && min !== undefined && max !== undefined
+        ? `Valid range: ${formatQuantity(min, unit)} - ${formatQuantity(max, unit)}`
+        : '';
+
+    return (
+        <Stack sx={{width: 'min-content', ...sx}}>
+            <InputFieldView
+                valid={valid}
+                message={message}
+                onChange={handleValueChange}
+                onBlur={handleValueChange}
+                value={displayValue}  // displayValue is what appears in the UI
+                inputStyle={inputStyle}
+                placeholder={placeholder || `Enter ${quantityName}`}
+                tooltip={tooltip || `Enter ${quantityName} within the valid range`}
+                label={label}
+                orientation={orientation}
+                connectedMarker={connectedMarker}
+                sx={{ '& .MuiInput-root': { paddingInlineEnd: 0 } }}
+                endDecorator={
+                    <QuantityUnitsPicker unit={unit} onChange={handleUnitChange}
+                                         unitOptions={quantityUnitOptions}
+                                         tooltip={`Unit of the ${quantityName}`}
+                                         {...slotProps?.units} />
+                }
+            />
+            <FormHelperText {...{ ...slotProps?.feedback }}>
+                {feedback}
+            </FormHelperText>
+        </Stack>
+    );
+}
+
+
+QuantityUnitsPicker.propTypes = {
+    unit: PropTypes.string,
+    onChange: PropTypes.func,
+    unitOptions: PropTypes.array,
+};
+
+QuantityInputFieldView.propTypes = {
+    min: PropTypes.number,
+    max: PropTypes.number,
+    sx: PropTypes.object,
+    slotProps: PropTypes.shape({
+        units: PropTypes.object,
+        feedback: PropTypes.object,
+    }),
+    inputStyle: PropTypes.object,
+    orientation: PropTypes.string,
+    label: PropTypes.string,
+    showFeedback: PropTypes.bool,
+    placeholder: PropTypes.string,
+    tooltip: PropTypes.string,
+    connectedMarker: PropTypes.bool,
+
+    // stateful props
+    onChange: PropTypes.func,
+    valid: PropTypes.bool,
+    message: PropTypes.string,
+    unit: PropTypes.string,
+    value: PropTypes.string,
+    displayValue: PropTypes.string,
+
+    // quantity-specific
+    quantityName: PropTypes.string,
+    convertQuantityUnits: PropTypes.func,
+    formatQuantity: PropTypes.func,
+    quantityBaseUnit: PropTypes.string,
+    quantityUnitOptions: PropTypes.array,
+};
+
+const normalizeInitState = (initialState={}, quantityBaseUnit, convertQuantityUnits) => {
+    const { value='', displayValue='', unit=quantityBaseUnit } = initialState;
+    const norm = { value, displayValue, unit }; // both strings
+    if (value && !displayValue) {
+        norm.displayValue = convertQuantityUnits(value, quantityBaseUnit, unit);
+    } else if (!value && displayValue) {
+        norm.value = convertQuantityUnits(displayValue, unit, quantityBaseUnit);
+    }
+    return norm;
+};
+
+const quantityBoundsValidator = (min, max, nullAllowed, unit, quantityName, formatQuantity) => (valueStr) => {
+    const makeMinMaxStr = (value) => formatQuantity(value, unit);
+    return Validate.floatRange(min, max, null, quantityName, valueStr, nullAllowed, makeMinMaxStr);
+};
+
+
+/**Uncontrolled component for Quantity Input that wires QuantityInputFieldView's state with the FieldGroup store.**/
+export const QuantityInputField = memo((props) => {
+    const { quantityBaseUnit, convertQuantityUnits, quantityName, formatQuantity } = props;
+    const { viewProps, fireValueChange } = useFieldGroupConnector({
+        ...props,
+        initialState: normalizeInitState(props?.initialState, quantityBaseUnit, convertQuantityUnits),
+    });
+
+    const handleOnChange = (ev, quantityInfoUpdate) => {
+        const { value, displayValue, unit=quantityBaseUnit, validator,
+            nullAllowed=false, min, max } = { ...viewProps, ...quantityInfoUpdate };
+
+        // Run custom validator first (on base-unit value). If valid, run bounds validator if min/max provided.
+        let validationResult = validator?.(value) ?? { valid: true, message: '' };
+        if (validationResult?.valid && (min!==undefined || max!==undefined)) {
+            const boundsValidator = quantityBoundsValidator(min, max, nullAllowed, unit, quantityName, formatQuantity);
+            validationResult = boundsValidator(value);
+        }
+        const { valid=true, message='' } = validationResult;
+
+        // Set the UI updates and validation result in FieldGroup store
+        fireValueChange({ value, displayValue, unit, valid, message });
+    };
+
+    return (
+        <QuantityInputFieldView
+            {...{
+                ...viewProps, //stateful props from FieldGroup store along with pass-through visual props
+                onChange: handleOnChange, //callback function that receives the state updates from UI (ev, quantityInfoUpdate)
+            }}
+        />
+    );
+});
+
+QuantityInputField.propTypes = {
+    ...QuantityInputFieldView.propTypes,
+    // FieldGroup wiring
+    fieldKey: PropTypes.string.isRequired,
+    groupKey: PropTypes.string,
+    // validation + bounds
+    validator: PropTypes.func,
+    min: PropTypes.number,
+    max: PropTypes.number,
+    nullAllowed: PropTypes.bool,
+    // initial state
+    initialState: PropTypes.shape({
+        value: PropTypes.any,
+        displayValue: PropTypes.string,
+        unit: PropTypes.string,
+    }),
+};

--- a/src/firefly/js/ui/SizeInputField.jsx
+++ b/src/firefly/js/ui/SizeInputField.jsx
@@ -1,223 +1,72 @@
-import {Divider, FormControl, FormHelperText, FormLabel, Stack} from '@mui/joy';
-import React, {useEffect, memo, useState, useContext} from 'react';
-import PropTypes, {bool, object, shape} from 'prop-types';
+/**
+ * NOTE: "Size" in this component refers to the **Angular Size** (for measuring cone search radius, rotation angle, etc.).
+ * It's not the linear size or a measure of (wave)length.
+ */
+
+import React, {useContext} from 'react';
+import PropTypes, {bool, object} from 'prop-types';
+import toFloat from 'validator/es/lib/toFloat';
 import {convertAngle} from '../visualize/VisUtil.js';
 import {ConnectionCtx} from './ConnectionCtx.js';
-import {InputFieldView} from './InputFieldView.jsx';
-import {ListBoxInputFieldView} from './ListBoxInputField.jsx';
-import Validate from '../util/Validate.js';
 import {toMaxFixed} from '../util/MathUtil.js';
-import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
+import {QuantityInputField} from 'firefly/ui/QuantityInputField';
 
-const invalidSizeMsg = 'Size is not set properly or size is out of range';
+
 const DEC_DIGIT = 6;
-const unitSign = { 'arcsec':'"', 'arcmin':'\'', 'deg':' deg' };
-
-const getUnitSign= (unit) => unitSign[unit];
-
-// input: string format,
-// output: size in degree (string foramt, no decimal digit limit), '': invalid input
-export const sizeToDeg = (sizestr, unit) => {
-    if (sizestr && isNaN(parseFloat(sizestr))) {
-        return sizestr;
-    }
-    return (sizestr) ? convertAngle(((unit) ? unit : 'deg'), 'deg', sizestr).toString() : '';
+const BASE_UNIT = 'deg';
+export const ANGULAR_SIZE_UNITS = {
+    [BASE_UNIT]: { name: 'degrees', symbol: '°' },
+    'arcmin': { name: 'arcminutes', symbol: '\'' },
+    'arcsec': { name: 'arcseconds', symbol: '"' },
 };
 
-// input: size in degree string format
-// output: size in string format in any given unit (for displaying)
-export const sizeFromDeg= (sizeDeg, unit) => (
-    (sizeDeg)? toMaxFixed(convertAngle('deg', ((unit) ? unit :'deg'), sizeDeg), DEC_DIGIT).toString() : ''
-);
 
-// validate if size (in degree, string format) is within the range
-const isSizeValid = (sizeDeg,  min, max) => (
-    (sizeDeg && Validate.floatRange(min, max, 1, 'value of  size in degree', sizeDeg).valid)
-);
-
-const isFieldValid= (valInDeg, nullAllowed, min, max) => (nullAllowed && !valInDeg) || isSizeValid(valInDeg, min, max);
-
-function updateSizeInfo({unit='deg', value, nullAllowed, min, max, displayValue}) {
-    return {
-        unit: unit || 'deg',
-        valid: isFieldValid(value, nullAllowed, min, max),
-        value,
-        displayValue: displayValue ? displayValue : sizeFromDeg(value, unit)
-    };
-}
-
-/**
- * @param ev
- * @param sizeInfo
- * @param params
- * @param fireValueChange unit, value, displayValue are string, and valid is bool
- * @return SizeInputFieldViewState
+/** Converter for handling all size conversions between units.
+ *
+ * @param {string} valueStr size value in the given fromUnit units
+ * @param {string} fromUnit unit of the given valueStr
+ * @param {string} toUnit unit to convert the valueStr into
+ * @returns {*|string}
  */
-function handleOnChange(ev, sizeInfo, params, fireValueChange) {
-     const {unit, value, valid, displayValue} = {...params, ...sizeInfo};
-     const min = () => sizeFromDeg(params.min, params.unit);
-     const max = () => sizeFromDeg(params.max, params.unit);
-     const feedback = valid? '': `${invalidSizeMsg}, ${min()}-${max()}${getUnitSign(params.unit)}.`;
-     fireValueChange({ feedback, displayValue, unit, value, valid });
-}
+const convertSizeUnits = (valueStr, fromUnit=BASE_UNIT, toUnit=BASE_UNIT) => {
+    if (valueStr===undefined || valueStr===null || valueStr==='') return '';
+    const value = toFloat(valueStr+'');
+    if (isNaN(value)) return valueStr; // preserve invalid input to let input validation will handle it
+    const newVal = convertAngle(fromUnit, toUnit, value.toString());
+    return toMaxFixed(newVal, DEC_DIGIT).toString();
+};
 
-function getFeedback(unit, min, max, showFeedback) {
-    const sign = getUnitSign(unit);
-    const minmsg = `${sizeFromDeg(min, unit)}`;
-    const maxmsg = `${sizeFromDeg(max, unit)}`;
-    return {
-        errmsg: `${invalidSizeMsg}, ${minmsg}-${maxmsg}${sign}.`,
-        feedback: showFeedback ? `Valid range between: ${minmsg}${sign} and ${maxmsg}${sign}` : ''
-    };
-}
+const formatSize = (valueInDeg, outputUnit) => `${convertSizeUnits(valueInDeg, BASE_UNIT, outputUnit)}${ANGULAR_SIZE_UNITS[outputUnit].symbol}`;
 
-/**
- * @typedef SizeInputFieldViewState
- * @prop {string} value size value in degree
- * @prop {string} displayValue size value displayed
- * @prop {string} unit selected unit
- * @prop {bool}   valid validation of size value in degree
- */
+const sizeQuantityProps = {
+    quantityName: 'Size',
+    convertQuantityUnits: convertSizeUnits,
+    formatQuantity: formatSize,
+    quantityBaseUnit: BASE_UNIT,
+    quantityUnitOptions: Object.keys(ANGULAR_SIZE_UNITS).map((unitKey) => ({
+        label: ANGULAR_SIZE_UNITS[unitKey].name,
+        value: unitKey
+    })),
+};
 
-const SizeInputFieldView= (props) => {
-    const {nullAllowed, min, max, sx, inputStyle={}, connectedMarker= false,
-        orientation='vertical', slotProps,
-        label='Size: ', showFeedback=false, onChange} = props;
-    const [{value, valid, displayValue, unit},setState]= useState(() => updateSizeInfo(props));
-    const {feedback, errmsg}= getFeedback(unit,min,max,showFeedback);
 
-    useEffect(() => {
-        setState(updateSizeInfo(props));
-    }, [ nullAllowed,  min, max,props.value, props.displayValue, props.unit]);
+export const SizeInputFields = (props) => {
     const connectContext= useContext(ConnectionCtx);
-
-    const onSizeChange= (ev) => {
-        const newDisplayValue = ev?.target?.value;
-        const degreesVal = sizeToDeg(newDisplayValue, unit);
-        const stateUpdate = {
-            displayValue: newDisplayValue,
-            value: degreesVal,
-            valid: isFieldValid(degreesVal,nullAllowed,min,max),
-            unit
-        };
-        setState(stateUpdate);
-        onChange?.(ev, stateUpdate);
-    };
-
-    const onUnitChange= (ev,newUnit) => {
-        if (unit === newUnit) return;
-        let newValue= value;
-        let newValid= valid;
-        if ( !valid ) {    // in case current displayed value is invalid, try keep it if it is good for new unit
-            newValue = sizeToDeg(displayValue, newUnit);
-            newValid = isFieldValid(newValue,nullAllowed,min,max);
-            if (!newValid) newValue = '';   // set back to empty string in case still invalid
-        }
-        const stateUpdate = {
-            unit:newUnit,
-            displayValue: valid ? sizeFromDeg(value, newUnit) : displayValue,
-            value: newValue,
-            valid: newValid,
-        };
-        setState(stateUpdate);
-        onChange?.(ev, stateUpdate);
-    };
-
+    const {value, displayValue, unit, ...restInitStateProps} = props?.initialState || {};
 
     return (
-        <Stack sx={sx}>
-            <Stack>
-                <FormControl orientation={orientation}>
-                    {label && <FormLabel>{label}</FormLabel>}
-                    <Stack spacing={1} direction='row'>
-                        <InputFieldView {...{
-                            valid,
-                            inputStyle,
-                            onChange:onSizeChange,
-                            onBlur:onSizeChange,
-                            value:displayValue,
-                            message:errmsg,
-                            connectedMarker: connectedMarker || connectContext.controlConnected,
-                            sx:{'& .MuiInput-root':{ 'paddingInlineEnd': 0, }},
-                            tooltip:'enter size within the valid range',
-                            endDecorator:(
-                                <Stack direction='row' alignItems='center'>
-                                    <Divider orientation='vertical'/>
-                                    <ListBoxInputFieldView
-                                        onChange={onUnitChange}
-                                        value={unit} multiple={false} label='' tooltip='unit of the size'
-                                        options={[
-                                            {label: 'degrees', value: 'deg'},
-                                            {label: 'arcminutes', value: 'arcmin'},
-                                            {label: 'arcseconds', value: 'arcsec'}
-                                        ]}
-                                        slotProps={{
-                                            input: {
-                                                variant:'plain',
-                                                sx:{minHeight:'unset'}
-                                                // sx:{'&:hover': { bgcolor: 'transparent' } }
-                                            }
-                                        }}
-                                    />
-                                </Stack>
-                            ),
-                        }} />
-                    </Stack>
-                </FormControl>
-                <FormHelperText {...{...slotProps?.feedback}}>
-                    {feedback}
-                </FormHelperText>
-            </Stack>
-        </Stack>
-    );
+        <QuantityInputField {...{
+            label: `${sizeQuantityProps.quantityName}: `,
+            connectedMarker: connectContext.controlConnected,
+            ...sizeQuantityProps,
+            ...props, // allow consumer overriding the props above
+
+            // initialState logic only cares about stateful props: value, unit, displayValue
+            // but other props might be nested in it, so destructure them out -- for backward compatibility
+            initialState: {value, displayValue, unit},
+            ...restInitStateProps,
+        }} />);
 };
-
-SizeInputFieldView.propTypes = {
-    unit:  PropTypes.string,
-    min:   PropTypes.number.isRequired,
-    max:   PropTypes.number.isRequired,
-    sx: object,
-    displayValue: PropTypes.string,
-    label:    PropTypes.string,
-    orientation: PropTypes.string,
-    nullAllowed: PropTypes.bool,
-    onChange: PropTypes.func,
-    value: PropTypes.any,
-    valid: PropTypes.bool,
-    showFeedback: PropTypes.bool,
-    inputStyle: PropTypes.object,
-    connectedMarker: bool,
-    slotProps: shape({
-        feedback: object,
-    })
-};
-
-
-
-export const SizeInputFields = memo( (props) => {
-
-    const {viewProps, fireValueChange}=  useFieldGroupConnector(
-        {
-            nullAllowed:props.initialState.nullAllowed??false, ...props,
-            initialState:{...props.initialState,
-                validator: (value) => {
-                    const v= (value+'').trim();
-                    const valid =
-                        (viewProps.nullAllowed && v==='') ||
-                        isSizeValid(value, props.initialState.min, props.initialState.max);
-                    const message= valid ? '' : (v ? 'Value out of range' : 'Value is required');
-                    return {valid, message};
-                }
-            }
-        }
-);
-    const {unit, valid, value, displayValue} = updateSizeInfo(viewProps);
-    return (<SizeInputFieldView
-            {...{...viewProps, unit, valid, value, displayValue}}
-            onChange= {(ev, sizeInfo) => handleOnChange(ev, sizeInfo, viewProps, fireValueChange)} />
-    );
-});
-
 
 SizeInputFields.propTypes={
     fieldKey : PropTypes.string,
@@ -227,12 +76,14 @@ SizeInputFields.propTypes={
     orientation: PropTypes.string,
     initialState: PropTypes.shape({
         value: PropTypes.any,
-        tooltip:  PropTypes.string,
         unit:  PropTypes.string,
+        displayValue: PropTypes.string,
+        // following are kept for backward compatibility, they should rather be supplied directly as props to SizeInputFields
+        // since initialState logic only cares about stateful props (value, unit, displayValue)
+        tooltip:  PropTypes.string,
         min:   PropTypes.number,
         max:   PropTypes.number,
         nullAllowed: PropTypes.bool,
-        displayValue: PropTypes.string,
         label:  PropTypes.string,
     }),
     label:       PropTypes.string,

--- a/src/firefly/js/ui/WavelengthInputField.jsx
+++ b/src/firefly/js/ui/WavelengthInputField.jsx
@@ -1,17 +1,14 @@
-import React, {memo} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import {Divider, FormControl, FormHelperText, FormLabel, Stack, Typography} from '@mui/joy';
+import {FormControl, FormLabel, Stack, Typography} from '@mui/joy';
 import {isNaN, memoize} from 'lodash';
-import {ListBoxInputFieldView} from 'firefly/ui/ListBoxInputField';
-import {useFieldGroupConnector} from './FieldGroupConnector.jsx';
-import {InputFieldView} from 'firefly/ui/InputFieldView';
-import Validate from 'firefly/util/Validate';
+import toFloat from 'validator/es/lib/toFloat';
+import {QuantityInputField} from 'firefly/ui/QuantityInputField';
 import {useFieldGroupValue} from 'firefly/ui/SimpleComponent';
 import {WAVELENGTH_UNITS} from 'firefly/visualize/VisUtil';
 
-// following strings are the keys in WAVELENGTH_UNITS object
+// following must be a key from the WAVELENGTH_UNITS object
 export const BASE_UNIT = 'um';
-const WVL_UNITS_OPTIONS = [BASE_UNIT, 'nm', 'angstrom']; // options that appear in the units dropdown
 
 // following are in BASE_UNIT (microns). These bounds work well for most of the EM spectrum we will ever deal with: X-rays to Microwaves
 const MIN_WVL = 1e-5; // = 0.1 Å (gamma rays < 0.1 Å)
@@ -27,8 +24,8 @@ const convertWavelength = (value, fromUnit, toUnit) => {
 const getFracDigits = memoize((unit) =>
     Math.log10(convertWavelength(MIN_WVL, BASE_UNIT, unit)) * -1);
 
-export const convertWavelengthStr = (valueStr, fromUnit, toUnit) => {
-    const value = parseFloat(valueStr);
+export const convertWvlUnits = (valueStr, fromUnit, toUnit) => {
+    const value = toFloat(valueStr+'');
     if (isNaN(value)) return valueStr;
     const newValue = convertWavelength(value, fromUnit, toUnit);
 
@@ -39,151 +36,27 @@ export const convertWavelengthStr = (valueStr, fromUnit, toUnit) => {
     return newValueStr;
 };
 
-const wvlWithUnitsStr = (value, unit) => `${convertWavelengthStr(value, BASE_UNIT, unit)} ${WAVELENGTH_UNITS[unit].symbol}`;
+const formatWvl = (baseValue, outputUnit) => `${convertWvlUnits(baseValue, BASE_UNIT, outputUnit)} ${WAVELENGTH_UNITS[outputUnit].symbol}`;
 
+const wvlQuantityProps = {
+    quantityName: 'Wavelength',
+    convertQuantityUnits: convertWvlUnits,
+    formatQuantity: formatWvl,
+    quantityBaseUnit: BASE_UNIT,
+    quantityUnitOptions: [BASE_UNIT, 'nm', 'angstrom'].map((unitKey) => ({
+        label: WAVELENGTH_UNITS[unitKey].symbol,
+        value: unitKey
+    })),
+};
 
-export const WavelengthUnitsView = ({ unit, onChange, ...props }) => (
-    <Stack direction='row' alignItems='center'>
-        <Divider orientation='vertical' />
-        <ListBoxInputFieldView
-            value={unit}
-            onChange={onChange}
-            options={WVL_UNITS_OPTIONS.map((unitKey) => ({
-                label: WAVELENGTH_UNITS[unitKey].symbol,
-                value: unitKey
-            }))}
-            tooltip='Unit of the wavelength'
-            multiple={false}
-            slotProps={{
-                input: {
-                    variant: 'plain',
-                    sx: { minHeight: 'unset' },
-                },
-            }}
-            {...props}
-        />
-    </Stack>
-);
-
-/**Controlled component for Wavelength Input.
- *
- * The state is controlled by `{value, displayValue, unit, valid, message}` props and the effect of state change is
- * controlled by `onChange`.
- *
- * @param props
- * @param props.value {string} wavelength value in BASE_UNIT
- * @param props.displayValue {string} wavelength value that is input by user
- * @param props.unit {string} wavelength unit input by user
- * @param props.valid {boolean} whether `value` is valid (i.e. satisfies min/max bounds, nullAllowed, etc.)
- * @param props.message {string} message to display if invalid
- * @param props.onChange {function(object, {value: string, displayValue: string, unit: string}): void} lifts the updated
- * value, displayValue, unit to the parent that controls the state.
- */
-function WavelengthInputFieldView({min=MIN_WVL, max=MAX_WVL, sx, slotProps, inputStyle={},
-                                      orientation='vertical', label, showFeedback=false,
-                                      placeholder='Enter wavelength', tooltip='Enter wavelength within the valid range',
-                                      onChange, valid, message, unit, value, displayValue}) {
-
-    const handleWvlChange = (ev) => {
-        const newDisplayValue = ev?.target?.value?.trim();
-        const newValue = convertWavelengthStr(newDisplayValue, unit, BASE_UNIT);
-        const wvlInfoUpdate = {
-            value: newValue,
-            displayValue: newDisplayValue,
-            unit,
-        };
-        onChange?.(ev, wvlInfoUpdate); // lift the state
-    };
-
-    const handleUnitChange = (ev, newUnit) => {
-        if (unit === newUnit) return;
-        let newValue = value;
-        let newDisplayValue = displayValue;
-
-        if (valid) {
-            newDisplayValue = convertWavelengthStr(value, BASE_UNIT, newUnit);
-        } else {
-            // maybe the displayValue (user-input number) is valid for new unit
-            // so keep displayValue unchanged but update value (which will be checked for validity by parent component)
-            newValue = convertWavelengthStr(displayValue, newUnit, BASE_UNIT);
-        }
-
-        const wvlInfoUpdate = {
-            value: newValue,
-            displayValue: newDisplayValue,
-            unit: newUnit,
-        };
-        onChange?.(ev, wvlInfoUpdate);
-    };
-
-    const feedback = showFeedback ? `Valid range: ${wvlWithUnitsStr(min, unit)} - ${wvlWithUnitsStr(max, unit)}` : '';
-
+export const WavelengthInputField = (props) => {
     return (
-        <Stack sx={sx}>
-            <InputFieldView
-                valid={valid}
-                message={message}
-                onChange={handleWvlChange}
-                onBlur={handleWvlChange}
-                value={displayValue}
-                inputStyle={inputStyle}
-                placeholder={placeholder}
-                tooltip={tooltip}
-                label={label}
-                orientation={orientation}
-                sx={{ '& .MuiInput-root': { paddingInlineEnd: 0 } }}
-                endDecorator={<WavelengthUnitsView unit={unit} onChange={handleUnitChange} {...slotProps?.units}/>}
-            />
-            <FormHelperText {...{...slotProps?.feedback}}>
-                {feedback}
-            </FormHelperText>
-        </Stack>
+        <QuantityInputField {...{
+            min: MIN_WVL, max: MAX_WVL, ...wvlQuantityProps,
+            ...props // at the end to allow consumer overriding the defaults
+        }}/>
     );
-}
-
-const isValidWavelength = (value, unit, nullAllowed, min, max, description) => {
-    const makeMinMaxStr = (value) => wvlWithUnitsStr(value, unit);
-    return Validate.floatRange(min, max, null, description, value, nullAllowed, makeMinMaxStr);
 };
-
-const handleOnChange = (ev, wvlInfoUpdate, viewProps, fireValueChange) => {
-    const { value, displayValue, unit=BASE_UNIT, validator, nullAllowed=false,
-        min=MIN_WVL, max=MAX_WVL, description='Wavelength' } = { ...viewProps, ...wvlInfoUpdate };
-
-    // run custom validator (`validator()`) before the default validator (`isValidWavelength()`) that checks wavelength bounds
-    let validationResult = validator?.(value) ?? {valid: true, message: ''};
-    if (validationResult?.valid) validationResult = isValidWavelength(value, unit, nullAllowed, min, max, description);
-    const { valid, message } = validationResult;
-
-    fireValueChange({ value, displayValue, unit, valid, message });
-};
-
-const updateInitState = ({value='', displayValue='', unit=BASE_UNIT}) => {
-    const initialState = {value, displayValue, unit};
-    if (value && !displayValue) initialState.displayValue = convertWavelengthStr(value, BASE_UNIT, unit);
-    else if (!value && displayValue) initialState.value = convertWavelengthStr(displayValue, unit, BASE_UNIT);
-    return initialState;
-};
-
-
-// TODO for future: Make a HOC called QuantityInputField for
-//  - abstraction of the redundant code/logic in WavelengthInputField(View) and SizeInputField(View)
-//  - cleanup state logic of SizeInputField (it's unnecessarily convoluted)
-
-/**Uncontrolled component for Wavelength Input that manages the state with respect to the FieldGroup.
- */
-export const WavelengthInputField = memo((props) => {
-    const { viewProps, fireValueChange } = useFieldGroupConnector({
-        ...props,
-        initialState: updateInitState(props?.initialState),
-    });
-
-    const newProps = {
-        ...viewProps,
-        onChange: (ev, wvlInfoUpdate) => handleOnChange(ev, wvlInfoUpdate, viewProps, fireValueChange)
-    };
-    return (<WavelengthInputFieldView {...newProps}/>);
-});
 
 const commonPropTypes = {
     min: PropTypes.number,
@@ -200,16 +73,6 @@ const commonPropTypes = {
         units: PropTypes.object,
         feedback: PropTypes.object,
     }),
-};
-
-WavelengthInputFieldView.propTypes = {
-    ...commonPropTypes,
-    value: PropTypes.string, // used by field group state, always in BASE_UNIT
-    displayValue: PropTypes.string, // what's displayed in the input field UI
-    unit: PropTypes.string,
-    valid: PropTypes.bool,
-    message: PropTypes.string,
-    onChange: PropTypes.func,
 };
 
 WavelengthInputField.propTypes = {

--- a/src/firefly/js/ui/tap/WavelengthPanel.jsx
+++ b/src/firefly/js/ui/tap/WavelengthPanel.jsx
@@ -16,7 +16,7 @@ import {
 import {tapHelpId} from './TapUtil.js';
 import {
     BASE_UNIT,
-    convertWavelengthStr,
+    convertWvlUnits,
     WavelengthInputField,
     WavelengthRangeInput
 } from 'firefly/ui/WavelengthInputField';
@@ -76,7 +76,7 @@ function makeWavelengthConstraints(filterDefinitions, fldObj) {
             errList.checkForError(wlContains);
             if (wlContains?.valid) {
                 // value is represented in BASE_UNIT but 'em_min' and 'em_max' in query fragment are in m (meters) so convert to m
-                const rangeBound = convertWavelengthStr(wlContains.value, BASE_UNIT, 'm');
+                const rangeBound = convertWvlUnits(wlContains.value, BASE_UNIT, 'm');
                 if (rangeBound) {
                     const rangeList = [[rangeBound, rangeBound]];
                     adqlConstraintsAry.push(makeAdqlQueryRangeFragment('em_min', 'em_max', rangeList, true));
@@ -93,8 +93,8 @@ function makeWavelengthConstraints(filterDefinitions, fldObj) {
             const anyHasValue = wlMinRange?.value || wlMaxRange?.value;
             if (anyHasValue) {
                 // value is represented in BASE_UNIT but 'em_min' and 'em_max' in query fragment are in m (meters) so convert to m
-                const lowerValue = convertWavelengthStr(wlMinRange?.value, BASE_UNIT, 'm') || '-Inf';
-                const upperValue = convertWavelengthStr(wlMaxRange?.value, BASE_UNIT, 'm') || 'Inf';
+                const lowerValue = convertWvlUnits(wlMinRange?.value, BASE_UNIT, 'm') || '-Inf';
+                const upperValue = convertWvlUnits(wlMaxRange?.value, BASE_UNIT, 'm') || 'Inf';
                 const rangeList = [[lowerValue, upperValue]];
                 adqlConstraintsAry.push(makeAdqlQueryRangeFragment('em_min', 'em_max', rangeList));
                 siaConstraints.push(...siaQueryRange('BAND', rangeList));
@@ -166,35 +166,32 @@ export function WavelengthOptions({initArgs, fieldKeys, filterDefinitionsLabel, 
             {useNumerical && (
                 <Stack spacing={1} {...slotProps?.numericalWvlOptions}>
                     {!fixedRangeType && (
-                        <div style={{display: 'flex'}}>
-                            <ListBoxInputField
-                                fieldKey={fieldKeys.rangeType}
-                                options={[
-                                    {label: 'contains', value: 'contains'},
-                                    {label: 'overlaps', value: 'overlaps'},
-                                ]}
-                                initialState={{value: initArgs?.urlApi?.[fieldKeys.rangeType] || 'contains'}}
-                                label='Select observations whose wavelength coverage'
-                                orientation='vertical'
-                                multiple={false}
-                                {...slotProps?.rangeType}
-                            />
-                        </div>
+                        <ListBoxInputField
+                            fieldKey={fieldKeys.rangeType}
+                            options={[
+                                {label: 'contains', value: 'contains'},
+                                {label: 'overlaps', value: 'overlaps'},
+                            ]}
+                            initialState={{value: initArgs?.urlApi?.[fieldKeys.rangeType] || 'contains'}}
+                            label='Select observations whose wavelength coverage'
+                            orientation='vertical'
+                            multiple={false}
+                            sx={{alignSelf: 'flex-start'}}
+                            {...slotProps?.rangeType}
+                        />
                     )}
                     {useRangeContains && (
-                        <div style={{ display: 'flex' }}>
-                            <WavelengthInputField fieldKey={fieldKeys.wvlContains}
-                                                  inputStyle={{ overflow: 'auto', height: 16 }}
-                                                  placeholder='enter wavelength'
-                                                  {...slotProps?.wvlContains}
-                                                  initialState={{
-                                                      unit: 'nm', //unit that shows up in the units dropdown
-                                                      ...slotProps?.wvlContains?.initialState,
-                                                      value: initArgs?.urlApi?.[fieldKeys.wvlContains], //always in BASE_UNIT
-                                                      //we don't need `unit` from initArgs since its purpose is only for display:
-                                                      //displayValue that shows in input field is computed with value and unit
-                                                  }}/>
-                        </div>
+                        <WavelengthInputField fieldKey={fieldKeys.wvlContains}
+                                              inputStyle={{ overflow: 'auto', height: 16 }}
+                                              placeholder='enter wavelength'
+                                              {...slotProps?.wvlContains}
+                                              initialState={{
+                                                  unit: 'nm', //unit that shows up in the units dropdown
+                                                  ...slotProps?.wvlContains?.initialState,
+                                                  value: initArgs?.urlApi?.[fieldKeys.wvlContains], //always in BASE_UNIT
+                                                  //we don't need `unit` from initArgs since its purpose is only for display:
+                                                  //displayValue that shows in input field is computed with value and unit
+                                              }}/>
                     )}
                     {useRangeOverlaps && (
                         <WavelengthRangeInput minFieldKey={fieldKeys.wvlMin} maxFieldKey={fieldKeys.wvlMax}


### PR DESCRIPTION
Fixes [FIREFLY-1832](https://jira.ipac.caltech.edu/browse/FIREFLY-1832), [FIREFLY-1882](https://jira.ipac.caltech.edu/browse/FIREFLY-1882)

Also see IFE PR: https://github.com/IPAC-SW/irsa-ife/pull/451


* Added a new generic `QuantityInputField` and supporting helpers to standardize the logic for handling quantities with units, including validation and unit conversion. This abstracts most of the logic from WavelengthInputField that I created recently and applies that to SizeInputField which had older & unnecessarily complex validation and state handling logic.
* Refactored `WavelengthInputField.jsx` and `SizeInputField.jsx` to use the new `QuantityInputField`, which enables:
  - changing the default  name used by quantity: "Size" -> "Angle" for Position Angle field in spherex
  - locking units to single option
  - not showing error in `SizeInputField` when no initial `value` is provided but `nullAllowed=false`

## Testing
SPHEREx: https://firefly-1832-flexible-sizeinput.irsakubedev.ipac.caltech.edu/applications/spherex

Go to Spectrophotometry tab -> select "Sersic Galaxy Profile" -> check that "Position Angle" and "Effective Radius" doesn't have issues mentioned in linked tickets and have fixed unit.

Also go to Spectral Image Search tab and check if location and spectral constraints (using SizeInput and WavelengthInput) are working as before. 

Firefly: https://fireflydev.ipac.caltech.edu/firefly-1832-flexible-sizeinput/firefly

Regression test all instances of SizeInputField - I tried TAP and IRSA catalogs and didn't see any problem but we need more rigorous testing
