### PR TITLE
FIREFLY-1838: Inconsistent CSV handling between API and direct upload

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -137,8 +137,8 @@ ARG user=tomcat
 ARG group=tomcat
 ARG uid=91
 ARG gid=91
-ARG TARGETARCH
-ARG TARGETOS
+ARG TARGETARCH=amd64
+ARG TARGETOS=linux
 ARG DUCKDB_VERSION=v1.1.3
 
 # These are the users replaceable environment variables, basically runtime arguments
@@ -198,9 +198,9 @@ RUN sed -i 's/<Connector port="8080" protocol="HTTP\/1.1"/<Connector port="8080"
     $CATALINA_HOME/conf/server.xml
 
 # preinstall DuckDB extensions; remember to update version when DuckDB is updated
-ENV DUCKDB_TARGET=${DUCKDB_VERSION}/${TARGETOS}_${TARGETARCH}
+ENV DUCKDB_TARGET=${DUCKDB_VERSION}/${TARGETOS}_${TARGETARCH}_gcc4
 RUN mkdir -p temp/$DUCKDB_TARGET \
-    && wget -P temp/$DUCKDB_TARGET http://community-extensions.duckdb.org/$DUCKDB_TARGET/magic.duckdb_extension.gz \
+    && wget -P temp/$DUCKDB_TARGET https://community-extensions.duckdb.org/$DUCKDB_TARGET/magic.duckdb_extension.gz \
     && gunzip -f temp/$DUCKDB_TARGET/magic.duckdb_extension.gz
 
 # Add permission to files and directories needed for runtime

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
@@ -280,10 +280,10 @@ public class DuckDbAdapter extends BaseDbAdapter {
 
     public record MimeDesc(String mime, String desc) {}
     @Nonnull
-    public static MimeDesc getMimeType(File inFile) {
+    public static MimeDesc getMimeType(String inFile) {
         try(JdbcFactory.SharedDS ds = JdbcFactory.getSharedDS(new DuckDbAdapter().createDbInstance())) {
             loadExtension(ds, "magic");
-            Map<String, Object> rs = ds.getJdbc().queryForMap("SELECT file, magic_mime(file) AS mime, magic_type(file) AS desc FROM glob('%s')".formatted(inFile.getAbsolutePath()));
+            Map<String, Object> rs = ds.getJdbc().queryForMap("SELECT file, magic_mime(file) AS mime, magic_type(file) AS desc FROM glob('%s')".formatted(inFile));
             if (!rs.isEmpty()) {
                 return new MimeDesc(String.valueOf(rs.get("mime")), String.valueOf(rs.get("desc")));
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/DbFromFileProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/DbFromFileProcessor.java
@@ -1,0 +1,91 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.core.background.JobInfo;
+import edu.caltech.ipac.firefly.core.background.JobManager;
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.db.DbAdapter;
+import edu.caltech.ipac.firefly.server.db.DbDataIngestor;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.util.FormatUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
+import static edu.caltech.ipac.util.StringUtils.isEmpty;
+
+
+/**
+ * Abstract Processor to ingest data from a file into the database.  Opposite of EmbeddedDbToFileProcessor where data is imported from a DataGroup into the database.
+ * It does not register itself as a SearchProcessorImpl; subclasses should do so.
+ *
+ * @author loi
+ * $Id: DbFromFileProcessor.java,v 1.6 2012/09/25 21:13:23 loi Exp $
+ */
+public abstract class DbFromFileProcessor extends EmbeddedDbProcessor {
+    public static final String FORMAT = "format";
+    public static final String TBL_INDEX = TableServerRequest.TBL_INDEX;
+
+    @Override
+    public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException {
+        // if getDataFile returns null, then subclasses should override fetchDataGroup to provide the data
+        return null;
+    }
+
+    /**
+     * Get the data file to ingest into the database.
+     * This allows loading data into the database without loading the entire data into memory first.
+     * @param req the table request used to get the data file
+     * @return the data file to ingest
+     * @throws DataAccessException if there is an error getting the data file
+     */
+    public abstract File getDataFile(TableServerRequest req) throws DataAccessException;
+
+    @Override
+    protected FileInfo ingestDataIntoDb(TableServerRequest req, DbAdapter dbAdapter) throws DataAccessException {
+        try {
+            dbAdapter.initDbFile();
+            int tblIdx = req.getIntParam(TBL_INDEX, 0);
+            String fmt = req.getParam(FORMAT);
+            FormatUtil.Format format = isEmpty(fmt) ? null : FormatUtil.Format.valueOf(fmt);
+
+            File dataFile = ifNotNull(getCachedFile(req)).getOrElse(getDataFile(req));
+            if (dataFile != null) {
+                return DbDataIngestor.ingestData(req, dbAdapter, (dg) -> applyExtraMeta(dg, req), dataFile, tblIdx, format);
+            } else {
+                return dbAdapter.ingestData(makeDgSupplier(req, () -> getOrFetchDataGroup(req)), dbAdapter.getDataTable());
+            }
+
+        } catch (IOException e) {
+            Logger.getLogger().error(e,"Failed to ingest data into the database:" + req.getRequestId());
+            throw new DataAccessException(e);
+        }
+    }
+
+    public File getCachedFile(TableServerRequest req) throws DataAccessException {
+        String jobId = req.getJobId();
+        if (isEmpty(jobId)) return null;
+
+        // a previously submitted job; try to get from cache
+        List<JobInfo.Result> results = ifNotNull(JobManager.getJobInfo(req.getJobId()))
+                .get(JobInfo::getResults);
+        if (results != null && !results.isEmpty()) {
+            File rval = ifNotEmpty(results.getFirst().href())
+                            .get(ServerContext::convertToFile);
+            if (rval != null && rval.canRead()) {       // if not found in cache, fetch from source
+                return rval;
+            }
+        }
+        return null;
+    }
+
+}
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -279,13 +279,17 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         TableUtil.consumeColumnMeta(dg, null);      // META-INFO in the request should only be pass-along and not persist.
     }
 
-    public File getDataFile(TableServerRequest request) throws IpacTableException, IOException, DataAccessException {
+    public File getDataFile(TableServerRequest request) throws DataAccessException {
         TableServerRequest cr = (TableServerRequest) request.cloneRequest();
         cr.setPageSize(Integer.MAX_VALUE);
         DataGroupPart results = getData(cr);
-        File ipacTable = createTempFile(cr, ".tbl");
-        IpacTableWriter.save(ipacTable, results.getData());
-        return ipacTable;
+        try {
+            File ipacTable = createTempFile(cr, ".tbl");
+            IpacTableWriter.save(ipacTable, results.getData());
+            return ipacTable;
+        } catch (IOException e) {
+            throw new DataAccessException(e);
+        }
     }
 
     public FileInfo writeData(OutputStream out, ServerRequest request, FormatUtil.Format format, TableUtil.Mode mode) throws DataAccessException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/IpacTablePartProcessor.java
@@ -311,7 +311,7 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
         }
     }
 
-    public File getDataFile(TableServerRequest request) throws IpacTableException, IOException, DataAccessException {
+    public File getDataFile(TableServerRequest request) throws DataAccessException {
         LOGGER.warn("<< slow getDataFile called." + this.getClass().getSimpleName());
 
         Cache<File> cache = CacheManager.getLocal();  // validateFile is called.  no need to set validator
@@ -323,86 +323,89 @@ abstract public class IpacTablePartProcessor implements SearchProcessor<DataGrou
         if (noBgWrite) {
             request.setPageSize(Integer.MAX_VALUE);
         }
+        try {
+            // go get original data
+            File resultsFile = getBaseDataFile(request);      // caching already done..
 
-        // go get original data
-        File resultsFile = getBaseDataFile(request);      // caching already done..
+            if (resultsFile == null || !resultsFile.canRead()) return null;
 
-        if (resultsFile == null || !resultsFile.canRead()) return null;
+            // from here on.. we use resultsFile as the cache key.
+            // if the source file changes, we ignore previously cached temp files
+            StringKey key = new StringKey(resultsFile.getPath());
 
-        // from here on.. we use resultsFile as the cache key.
-        // if the source file changes, we ignore previously cached temp files
-        StringKey key = new StringKey(resultsFile.getPath());
-
-        // do filtering
-        CollectionUtil.Filter<DataObject>[] filters = QueryUtil.convertToDataFilter(request.getFilters());
-        if (filters != null && filters.length > 0) {
-            key = key.appendToKey((Object[]) filters);
-            File filterFile = validateFile(cache.get(key));
-            if (filterFile == null) {
-                filterFile = File.createTempFile(getFilePrefix(request), ".tbl", QueryUtil.getTempDir(request));
-                doFilter(filterFile, resultsFile, filters, request);
-                cache.put(key, filterFile);
-            }
-            resultsFile = filterFile;
-        }
-
-        // do sorting...
-        SortInfo sortInfo = request.getSortInfo();
-        if (sortInfo != null) {
-            key = key.appendToKey(sortInfo);
-            File sortedFile = validateFile(cache.get(key));
-            if (sortedFile == null) {
-                sortedFile = File.createTempFile(getFilePrefix(request), ".tbl", QueryUtil.getTempDir(request));
-                doSort(resultsFile, sortedFile, sortInfo, request);
-                cache.put(key, sortedFile);
-            }
-            resultsFile = sortedFile;
-        }
-
-        // do decimation
-        DecimateInfo decimateInfo = DecimationProcessor.getDecimateInfo(request);
-        if (decimateInfo != null) {
-            key = key.appendToKey(decimateInfo);
-            File deciFile = validateFile(cache.get(key));
-            if (deciFile == null) {
-                // only read in the required columns
-                String xColExpr = decimateInfo.getxColumnName();
-                String yColExpr = decimateInfo.getyColumnName();
-                String [] requestedCols = new String[]{xColExpr, yColExpr};
-
-                DataGroup dg = IpacTableReader.read(resultsFile, requestedCols);
-
-                deciFile = File.createTempFile(getFilePrefix(request), ".tbl", QueryUtil.getTempDir(request));
-                DataGroup retval = QueryUtil.doDecimation(dg, decimateInfo);
-                IpacTableWriter.save(deciFile, retval);
-                cache.put(key, deciFile);
-            }
-            resultsFile = deciFile;
-        }
-
-        // return only the columns requested, ignore when decimation is requested
-        String ic = request.getParam(TableServerRequest.INCL_COLUMNS);
-        if (decimateInfo == null && !StringUtils.isEmpty(ic) && !ic.equals("ALL")) {
-            key = key.appendToKey(ic);
-            File subFile = validateFile(cache.get(key));
-            if (subFile == null) {
-                subFile = File.createTempFile(getFilePrefix(request), ".tbl", QueryUtil.getTempDir(request));
-                String sql = "select col " + ic + " from " + resultsFile.getAbsolutePath() + " into " + subFile.getAbsolutePath() + " with complete_header";
-                try {
-                    DataGroupQueryStatement.parseStatement(sql).executeInline();
-                } catch (InvalidStatementException e) {
-                    throw new DataAccessException("InvalidStatementException", e);
+            // do filtering
+            CollectionUtil.Filter<DataObject>[] filters = QueryUtil.convertToDataFilter(request.getFilters());
+            if (filters != null && filters.length > 0) {
+                key = key.appendToKey((Object[]) filters);
+                File filterFile = validateFile(cache.get(key));
+                if (filterFile == null) {
+                    filterFile = File.createTempFile(getFilePrefix(request), ".tbl", QueryUtil.getTempDir(request));
+                    doFilter(filterFile, resultsFile, filters, request);
+                    cache.put(key, filterFile);
                 }
-                cache.put(key, subFile);
+                resultsFile = filterFile;
             }
-            resultsFile = subFile;
-        }
 
-        if (noBgWrite) {
-            request.setPageSize(oriPageSize);
-        }
+            // do sorting...
+            SortInfo sortInfo = request.getSortInfo();
+            if (sortInfo != null) {
+                key = key.appendToKey(sortInfo);
+                File sortedFile = validateFile(cache.get(key));
+                if (sortedFile == null) {
+                    sortedFile = File.createTempFile(getFilePrefix(request), ".tbl", QueryUtil.getTempDir(request));
+                    doSort(resultsFile, sortedFile, sortInfo, request);
+                    cache.put(key, sortedFile);
+                }
+                resultsFile = sortedFile;
+            }
 
-        return resultsFile;
+            // do decimation
+            DecimateInfo decimateInfo = DecimationProcessor.getDecimateInfo(request);
+            if (decimateInfo != null) {
+                key = key.appendToKey(decimateInfo);
+                File deciFile = validateFile(cache.get(key));
+                if (deciFile == null) {
+                    // only read in the required columns
+                    String xColExpr = decimateInfo.getxColumnName();
+                    String yColExpr = decimateInfo.getyColumnName();
+                    String [] requestedCols = new String[]{xColExpr, yColExpr};
+
+                    DataGroup dg = IpacTableReader.read(resultsFile, requestedCols);
+
+                    deciFile = File.createTempFile(getFilePrefix(request), ".tbl", QueryUtil.getTempDir(request));
+                    DataGroup retval = QueryUtil.doDecimation(dg, decimateInfo);
+                    IpacTableWriter.save(deciFile, retval);
+                    cache.put(key, deciFile);
+                }
+                resultsFile = deciFile;
+            }
+
+            // return only the columns requested, ignore when decimation is requested
+            String ic = request.getParam(TableServerRequest.INCL_COLUMNS);
+            if (decimateInfo == null && !StringUtils.isEmpty(ic) && !ic.equals("ALL")) {
+                key = key.appendToKey(ic);
+                File subFile = validateFile(cache.get(key));
+                if (subFile == null) {
+                    subFile = File.createTempFile(getFilePrefix(request), ".tbl", QueryUtil.getTempDir(request));
+                    String sql = "select col " + ic + " from " + resultsFile.getAbsolutePath() + " into " + subFile.getAbsolutePath() + " with complete_header";
+                    try {
+                        DataGroupQueryStatement.parseStatement(sql).executeInline();
+                    } catch (Exception e) {
+                        throw new DataAccessException(e);
+                    }
+                    cache.put(key, subFile);
+                }
+                resultsFile = subFile;
+            }
+
+            if (noBgWrite) {
+                request.setPageSize(oriPageSize);
+            }
+
+            return resultsFile;
+        } catch (IOException e) {
+            throw new DataAccessException("IOException: " + e.getMessage(), e);
+        }
     }
 
     public void prepareTableMeta(TableMeta defaults, List<DataType> columns, ServerRequest request) {}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/ResourceProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/ResourceProcessor.java
@@ -46,7 +46,7 @@ import static edu.caltech.ipac.util.FileUtil.writeStringToFile;
             @ParamDoc(name = "scope",           desc = "visibility of this resource.  one of 'global', 'user', 'protected'.  defaults to 'global'"),
             @ParamDoc(name = "secret",          desc = "secret token used to access 'protected' resources"),
         })
-public class ResourceProcessor extends EmbeddedDbProcessor {
+public class ResourceProcessor extends DbFromFileProcessor {
     public static final String PROC_ID = "ResourceProcessor";
     public static final String SUBDIR_PATH = "resource-db";
 
@@ -70,7 +70,7 @@ public class ResourceProcessor extends EmbeddedDbProcessor {
     public DbAdapter getDbAdapter(TableServerRequest treq) {
         String resourceID = getResourceID(treq);
         return DbAdapter.getAdapter(treq, (ext) ->
-                new File(ServerContext.getHiPSDir(), "%s/%s.%s".formatted(SUBDIR_PATH, resourceID, ext))
+                new File(ServerContext.getHiPSDir(), "%s/%s.%s".formatted(SUBDIR_PATH, resourceID, ext))            // use HiPS dir for longest retention period
         );
     }
 
@@ -89,7 +89,9 @@ public class ResourceProcessor extends EmbeddedDbProcessor {
     }
 
     protected FileInfo ingestDataIntoDb(TableServerRequest req, DbAdapter dbAdapter) throws DataAccessException {
-        writeStringToFile(getAclFile(dbAdapter.getDbFile()), String.format("scope=%s\nsecret=%s\nuser=%s\n",
+        File aclFile= getAclFile(dbAdapter.getDbFile());
+        aclFile.getParentFile().mkdirs();       // ensure directory exists
+        writeStringToFile(aclFile, String.format("scope=%s\nsecret=%s\nuser=%s\n",
                 req.getParam(SCOPE, GLOBAL),
                 req.getParam(SECRET, ""),
                 ServerContext.getRequestOwner().getUserKey()));
@@ -97,16 +99,30 @@ public class ResourceProcessor extends EmbeddedDbProcessor {
         return super.ingestDataIntoDb(req, dbAdapter);
     }
 
-    public DataGroup fetchDataGroup(TableServerRequest treq) throws DataAccessException {
-        try {
-            TableServerRequest sreq = QueryUtil.getSearchRequest(treq);
-            SearchProcessor<?> processor = SearchManager.getProcessor(sreq.getRequestId());
-            if (processor instanceof CanFetchDataGroup) {
-                return ((CanFetchDataGroup)processor).fetchDataGroup(sreq);
-            } else throw new IllegalArgumentException("SearchProcessor not found for the given request: " + getUniqueID(treq));
-        } catch (Exception e) {
-            throw new DataAccessException(e.getMessage(), e);
+    @Override
+    public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException {
+        TableServerRequest sreq = QueryUtil.getSearchRequest(req);
+        if (getRefProcessor(sreq) instanceof CanFetchDataGroup proc) {
+            return proc.fetchDataGroup(sreq);
         }
+        return null;
+    }
+
+    @Override
+    public File getDataFile(TableServerRequest req) throws DataAccessException {
+        TableServerRequest sreq = QueryUtil.getSearchRequest(req);
+        if (getRefProcessor(sreq) instanceof CanGetDataFile proc) {
+            return proc.getDataFile(sreq);
+        }
+        return null;
+    }
+
+    private SearchProcessor<?> getRefProcessor(TableServerRequest req) throws DataAccessException {
+        SearchProcessor<?> processor = SearchManager.getProcessor(req.getRequestId());
+        if (processor == null) {
+            throw new DataAccessException("SearchProcessor not found for the given request: " + getUniqueID(req));
+        }
+        return processor;
     }
 
     protected DataGroupPart getResultSet(TableServerRequest treq, DbAdapter dbAdapter) throws DataAccessException {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchManager.java
@@ -98,8 +98,8 @@ public class SearchManager {
         SearchProcessor processor = getProcessor(request.getRequestId());
         if (processor != null) {
             try {
-                if (processor instanceof SearchProcessor.CanGetDataFile) {
-                    File dgFile = ((SearchProcessor.CanGetDataFile)processor).getDataFile(request);
+                if (processor instanceof SearchProcessor.CanGetDataFile proc) {
+                    File dgFile = proc.getDataFile(request);
                     // page size will not be taken into account
                     return new FileInfo(dgFile);
                 } else {
@@ -108,12 +108,6 @@ public class SearchManager {
             } catch (ClassCastException e) {
                 LOGGER.error(e, "Invalid processor mapping.  Return value is not of type FileInfo.");
                 throw new DataAccessException("Request failed due to unexpected exception.", e);
-            } catch (IpacTableException e) {
-                LOGGER.error(e, "IPAC table exception. Unable to get IPAC table.");
-                throw new DataAccessException("Request failed.", e);
-            } catch (IOException e) {
-                LOGGER.error(e, "IO Exception. Unable to get IPAC table.");
-                throw new DataAccessException("Request failed.", e);
             }
         }
         return null;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SearchProcessor.java
@@ -98,7 +98,7 @@ public interface SearchProcessor<Type> {
      *
      */
     interface CanGetDataFile {
-        File getDataFile(TableServerRequest request) throws IpacTableException, IOException, DataAccessException;
+        File getDataFile(TableServerRequest request) throws DataAccessException;
     }
 
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
@@ -3,81 +3,75 @@
  */
 package edu.caltech.ipac.firefly.server.query.tables;
 
-import edu.caltech.ipac.firefly.core.background.JobInfo;
-import edu.caltech.ipac.firefly.core.background.JobManager;
-import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.ServerParams;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.server.ServerContext;
-import edu.caltech.ipac.firefly.server.db.DbAdapter;
-import edu.caltech.ipac.firefly.server.db.DbDataIngestor;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
-import edu.caltech.ipac.firefly.server.query.EmbeddedDbProcessor;
+import edu.caltech.ipac.firefly.server.query.DbFromFileProcessor;
 import edu.caltech.ipac.firefly.server.query.SearchManager;
 import edu.caltech.ipac.firefly.server.query.SearchProcessor;
 import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
-import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.firefly.server.ws.WsServerUtils;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.DataGroupPart;
-import edu.caltech.ipac.table.TableMeta;
-import edu.caltech.ipac.table.TableUtil;
-import edu.caltech.ipac.util.FormatUtil;
 
 import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.util.List;
-import java.util.function.Consumer;
 
-import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
-import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_INDEX;
 import static edu.caltech.ipac.firefly.data.table.MetaConst.CATALOG_OVERLAY_TYPE;
-import static edu.caltech.ipac.firefly.server.ServerContext.convertToFile;
 import static edu.caltech.ipac.firefly.server.query.tables.IpacTableFromSource.PROC_ID;
 import static edu.caltech.ipac.firefly.server.util.QueryUtil.SEARCH_REQUEST;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
-import edu.caltech.ipac.firefly.core.Util.Try;
 
 
 @SearchProcessorImpl(id = PROC_ID)
-public class IpacTableFromSource extends EmbeddedDbProcessor {
+public class IpacTableFromSource extends DbFromFileProcessor {
     public static final String PROC_ID = "IpacTableFromSource";
     private static final String TBL_TYPE = "tblType";
     private static final String TYPE_CATALOG = "catalog";
     private static final String FORMAT = "format";          // format of the source file if known.
 
-    /**
-     * This method should not be called anymore because ingestDataIntoDb is overridden.
-     */
-    @Deprecated
+
+    @Override
     public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException {
+        // when SOURCE is not provided, try to get data from processor or search request
         String processor = req.getParam("processor");
         String jsonSearchRequest = req.getParam(SEARCH_REQUEST);
-
-        // by processor ID
-        if (!isEmpty(processor)) {
+        if (!isEmpty(processor))  {
             return getByProcessor(processor, req);
-        }
-
-        // by a TableRequest as json string
-        if (!isEmpty(jsonSearchRequest)) {
+        } else if (!isEmpty(jsonSearchRequest)) {
             return getByTableRequest(jsonSearchRequest);
         }
-
-        var srcFile = fetchSourceFile(req);
-        return fetchDataFromFile(req, srcFile);
+        return null;
     }
 
-    DataGroup fetchDataFromFile(TableServerRequest req, File srcFile) throws DataAccessException {
-        try {
-            int tblIdx = req.getIntParam(TBL_INDEX, 0);
-            return TableUtil.readAnyFormat(srcFile, tblIdx, req);
-        } catch (IOException e) {
-            throw new DataAccessException(e.getMessage(), e);
+    @Override
+    public File getDataFile(TableServerRequest req) throws DataAccessException {
+        String source = req.getParam(ServerParams.SOURCE);
+        String altSource = req.getParam(ServerParams.ALT_SOURCE);
+        updateJob(ji -> ji.getAux().setJobUrl(source));
+
+        if (isWorkspace(req)) {
+            // by workspace
+            File inf = getFromWorkspace(source, altSource);
+            if (inf == null || !inf.canRead()) {
+                throw new DataAccessException("Unable to read file from workspace: " + source);
+            }
+            return inf;
         }
+        if (isEmpty(source) && isEmpty(altSource)) {
+            return null;        // no source provided; return null so fetchDataGroup can be tried
+        }
+
+        // by source parameter
+        File inf = QueryUtil.resolveFileFromSource(source, req);
+        if (inf == null) inf = QueryUtil.resolveFileFromSource(altSource, req);
+        if (inf == null) {
+            throw new DataAccessException(String.format("Unable to fetch file from path[alt_path]: %s[%s]", source, altSource));
+        }
+        setJobResults(inf);
+        return inf;
     }
 
     @Override
@@ -90,107 +84,6 @@ public class IpacTableFromSource extends EmbeddedDbProcessor {
                 }
             }
         }
-    }
-
-    @Override
-    protected FileInfo ingestDataIntoDb(TableServerRequest req, DbAdapter dbAdapter) throws DataAccessException {
-        try {
-            dbAdapter.initDbFile();
-
-            String processor = req.getParam("processor");
-            String jsonSearchRequest = req.getParam(SEARCH_REQUEST);
-            int tblIdx = req.getIntParam(TBL_INDEX, 0);
-            String fmt = req.getParam(FORMAT);
-            FormatUtil.Format format = isEmpty(fmt) ? null : FormatUtil.Format.valueOf(fmt);
-            File srcFile = null;
-            DbAdapter.DataGroupSupplier fetchDataGroup = null;
-
-            if (!isEmpty(processor))  {
-                fetchDataGroup = () -> getByProcessor(processor, req);
-            } else if (!isEmpty(jsonSearchRequest)) {
-                fetchDataGroup = () -> getByTableRequest(jsonSearchRequest);
-            } else {
-                srcFile = getOrFetchSourceFile(req);
-            }
-            if (srcFile == null) {
-                return DbDataIngestor.ingestData(req, dbAdapter, makeDgSupplier(req, fetchDataGroup));
-            } else {
-                return DbDataIngestor.ingestData(req, dbAdapter, (dg) -> applyExtraMeta(dg, req), srcFile, tblIdx, format);
-            }
-        } catch (IOException e) {
-            Logger.getLogger().error(e,"Failed to ingest data into the database:" + req.getRequestId());
-            throw new DataAccessException(e);
-        }
-    }
-
-    /**
-     * This allows the processor to fetch data from a previously submitted job.
-     * @param req  the request to fetch data from
-     * @return the DataGroup containing the data
-     */
-    private File getOrFetchSourceFile(TableServerRequest req) throws DataAccessException {
-        File retval = null;
-        if (!isEmpty(req.getJobId())) {
-            // a previously submitted job; try to get from cache
-            List<JobInfo.Result> results = ifNotNull(JobManager.getJobInfo(req.getJobId()))
-                    .get(JobInfo::getResults);
-            if (results != null && !results.isEmpty()) {
-                String href = results.getFirst().href();
-                if (!isEmpty(href)) {
-                    retval = convertToFile(href);
-                }
-            }
-        }
-        if (retval == null || ! retval.canRead()) {       // if not found in cache, fetch from source
-            retval = fetchSourceFile(req);
-        }
-        return retval;
-    }
-
-    private File fetchSourceFile (TableServerRequest req) throws DataAccessException {
-
-        String source = req.getParam(ServerParams.SOURCE);
-        String altSource = req.getParam(ServerParams.ALT_SOURCE);
-        updateJob(ji -> ji.getAux().setJobUrl(source));
-
-        File inf = null;
-        if (isWorkspace(req)) {
-            // by workspace
-            inf = getFromWorkspace(source, altSource);
-        } else {
-            boolean isExternal = isExternalSource(source);
-            inf = QueryUtil.resolveFileFromSource(source, req);
-            if (inf == null) {
-                isExternal = isExternalSource(altSource);
-                inf = QueryUtil.resolveFileFromSource(altSource, req);
-            }
-            if (isExternal) req.setMeta(TableMeta.DATA_ORIGIN, "external");
-        }
-        if (inf == null) {
-            throw new DataAccessException(String.format("Unable to fetch file from path[alt_path]: %s[%s]", source, altSource));
-        }
-
-        setJobResults(inf);
-
-        return inf;
-    }
-
-    private boolean isExternalSource(String source) {
-        String sourceBase = getBaseDomain(source);
-        if (sourceBase == null) return false;
-        String hostBase = getBaseDomain(ServerContext.getRequestOwner().getBaseUrl());
-        boolean isExternal = !sourceBase.equals(hostBase);
-        if (isExternal) Logger.getLogger().trace("External source detected. sourceBase: " + sourceBase + " hostBase: " + hostBase);
-        return isExternal;
-    }
-
-    private static String getBaseDomain(String source) {
-        URI uri = Try.it(() -> new URI(source.toLowerCase())).get();
-        if (uri == null) return null;
-        String host = ifNotNull(uri.getHost()).getOrElse("");
-        String[] parts = host.split("\\.");
-        if (parts.length < 2) return host;
-        return parts[parts.length - 2] + "." + parts[parts.length - 1];
     }
 
 //====================================================================

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -59,6 +59,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -67,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.firefly.data.TableServerRequest.FF_SESSION_ID;
 import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_ID;
 import static edu.caltech.ipac.firefly.visualize.WebPlotRequest.URL_CHECK_FOR_NEWER;
@@ -150,10 +152,30 @@ public class QueryUtil {
     }
 
     public static File resolveFileFromSource(String source,TableServerRequest request) throws DataAccessException {
-        return resolveFileFromSource(source,
+        File rval = resolveFileFromSource(source,
                 request.getBooleanParam(URL_CHECK_FOR_NEWER, true),
                 tmpFileForUrl(source, request.getRequestId() + "_", QueryUtil.getTempDir(request))
         );
+        if (rval != null && isExternalSource(source)) request.setMeta(TableMeta.DATA_ORIGIN, "external");
+        return rval;
+    }
+
+    private static boolean isExternalSource(String source) {
+        String sourceBase = getBaseDomain(source);
+        if (sourceBase == null) return false;
+        String hostBase = getBaseDomain(ServerContext.getRequestOwner().getBaseUrl());
+        boolean isExternal = !sourceBase.equals(hostBase);
+        if (isExternal) Logger.getLogger().trace("External source detected. sourceBase: " + sourceBase + " hostBase: " + hostBase);
+        return isExternal;
+    }
+
+    private static String getBaseDomain(String source) {
+        URI uri = Util.Try.it(() -> new URI(source.toLowerCase())).get();
+        if (uri == null) return null;
+        String host = ifNotNull(uri.getHost()).getOrElse("");
+        String[] parts = host.split("\\.");
+        if (parts.length < 2) return host;
+        return parts[parts.length - 2] + "." + parts[parts.length - 1];
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/util/FormatUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/util/FormatUtil.java
@@ -78,7 +78,7 @@ public class FormatUtil {
      * @return A String representing the MIME type of the file, or "application/x-unknown" otherwise
      */
     public static DuckDbAdapter.MimeDesc getMimeType(File inFile) {
-        return DuckDbAdapter.getMimeType(inFile);
+        return DuckDbAdapter.getMimeType(inFile.getAbsolutePath());
     }
 
     /**
@@ -92,7 +92,7 @@ public class FormatUtil {
     public static Format detect(File inFile) throws IOException {
 
         Format format = null;
-        DuckDbAdapter.MimeDesc mimeDesc = DuckDbAdapter.getMimeType(inFile);
+        DuckDbAdapter.MimeDesc mimeDesc = DuckDbAdapter.getMimeType(inFile.getAbsolutePath());
         String mime = mimeDesc.mime();
         format = mapToFormat(mimeDesc.mime(), mimeDesc.desc());
         LOGGER.trace("detectFormat: " + inFile, "mime-type: " + mime, "description: " + mimeDesc.desc());

--- a/src/firefly/test/edu/caltech/ipac/table/IpacTableFromSourceTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/IpacTableFromSourceTest.java
@@ -41,14 +41,14 @@ public class IpacTableFromSourceTest extends ConfigTest {
             req.setParam(ServerParams.SOURCE, testFile.getAbsolutePath());
             req.setParam(TBL_INDEX, "0");
 
-            DataGroup results = new IpacTableFromSource().fetchDataGroup(req);
+            DataGroup results = new IpacTableFromSource().getData(req).getData();
             verifyTableData(results, null);
 
 
             // now load the 2nd table.  columns and table IDs are appended with "-1", but the data are the same
             // using same validation test.. but for 2nd table
             req.setParam(TBL_INDEX, "1");
-            results = new IpacTableFromSource().fetchDataGroup(req);
+            results = new IpacTableFromSource().getData(req).getData();
             verifyTableData(results, "-1");
         } catch (Exception e) {
             Assert.fail("IpacTableFromSourceTest.fromFileSystem failed with exception: " + e.getMessage());
@@ -61,13 +61,13 @@ public class IpacTableFromSourceTest extends ConfigTest {
             TableServerRequest req = new TableServerRequest(IpacTableFromSource.PROC_ID);
             req.setParam(ServerParams.SOURCE, "https://web.ipac.caltech.edu/staff/loi/demo/sample_multi_votable.xml");
 
-            DataGroup results = new IpacTableFromSource().fetchDataGroup(req);
+            DataGroup results = new IpacTableFromSource().getData(req).getData();
             verifyTableData(results, null);
 
             // now load the 2nd table.  columns and table IDs are appended with "-1", but the data are the same
             // using same validation test.. but for 2nd table
             req.setParam(TBL_INDEX, "1");
-            results = new IpacTableFromSource().fetchDataGroup(req);
+            results = new IpacTableFromSource().getData(req).getData();
             verifyTableData(results, "-1");
         } catch (Exception e) {
             Assert.fail("IpacTableFromSourceTest.fromUrl failed with exception: " + e.getMessage());
@@ -132,7 +132,7 @@ public class IpacTableFromSourceTest extends ConfigTest {
         suffix = suffix == null ? "" : suffix;
         // test table row and column count
         Assert.assertEquals("Number of rows:", 3, data.size());
-        Assert.assertEquals("Number of columns:", 6, data.getDataDefinitions().length);
+        Assert.assertEquals("Number of columns:", 8, data.getDataDefinitions().length);     // 6 + 2 index columns
 
         // test table's data
         Assert.assertEquals(10.68, data.get(0).getFloat("RA" + suffix, Float.MIN_VALUE), 0.00001);

--- a/src/firefly/test/edu/caltech/ipac/util/cache/CachePeerProviderFactoryTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/cache/CachePeerProviderFactoryTest.java
@@ -14,8 +14,11 @@ import net.sf.ehcache.Element;
 import net.sf.ehcache.distribution.CacheManagerPeerProvider;
 import net.sf.ehcache.distribution.CachePeer;
 import org.apache.logging.log4j.Level;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -33,6 +36,7 @@ import static org.junit.Assert.assertEquals;
  * @author loi
  * @version $Id: $
  */
+@Ignore("Not using ehcache peer replication anymore")
 public class CachePeerProviderFactoryTest extends ConfigTest {
 
     private static CacheManager peer1, peer2, peer3;
@@ -83,6 +87,7 @@ public class CachePeerProviderFactoryTest extends ConfigTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
+
 
         if (false) Logger.setLogLevel(Level.TRACE);			// for debugging.
         RedisService.init();


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1838
Also included in this PR:
- Fixed the issue with preinstalling DuckDB extensions not working
- Disabled CachePeerProviderFactoryTest

This change primarily needs regression testing.
The bug referenced in the ticket requires the JS API to load a web-accessible CSV file (attached in the ticket), which isn’t practical to reproduce within this PR. However, I tested the scenario locally.

