### PR TITLE
FIREFLY-1902: Radar and Gator are no longer showing SEDs

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/tables/IpacTableFromSource.java
@@ -97,7 +97,7 @@ public class IpacTableFromSource extends DbFromFileProcessor {
         nReq.setStartIndex(0);
         SearchProcessor<DataGroupPart> proc = SearchManager.getProcessor(processor);
         if (proc != null) {
-            return (proc instanceof CanFetchDataGroup) ? ((CanFetchDataGroup)proc).fetchDataGroup(nReq) : proc.getData(nReq).getData();
+            return proc.getData(nReq).getData();
         } else {
             throw new DataAccessException("Unable to find a suitable SearchProcessor for the given ID: " + processor);
         }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1902

Test: https://firefly-1902-radar-gator-failed-sed.irsakubedev.ipac.caltech.edu/frontpage/

Steps to reproduce taken from the ticket:
```
the NED SED pull fails. To reproduce:
1. search in Radar on M101
2. SED plot displays "Cannot display requested data: NED SED data Error"
3. SED table displays "Cause: DataAccessException Failed to retrieve data

the VizieR SED pull fails. To reproduce:
1. search in Radar on HD555
2. SED plot displays "Cannot display requested data: VizieR SED data Error"
3. SED table displays "Cause: DataAccessException Failed to retrieve data
```