### PR TITLE
FIREFLY-1899: Single column table viewer goes into infinite loop

### DIFF
--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -152,7 +152,7 @@ const BasicTableViewInternal = React.memo(({ selectable:selectableIn= false, sho
         const changes = {};
         if (!isEmpty(columns)){
             const calcWidth = width-15-( selectable ? 25 : 0);
-            if (isSingleColumnTable(columns) && (!columnWidths || columnWidths[0]!==calcWidth)) {
+            if (calcWidth > 0 && isSingleColumnTable(columns) && (columnWidths?.[0]!==calcWidth)) {
                 // set 1st (only visible) column's width to table's width minus scrollbar's width (15px)
                 changes.columnWidths = [calcWidth, ...Array(columns.length - 1).fill(0)];
             } else if(columnWidths?.length !== columns.length) {


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1899
- Table Viewer: Infinite loop when loading Roman's CONFIG extension

Test: https://fireflydev.ipac.caltech.edu/firefly-1899-table-loop-roman-table/firefly/
- Upload the file attached in the ticket.
- You should see the JSON string displayed across multiple rows, as shown in the screenshot in the ticket.

For comparison, the nightly build goes into an infinite loop and renders a blank page.