### PR TITLE
Firefly-1909: fixed: resizing extraction window causes hanging

### DIFF
--- a/src/firefly/js/charts/ui/PlotlyWrapper.jsx
+++ b/src/firefly/js/charts/ui/PlotlyWrapper.jsx
@@ -141,7 +141,7 @@ export class PlotlyWrapper extends Component {
                 if (!this.isUnmounted && this.state.showMask) {
                     this.setState(() => ({showMask:false}));
                 }
-            },0);
+            }, MASKING_DELAY);
         }
     }
 
@@ -174,7 +174,7 @@ export class PlotlyWrapper extends Component {
 
 
         const {data,layout, config, dataUpdate, layoutUpdate}= this.props;
-        const { maskOnLayout=true, maskOnRestyle=false, maskOnResize=true, maskOnNewPlot=true,
+        const { maskOnLayout=true, maskOnRestyle=false, maskOnResize=false, maskOnNewPlot=true,
                 autoSizePlot=false, doingResize=false, autoDetectResizing=false }= np;
 
         const treatAsResize= doingResize || (autoDetectResizing && detectedResize);
@@ -194,7 +194,12 @@ export class PlotlyWrapper extends Component {
                 this.updateRenderType(maskOnLayout, treatAsResize, RenderType.RELAYOUT);
             }
             else if (detectedResize && autoSizePlot) {
-                this.updateRenderType(maskOnResize, true, RenderType.RESIZE);
+                // there is a race condition that I don't understand, maybe the plotly update,
+                // this condition no longer seems to work especially on firefox,
+                // it also may be because of other changes to the file.
+                // it happens out of order and adds a permanent mask
+                // for now I am just commenting this out. probably detectedResize could be removed
+                //this.updateRenderType(maskOnResize, false, RenderType.RESIZE);
             }
             else { // in this case- the important props have not changed, therefore return on state (showMask) change
                    // everywhere else the props have changed so we return true


### PR DESCRIPTION
#### [Firefly-1909](https://jira.ipac.caltech.edu/browse/FIREFLY-1909): fixed: resizing extraction window causes hanging

- fix


#### Testing
- test according to ticket
- spherex: https://firefly-1909-ext-resize-mask.irsakubedev.ipac.caltech.edu/applications/spherex
- firefly: https://fireflydev.ipac.caltech.edu/firefly-1909-ext-resize-mask/firefly