### PR TITLE
FIREFLY-1916: Per-plane spectral coord display when WCSAXES != NAXIS

### DIFF
--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -992,7 +992,7 @@ export function getPtSpectralCoords(plot, pt, cubeIdx, band= Band.NO_BAND) {
     if (!plot?.wlDataAry?.[band.value] || !hasWLInfo(plot)) return [0,0];
     const ipt= CCUtil.getImageCoords(plot,pt);
     if (!ipt && plot?.wlData?.hasPixelLevelCoordInfo) return [0,0];
-    return getWavelength(ipt, cubeIdx, plot.wlDataAry[band.value]) ?? [0,0];
+    return getWavelength(ipt||makeImagePt(0,0), cubeIdx, plot.wlDataAry[band.value]) ?? [0,0];
 }
 
 //=============================================================

--- a/src/firefly/js/visualize/projection/Wavelength.js
+++ b/src/firefly/js/visualize/projection/Wavelength.js
@@ -735,20 +735,19 @@ function getPixelCoords(ipt, cubeIdx) {
  *  s_3: is a scaling factor given by CDELT3
  *  m3_j: is a linear transformation matrix given either by PC3_j or CD3_j
  *
- * @param pixCoords: pixel coordinates, normally this will be an array [imagePt.x,imagePt.y,plane]
+ * @param pixCoords pixel coordinates, normally this will be an array [imagePt.x,imagePt.y,plane]
  * @param {number} N
- * @param {Array.<number>} r_j: r j are pixel coordinates of the reference point given by CRPIX j
- * @param {Array.<number>} pc_3j: PC_3j matrix, if length=3 array and first two entries are 0,
+ * @param {Array.<number>} r_j r j are pixel coordinates of the reference point given by CRPIX j
+ * @param {Array.<number>} pc_3j PC_3j matrix, if length=3 array and first two entries are 0,
  * then probably all pixels on the plane have the same value
- * @param {Number} s_3: CDELT3 value
+ * @param {Number} s_3 CDELT3 value
  * @return number
  */
-
 function getOmega(pixCoords, N, r_j, pc_3j, s_3) {
     let omega = 0.0;
-    for (let i = 0; i < N; i++) {
+    // N is max(WCSAXES, NAXIS)
+    for (let i = 0; i < Math.min(pixCoords.length, N); i++) {
         omega += s_3 * pc_3j[i] * (pixCoords[i] - r_j[i]);
     }
     return omega;
 }
-

--- a/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
+++ b/src/firefly/js/visualize/projection/WavelengthHeaderParser.js
@@ -4,7 +4,7 @@
 
 import {makeDoubleHeaderParse} from '../FitsHeaderUtil.js';
 import {convertToArraySize} from '../../tables/TableUtil.js';
-import {algorithmTypes, spectralCoordTypes, LINEAR, TAB, WAVE, VRAD} from './Wavelength.js';  // eslint-disable-line no-unused-vars
+import {algorithmTypes, spectralCoordTypes, LINEAR, TAB, WAVE, VRAD} from './Wavelength.js';
 import {isDefined} from '../../util/WebUtil.js';
 import {Logger} from '../../util/Logger.js';
 
@@ -172,7 +172,7 @@ function isNonSeparableTABGroup(spectralCoords) {
     // all coordinates refer to the same table and output column
     const table = spectralCoords[0].tab.table;
     const ps3_1 = spectralCoords[0].tab.ps3_1.toUpperCase();
-    return spectralCoords.slice(1).every((c) => c.tab.table === table || c.tab.ps3_1.toUpperCase() === ps3_1);
+    return spectralCoords.slice(1).every((c) => c.tab.table === table && c.tab.ps3_1.toUpperCase() === ps3_1);
 }
 
 
@@ -183,8 +183,6 @@ function isNonSeparableTABGroup(spectralCoords) {
  * @returns {{nAxis: int, restWAV: number, r_j: Array.<int>, N: int}}
  */
 function calculateSharedParams(parse, altWcs) {
-
-    // todo should N be max(WCSAXESa, NAXIS)?
     // WCSAXES – [integer; default: NAXIS, or larger of WCS indices i
     // or j]. Number of axes in the WCS description. This keyword,
     // if present, must precede all WCS keywords except NAXIS in
@@ -193,9 +191,12 @@ function calculateSharedParams(parse, altWcs) {
     //
     // It is not recommended for WCSAXES to be smaller than NAXIS,
     // as this would imply that some of the data dimensions are not included in the WCS.
-    const N = parse.getIntOneOfValue(['WCSAXES', 'WCSAXIS', 'NAXIS'], -1);
+    const nAxisWCS = parse.getIntOneOfValue(['WCSAXES', 'WCSAXIS', 'NAXIS'], -1);  // WCS axes
 
-    const nAxis = parse.getIntValue('NAXIS');
+    const nAxis = parse.getIntValue('NAXIS');  // pixel axes
+
+    // N should be max(WCSAXESa, NAXIS)
+    const N = Math.max(nAxisWCS, nAxis);
 
     // reference pixel, CRPIXj default is 0.0
     let r_j = parse.getDoubleAry('CRPIX', altWcs, 1, N, undefined);


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1916
Test URL: https://fireflydev.ipac.caltech.edu/firefly-1916-wcsaxes/firefly

- Fixed bugs in the function that determines if the spectral coordinates are non-separable (should be calculated together).
- Bug fixes for the case when the number of WCS axes is different from the number of pixel axes.