### PR TITLE
FIREFLY-1854: Expose any data file upload functionality as an action dispatcher

### DIFF
--- a/src/firefly/js/api/webApiCommands/AnyFileLoadCommands.js
+++ b/src/firefly/js/api/webApiCommands/AnyFileLoadCommands.js
@@ -1,6 +1,5 @@
 import {makeExamples} from 'firefly/api/WebApi';
-import {EXTERNAL_UPLOAD} from '../../core/AppDataCntlr';
-import {flux} from '../../core/ReduxFlux';
+import {dispatchExternalUpload} from '../../core/AppDataCntlr';
 
 
 const anyFileOverview= {
@@ -39,7 +38,7 @@ function enableFileLoad(cmd,inParams) {
     const params= {...inParams};
     setTimeout(() => {
         const {url, execute=false}= params;
-        flux.process({type:EXTERNAL_UPLOAD, payload:{url, displayName:'some name', immediate:execute}});
+        dispatchExternalUpload({url, displayName:'some name', immediate:execute});
     },10);
 }
 

--- a/src/firefly/js/core/AppDataCntlr.js
+++ b/src/firefly/js/core/AppDataCntlr.js
@@ -195,6 +195,18 @@ export function dispatchFormCancel(payload) {
     flux.process({ type : FORM_CANCEL, payload});
 }
 
+/**
+ * Load any file that Firefly can recognize either from a url or a file already uploaded to the server.
+ * @param {object} payload
+ * @param {string} [payload.fileOnServer] the path of the file already uploaded to server (mutually exclusive with url)
+ * @param {string} [payload.url] the url of the remote file to load (mutually exclusive with fileOnServer)
+ * @param {string} [payload.displayName] the name to display for this file when loaded in the UI
+ * @param {boolean} [payload.immediate] whether to load the file immediately without displaying the metadata preview in "Upload" tab
+ */
+export function dispatchExternalUpload(payload) {
+    flux.process({ type : EXTERNAL_UPLOAD, payload});
+}
+
 /*---------------------------- EXPORTED FUNCTIONS -----------------------------*/
 
 


### PR DESCRIPTION
Fixes [FIREFLY-1854](https://jira.ipac.caltech.edu/browse/FIREFLY-1854)

See JL ext PR: https://github.com/Caltech-IPAC/jupyter_firefly_extensions/pull/40

This allows firefly JS API to invoke external upload action.

## Testing
Test `load` command examples in URL API: https://fireflydev.ipac.caltech.edu/firefly-1854-file-viewer/firefly/?api