### PR TITLE
FIREFLY-1634: Table toolbar needs to wrap when table is narrow

### DIFF
--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -317,13 +317,17 @@ function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
     if (!showToolbar) return null;
 
     return (
-        <Sheet component={Stack} variant='soft' className='FF-Table-Toolbar' direction='row' justifyContent='space-between' width={1} {...slotProps?.toolbar}>
-            <LeftToolBar {...{tbl_id, title, removable, showTitle, leftButtons}}/>
-            <Stack direction='row' spacing={1} alignItems='center'>
-                {showPaging && <PagingBar {...{currentPage, pageSize, showLoading, totalRows, callbacks:connector}} /> }
-                <OverflowMarker tbl_id={tbl_id}/>
+        <Sheet component={Stack} variant='soft' className='FF-Table-Toolbar' direction='row'
+               sx={{justifyContent:'space-between', flexWrap:'wrap', width:1}}
+               {...slotProps?.toolbar}>
+            <Stack direction='row' sx={{alignItems:'center', flexWrap:'wrap', flex:'1 1 0'}}>
+                <LeftToolBar {...{tbl_id, title, removable, showTitle, leftButtons}}/>
+                <Stack direction='row' spacing={1} sx={{flexGrow: 1, justifyContent:'center'}} >
+                    {showPaging && <PagingBar {...{currentPage, pageSize, showLoading, totalRows, callbacks:connector}} /> }
+                    <OverflowMarker tbl_id={tbl_id}/>
+                </Stack>
             </Stack>
-            <Stack direction='row' alignItems='center'>
+            <Stack direction='row' sx={{alignItems:'center', flex:'0 1 auto'}}>
                 {rightButtons}
                 {showSearchButton &&  isTableActionsDropVisible(searchActions,tbl_id ) &&
                 <ActionsDropDownButton {...{searchActions, tbl_id}} tip='Search drop down: search based on table'/>
@@ -365,7 +369,7 @@ function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
 }
 
 
-function LeftToolBar({tbl_id, title, removable, showTitle, leftButtons}) {
+function LeftToolBar({tbl_id, title, removable, showTitle, leftButtons=[]}) {
     const style = {display: 'inline-flex', alignItems: 'center'};
     const lbStyle = showTitle ? {...style, paddingLeft:10, alignSelf:'center'} : style;
 
@@ -383,15 +387,11 @@ function LeftToolBar({tbl_id, title, removable, showTitle, leftButtons}) {
                 <ToolbarHorizontalSeparator/>
             </Stack>
         );
-        if (leftButtons) {
-            leftButtons.push(doclink);
-        } else {
-            leftButtons = [doclink];
-        }
+        leftButtons.push(doclink);
     }
 
     return (
-        <Stack direction='row' style={style}>
+        <Stack direction='row' sx={{flexWrap:'wrap'}} >
             { showTitle && <Title {...{title, removable, tbl_id}}/>}
             {leftButtons && <Stack direction='row' spacing={1} style={lbStyle}>{leftButtons}</Stack>}
         </Stack>

--- a/src/firefly/js/ui/PagingBar.jsx
+++ b/src/firefly/js/ui/PagingBar.jsx
@@ -35,26 +35,30 @@ export function PagingBar(props) {
         return showingLabel;
     } else {
         return (
-            <Typography component='div' display='flex' alignItems='center' direction='row' level='body-sm' noWrap>
-                <ToolbarButton icon={<FirstPage/>} tip='First Page' onClick={() => callbacks.onGotoPage(1)}/>
-                <ToolbarButton icon={<NavigateBefore/>} tip='Previous Page' onClick={() => callbacks.onGotoPage(currentPage - 1)}/>
-                <Stack direction='row' alignItems='center' spacing={1/2}>
-                    <InputField
-                        slotProps={{ input: { size: 'sm', sx: {width:'3em'} } }}
-                        style={{textAlign: 'right', width: `${nchar+1}ch`}}
-                        validator = {intValidator(1, totalPages, 'Page Number')}
-                        tooltip = 'Jump to this page'
-                        value = {currentPage+''}
-                        onChange = {onPageChange}
-                        actOn={['blur','enter']}
-                        showWarning={false}
-                    /> <div> of {totalPages}</div>
+            <Stack direction='row' sx={{flexWrap:'wrap', alignItems:'center'}}>
+                <Stack direction='row'>
+                    <ToolbarButton icon={<FirstPage/>} tip='First Page' onClick={() => callbacks.onGotoPage(1)}/>
+                    <ToolbarButton icon={<NavigateBefore/>} tip='Previous Page' onClick={() => callbacks.onGotoPage(currentPage - 1)}/>
+                    <Stack direction='row' alignItems='center' spacing={1/2}>
+                        <InputField
+                            slotProps={{ input: { size: 'sm', sx: {width:'3em'} } }}
+                            style={{textAlign: 'right', width: `${nchar+1}ch`}}
+                            validator = {intValidator(1, totalPages, 'Page Number')}
+                            tooltip = 'Jump to this page'
+                            value = {currentPage+''}
+                            onChange = {onPageChange}
+                            actOn={['blur','enter']}
+                            showWarning={false}
+                        /> <Typography level='body-sm' noWrap={true}> of {totalPages}</Typography>
+                    </Stack>
+                    <ToolbarButton icon={<NavigateNext/>} tip='Next Page' onClick={() => callbacks.onGotoPage(currentPage + 1)}/>
+                    <ToolbarButton icon={<LastPage/>} tip='Last Page' onClick={() => callbacks.onGotoPage(totalPages)}/>
                 </Stack>
-                <ToolbarButton icon={<NavigateNext/>} tip='Next Page' onClick={() => callbacks.onGotoPage(currentPage + 1)}/>
-                <ToolbarButton icon={<LastPage/>} tip='Last Page' onClick={() => callbacks.onGotoPage(totalPages)}/>
-                {showingLabel}
-                {showLoading ? <img style={{width:14,height:14,marginTop: '3px'}} src={LOADING}/> : false}
-            </Typography>
+                <Typography level='body-sm'>
+                    {showingLabel}
+                    {showLoading ? <img style={{width:14,height:14,marginTop: '3px'}} src={LOADING}/> : false}
+                </Typography>
+            </Stack>
         );
     }
 }


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1634

The table toolbar now wraps into multiple sections, flowing from left to right.

**Note:** If the issue is related to the page’s minimum width, I can address that as well. It is currently set to 1000px.

**Test**: https://firefly-1634-table-toolbar-wrap.irsakubedev.ipac.caltech.edu/irsaviewer/dce
- Submit any query
- In the default tri-view layout, the table toolbar does not need to wrap.  It's limited by the page min-size.
- Switch to side-by-side layout mode:  [Table][coverage/images/charts] 
  - Menu(hamburger icon) -> Result Layout -> 5th option
- Use middle slider to shrink the table component and observe the toolbar toolbar wrapping behavior.

