### PR TITLE
Firefly-1921: support mask cubes

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
@@ -28,6 +28,7 @@ public class RelatedData implements Serializable, HasSizeOf {
     private Map<String,String> searchParams= new HashMap<>();
     private Map<String,String> availableMask= new HashMap<>();
     private int primaryHduIdx =0;
+    private boolean parallelCubePlane = false;
     private String hduName= null;
     private int hduVersion= 1;
     private int hduLevel= 1;
@@ -50,13 +51,13 @@ public class RelatedData implements Serializable, HasSizeOf {
      * @param dataKey - should be a unique string for a fits file
      * @return RelatedData
      */
-    public static RelatedData makeMaskRelatedData(int primaryHduIdx, String fileName, Map<String,String> availableMask, int extensionNumber, String dataKey) {
+    public static RelatedData makeMaskRelatedData(int primaryHduIdx, String fileName, Map<String,String> availableMask, boolean parallelCubePlane, int extensionNumber, String dataKey) {
         Map<String,String> searchParams= new HashMap<>();
         searchParams.put(WebPlotRequest.FILE, fileName);
         searchParams.put(WebPlotRequest.PLOT_AS_MASK, "true");
         searchParams.put(WebPlotRequest.TYPE, RequestType.FILE+"");
-        searchParams.put(WebPlotRequest.MULTI_IMAGE_IDX, extensionNumber+"");
-        return makeMaskRelatedData(primaryHduIdx, searchParams, availableMask, dataKey);
+        searchParams.put(WebPlotRequest.MULTI_IMAGE_EXTS, extensionNumber+"");
+        return makeMaskRelatedData(primaryHduIdx, searchParams, availableMask, parallelCubePlane, dataKey);
     }
 
     /**
@@ -66,11 +67,12 @@ public class RelatedData implements Serializable, HasSizeOf {
      * @param dataKey - should be a unique string for a fits file
      * @return RelatedData
      */
-    public static RelatedData makeMaskRelatedData(int primaryHduIdx, Map<String,String> searchParams, Map<String,String> availableMask, String dataKey) {
+    public static RelatedData makeMaskRelatedData(int primaryHduIdx, Map<String,String> searchParams, Map<String,String> availableMask, boolean parallelCubePlane, String dataKey) {
         RelatedData d= new RelatedData(IMAGE_MASK, dataKey, "Mask");
         d.availableMask= availableMask;
         d.searchParams= searchParams;
         d.primaryHduIdx = primaryHduIdx;
+        d.parallelCubePlane = parallelCubePlane;
         return d;
     }
 
@@ -154,5 +156,6 @@ public class RelatedData implements Serializable, HasSizeOf {
     public int getHduLevel() {return hduLevel;}
     public int getHduIdx() { return hduIdx;}
     public int getPrimaryHduIdx() { return primaryHduIdx;}
+    public boolean isParallelCubePlane() { return parallelCubePlane;}
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
@@ -295,6 +295,7 @@ public class VisJsonSerializer {
         putStr(retObj, "band", band.toString().toUpperCase());
         putStr(retObj, "dataKey", rData.getDataKey());
         putStrNotNull(retObj, "hduName", rData.getHduName());
+        putBoolIfTrue(retObj, "parallelCubePlane", rData.isParallelCubePlane());
         if (rData.getHduIdx()>-1) {
             putNum(retObj, "hduIdx", rData.getHduIdx());
             putNum(retObj, "hduVersion", rData.getHduVersion());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/MaskEval.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/MaskEval.java
@@ -3,16 +3,11 @@
  */
 
 package edu.caltech.ipac.firefly.server.visualize.fitseval;
-/**
- * User: roby
- * Date: 7/13/18
- * Time: 10:39 AM
- */
-
 
 import edu.caltech.ipac.firefly.data.RelatedData;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
 import edu.caltech.ipac.visualize.plot.plotdata.FitsRead;
+import edu.caltech.ipac.visualize.plot.plotdata.FitsReadUtil;
 import nom.tam.fits.BasicHDU;
 import nom.tam.fits.Header;
 import nom.tam.fits.HeaderCard;
@@ -20,6 +15,7 @@ import nom.tam.util.Cursor;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +24,9 @@ import java.util.Map;
  * @author Trey Roby
  */
 class MaskEval implements FitsEvaluation.Eval {
+
+    private final List<String> imageNames= Arrays.asList("IMAGE", "FLUX");
+    private final List<String> maskNames= Arrays.asList("MASK", "FLAGS");
     /**
      * This method attempts to find how data might be related in a multi-extension fits file. I expect it will grow
      * and become more advanced over time.
@@ -38,19 +37,22 @@ class MaskEval implements FitsEvaluation.Eval {
      * @param frAry the array of FitsRead objects that came from the file.
      * @return the data relations
      */
-    public List<RelatedData> evaluate(File f, FitsRead[] frAry, BasicHDU[] HDUs, int fitsReadIndex, int hduIndex, WebPlotRequest req) {
+    public List<RelatedData> evaluate(File f, FitsRead[] frAry, BasicHDU<?>[] HDUs, int fitsReadIndex, int hduIndex, WebPlotRequest req) {
         if (HDUs.length<2) return null;
-        String extType = frAry[fitsReadIndex].getExtType();
-        if (extType.equalsIgnoreCase("IMAGE")) {
+        Header h = frAry[fitsReadIndex].getHeader();
+        String extType = FitsReadUtil.getExtTypeOrName(h);
+        extType= extType==null ? "" : extType.toUpperCase();
+
+        if (imageNames.contains(extType)) {
             FitsRead baseFr= frAry[fitsReadIndex];
             List<RelatedData> relatedList = new ArrayList<>();
             for (int i = 0; (i < frAry.length); i++) {
                 if (i != fitsReadIndex) {
-                    if (isMask(frAry[i], baseFr.getNaxis1(), baseFr.getNaxis2())) {
+                    if (isMask(frAry[i], baseFr)) {
                         RelatedData d = RelatedData.makeMaskRelatedData(
-                                baseFr.getHduNumber(),
-                                f.getAbsolutePath(),
-                                getMaskHeaders(frAry[i].getHeader()), i, "mask");
+                                baseFr.getHduNumber(), f.getAbsolutePath(),
+                                getMaskHeaders(frAry[i].getHeader()),
+                                frAry[i].isCube(), frAry[i].getHduNumber(), "mask");
                         relatedList.add(d);
                     }
                     if (isVariance(frAry[i])) {
@@ -60,7 +62,7 @@ class MaskEval implements FitsEvaluation.Eval {
                     }
                 }
             }
-            return relatedList.size() > 0 ? relatedList : null;
+            return !relatedList.isEmpty() ? relatedList : null;
         } else {
             return null;
         }
@@ -69,9 +71,9 @@ class MaskEval implements FitsEvaluation.Eval {
     private static Map<String, String> getMaskHeaders(Header header) {
         Map<String, String> maskHeaders = new HashMap<>(23);
         HeaderCard hc;
-        Cursor extraIter = header.iterator();
-        for (; extraIter.hasNext(); ) {
-            hc = (HeaderCard) extraIter.next();
+        Cursor<String, HeaderCard> extraIter = header.iterator();
+        while (extraIter.hasNext()) {
+            hc = extraIter.next();
             if (hc.getKey().startsWith("MP") || hc.getKey().startsWith("HIERARCH.MP")) {
                 maskHeaders.put(hc.getKey(), hc.getValue());
             }
@@ -79,9 +81,16 @@ class MaskEval implements FitsEvaluation.Eval {
         return maskHeaders;
     }
 
-    public boolean isMask(FitsRead fr, int naxis1, int naxis2) {
-        if (fr.isCube() && fr.getPlaneNumber()>0) return false;
-        return (fr.getNaxis1()==naxis1 && fr.getNaxis2()==naxis2 && fr.getExtType().equalsIgnoreCase("MASK"));
+     public boolean isMask(FitsRead maskFr, FitsRead baseFr) {
+        boolean isCube= baseFr.isCube();
+        int cubePlaneNumber=  baseFr.getPlaneNumber();
+        if (!isCube && maskFr.isCube() && maskFr.getPlaneNumber()>0) return false;
+        if (maskFr.getNaxis1()!=baseFr.getNaxis1() || maskFr.getNaxis2()!=baseFr.getNaxis2()) return false;
+        var extType= FitsReadUtil.getExtTypeOrName(maskFr.getHeader());
+        extType= extType==null ? "" : extType.toUpperCase();
+        if (!maskNames.contains(extType)) return false;
+        if (!maskFr.isCube()) return true;
+        return (maskFr.getNaxis3()==baseFr.getNaxis3() && cubePlaneNumber==maskFr.getPlaneNumber());
     }
 
     public boolean isVariance(FitsRead fr) {

--- a/src/firefly/js/threadWorker/WorkerAccess.js
+++ b/src/firefly/js/threadWorker/WorkerAccess.js
@@ -98,7 +98,7 @@ export function getNextWorkerKey() {
 
 
 export function removeWorker(workerKey) {
-    void postToWorker( { type: RawDataThreadActions.CLOSE_WHEN_IDLE, workerKey, payload:{workerKey}});
+    void postToWorker( { type: RawDataThreadActions.CLOSE_WHEN_IDLE, workerKey, callKey:'', payload:{workerKey}});
     workerMap.delete(workerKey);
 }
 

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -798,7 +798,7 @@ export function dispatchChangeHiPS({ plotId, hipsUrlRoot, coordSys, centerProjPt
  * @param {number} p.maskValue power of 2, e.g 4, 8, 32, 128, etc
  * @param {number} p.maskNumber 2, e.g 4, 8, 32, 128, etc
  * @param {string} p.imageOverlayId
- * @param {number} p.imageNumber hdu number of fits
+ * @param {number} p.hduNumber hdu number of fits
  * @param {string} p.fileKey file on the server
  * @param {string} p.color - color is optional, if not specified, one is chosen
  * @param {string} p.title
@@ -812,12 +812,12 @@ export function dispatchChangeHiPS({ plotId, hipsUrlRoot, coordSys, centerProjPt
  * @memberof firefly.action
  */
 export function dispatchPlotMask({plotId,imageOverlayId, maskValue, fileKey,
-                                  imageNumber, maskNumber=-1, color, title,
+                                  hduNumber, maskNumber=-1, color, title,
                                   uiCanAugmentTitle,
                                   relatedDataId, lazyLoad, dispatcher= flux.process}) {
 
     dispatcher( { type: PLOT_MASK, payload: { plotId,imageOverlayId, fileKey, maskValue,
-                                              uiCanAugmentTitle, imageNumber, maskNumber,
+                                              uiCanAugmentTitle, hduNumber, maskNumber,
                                               color, title, relatedDataId, lazyLoad } });
 }
 

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -127,7 +127,7 @@ export function getPlotViewIdListByPositionLock(visRoot, pvOrId) {
         .filter( (id) => getPlotViewById(visRoot,id)?.plots?.length );
 }
 /**
- * Return an array of plotId's that are in the plot group associated with the the pvOrId parameter.
+ * Return an array of plotId's that are in the plot group associated with the pvOrId parameter.
  * @param {VisRoot} visRoot - root of the visualization object in store
  * @param pvOrId this parameter will take the plotId string or a plotView objects
  * @returns {Array.<String>}
@@ -229,7 +229,9 @@ export const getOverlayByPvAndId = (ref,plotId,imageOverlayId) =>
 
 export function removeRawDataByPlotView(pv) {
     pv?.plots.forEach( (p) => removeRawData(p.plotImageId));
-    pv?.overlayPlotViews?.forEach( (oPv) => oPv?.plot?.plotImageId && removeRawData(oPv.plot.plotImageId) );
+    pv?.overlayPlotViews?.forEach( (opv) => {
+        opv.plots.forEach( (p) => p?.plotImageId && removeRawData(p.plotImageId) );
+    } );
 }
 
 /**

--- a/src/firefly/js/visualize/RelatedDataUtil.js
+++ b/src/firefly/js/visualize/RelatedDataUtil.js
@@ -161,7 +161,7 @@ function enableRelatedDataLayerMaskInGroup(vr, pv,relatedData) {
 
 
 function enableRelatedDataLayerMask(pv, relatedData) {
-    const imageNumber= relatedData.searchParams[WPConst.MULTI_IMAGE_IDX];
+    const hduNumber= relatedData.searchParams[WPConst.MULTI_IMAGE_EXTS];
     const fileKey= relatedData.searchParams[WPConst.FILE];
 
 
@@ -171,7 +171,7 @@ function enableRelatedDataLayerMask(pv, relatedData) {
         .sort( (v1,v2) => v1-v2)
         .forEach(  (v) =>
             {
-                addMaskLayer(pv, v, imageNumber, fileKey, relatedData);
+                addMaskLayer(pv, v, hduNumber, fileKey, relatedData);
             }
         );
 
@@ -181,7 +181,7 @@ function enableRelatedDataLayerMask(pv, relatedData) {
 const maskIdRoot= 'AUTO_LOADED_MASK';
 let maskCnt= 0;
 
-function addMaskLayer(pv, maskNumber, imageNumber, fileKey, relatedData) {
+function addMaskLayer(pv, maskNumber, hduNumber, fileKey, relatedData) {
 
     const {relatedDataId}= relatedData;
 
@@ -190,7 +190,7 @@ function addMaskLayer(pv, maskNumber, imageNumber, fileKey, relatedData) {
     dispatchPlotMask({plotId:pv.plotId,
         imageOverlayId:`${pv.plotId}-${maskIdRoot}_#${maskNumber}_${maskCnt}`,
         fileKey, maskNumber, maskValue:Math.pow(2,Number(maskNumber)),
-        uiCanAugmentTitle:false, imageNumber, title,
+        uiCanAugmentTitle:false, hduNumber, title,
         relatedDataId, lazyLoad:true});
     maskCnt++;
 }

--- a/src/firefly/js/visualize/rawData/RawDataCache.js
+++ b/src/firefly/js/visualize/rawData/RawDataCache.js
@@ -46,10 +46,11 @@ export const {addRawDataToCache, getEntry, removeRawData,addLoadingPromise, mark
     };
 
     const removeRawData= (plotImageId) => {
-        const entry= getEntry(plotImageId);
+        const entry= getEntry(plotImageId,false);
+        if (!entry) return;
         rawDataStore= rawDataStore.filter( (s) => s.plotImageId!==plotImageId);
         if (entry.initialized) {
-            const action= {type:RawDataThreadActions.REMOVE_RAW_DATA, workerKey:entry.workerKey, payload:{plotImageId}};
+            const action= {type:RawDataThreadActions.REMOVE_RAW_DATA, workerKey:entry.workerKey, callKey:'', payload:{plotImageId}};
             postToWorker(action).then(({entryCnt}) => {
                 if (entryCnt===0) removeWorker(entry.workerKey);
             });

--- a/src/firefly/js/visualize/rawData/RawDataOps.js
+++ b/src/firefly/js/visualize/rawData/RawDataOps.js
@@ -4,7 +4,7 @@ import BrowserInfo from '../../util/BrowserInfo';
 import {Band} from '../Band.js';
 import {PlotAttribute} from '../PlotAttribute';
 import {
-    findPlot, getOverlayById, getPlotViewById, isThreeColor, primePlot
+    findPlot, getOverlayById, getPlotViewById, hasLocalStretchByteData, isThreeColor, primePlot
 } from '../PlotViewUtil.js';
 import {MEG} from '../../util/WebUtil.js';
 import ImagePlotCntlr, {
@@ -155,7 +155,6 @@ export async function changeLocalRawDataColor(obj) {
     });
     colorChangeDonePromises.set(plotImageId, donePromise);
 
-    //todo makeColorAction
     try {
         if (shouldUseGpuInWorker()) {
             const colorResult= await postToWorker(makeColorAction({...obj, workerKey:entry.workerKey}));
@@ -221,14 +220,20 @@ export function colorTableMatches(plot) {
     return true;
 }
 
+export async function changeLocalMaskColorOnOverlayPlotView(opv, maskColor) {
+
+    const promiseAry= opv.plots
+        .filter( (p) => hasLocalStretchByteData(p))
+        .map( (p) => changeLocalMaskColor(p,maskColor) );
+    return Promise.all(promiseAry);
+}
 
 
-export async function changeLocalMaskColor(plot, maskColor) {
+async function changeLocalMaskColor(plot, maskColor) {
     const entry = getEntry(plot.plotImageId);
     if (!entry.initialized) return;
     const newPlotState = plot.plotState.copy();
     const {workerKey} = entry;
-    // entry.rawTileDataGroup = await populateTilesAsync({rawTileDataGroup:entry.rawTileDataGroup, mask:true, maskColor});
     const result= await postToWorker(makeMaskColorAction({plot,maskColor,workerKey}));
     const rawTileDataGroup= result.rawTileDataGroup;
     entry.rawTileDataGroup = await populateTilesAsync({rawTileDataGroup, make:true, maskColor});

--- a/src/firefly/js/visualize/reducer/HandlePlotChange.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotChange.js
@@ -29,7 +29,8 @@ import {
     primePlot, clonePvAry, clonePvAryWithPv, applyToOnePvOrAll, applyToOnePvOrOverlayGroup,
     matchPlotViewByPositionGroup, getPlotViewIdxById, getPlotGroupIdxById, findPlotGroup,
     getPlotViewById, findCurrentCenterPoint, getCenterOfProjection,
-    isRotationMatching, hasWCSProjection, isThreeColor, getHDU, getMatchingRotationAngle
+    isRotationMatching, hasWCSProjection, isThreeColor, getHDU, getMatchingRotationAngle, isImageCube,
+    convertImageIdxToHDU
 } from '../PlotViewUtil.js';
 import Point, {parseAnyPt, makeImagePt, makeWorldPt, makeDevicePt} from '../Point.js';
 import {UserZoomTypes} from '../ZoomUtil.js';
@@ -713,9 +714,17 @@ function recenterPv(centerPt,  centerOnImage, updateFixedTarget= false) {
 
 function makeNewPrimePlot(state,action) {
     const {plotId,primeIdx}= action.payload;
-    let pv=  getPlotViewById(state,plotId);
-    if (!pv || isEmpty(pv.plots) || pv.plots.length<=primeIdx) return state;
-    pv= changePrimePlot(pv, primeIdx);
+    const existingPv=  getPlotViewById(state,plotId);
+    if (!existingPv || isEmpty(existingPv.plots) || existingPv.plots.length<=primeIdx) return state;
+    const pv= changePrimePlot(existingPv, primeIdx);
+
+    if (isImageCube(primePlot(pv))) {
+        const primeIdx= convertImageIdxToHDU(pv,pv.primeIdx).cubeIdx;
+        pv.overlayPlotViews= pv.overlayPlotViews.map( (oPv) => {
+            if (!oPv.cube || !oPv.plot || !oPv.plots.length) return oPv;
+            return {...oPv,plot:oPv.plots[primeIdx], primeIdx};
+        });
+    }
     return {...state, plotViewAry:clonePvAryWithPv(state,pv)};
 }
 
@@ -808,9 +817,10 @@ function requestLocalData(state, action) {
     let updatedPv;
     if (imageOverlayId) {
         const overlayPlotViews= pv.overlayPlotViews.map( (oPv) => {
-            if (oPv?.plot?.plotImageId!==plotImageId) return oPv;
-            oPv.plot= {...oPv.plot,dataRequested};
-            return oPv;
+            const plots= oPv.plots.map( (p) =>
+                p.plotImageId!==plotImageId ? p : {...p,dataRequested}
+            );
+            return {...oPv, plots, plot:plots[oPv.primeIdx]};
         });
         updatedPv= {...pv, overlayPlotViews};
     }

--- a/src/firefly/js/visualize/reducer/HandlePlotCreation.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotCreation.js
@@ -9,7 +9,7 @@ import {
     replacePlots, makePlotView, updatePlotViewScrollXY,
     findScrollPtToCenterImagePt, updateScrollToWcsMatch, initScrollCenterPoint
 } from './PlotView.js';
-import {makeOverlayPlotView, replaceOverlayPlots} from './OverlayPlotView.js';
+import {makeOverlayPlotView, initOverlayPlots} from './OverlayPlotView.js';
 import {
     primePlot, getPlotViewById, clonePvAry, getOverlayById, getPlotViewIdListByPositionLock,
     getCubePlaneCnt, getHDU, getImageCubeIdx, } from '../PlotViewUtil.js'; import {getPlotGroupById, makePlotGroup} from '../PlotGroup.js';
@@ -250,7 +250,7 @@ function updateForWcsMatching(visRoot, pv, mpwWcsPrimId) {
 
 
 function newOverlayPrep(state, action) {
-    const {plotId, imageOverlayId, imageNumber, maskValue, maskNumber,
+    const {plotId, imageOverlayId, hduNumber, maskValue, maskNumber,
            color, title, drawingDef, relatedDataId,lazyLoadPayload, fileKey}= action.payload;
 
     const pv= getPlotViewById(state, plotId);
@@ -261,7 +261,7 @@ function newOverlayPrep(state, action) {
     let opv;
     if (!overlayPv) {
         oPvArray= isEmpty(pv.overlayPlotViews) ? [] : pv.overlayPlotViews.slice(0);
-        opv= makeOverlayPlotView(imageOverlayId, plotId, title, imageNumber,
+        opv= makeOverlayPlotView(imageOverlayId, plotId, title, hduNumber,
                                            maskNumber, maskValue, color, drawingDef, relatedDataId,
                                            fileKey);
         if (lazyLoadPayload) {
@@ -272,7 +272,7 @@ function newOverlayPrep(state, action) {
     }
     else {
         oPvArray= pv.overlayPlotViews.map( (opv) => opv.imageOverlayId===imageOverlayId ?
-                             {...overlayPv, imageNumber, maskValue, color, drawingDef, plot:null} : opv);
+                             {...overlayPv, imageNumber:hduNumber, maskValue, color, drawingDef, plot:null} : opv);
     }
 
     return {...state, plotViewAry:clonePvAry(state, plotId, {overlayPlotViews:oPvArray})};
@@ -280,13 +280,14 @@ function newOverlayPrep(state, action) {
 
 
 function addOverlay(state, action) {
-    const {plotId, imageOverlayId, plot}= action.payload;
+    const {plotId, imageOverlayId, cube=false, primeIdx=-1}= action.payload;
 
     const plotViewAry= state.plotViewAry.map( (pv) => {
         if (pv.plotId!== plotId) return pv;
         const overlayPlotViews= pv.overlayPlotViews.map( (opv) => {
             if (opv.imageOverlayId!== imageOverlayId) return opv;
-            return replaceOverlayPlots(opv,{...plot, affTrans:pv.affTrans});
+            const plots= action.payload.plots.map( (p) => ({...p,affTrans:pv.affTrans}));
+            return initOverlayPlots({...opv,cube, plots, primeIdx});
         });
         return {...pv, overlayPlotViews};
     });

--- a/src/firefly/js/visualize/reducer/OverlayPlotView.js
+++ b/src/firefly/js/visualize/reducer/OverlayPlotView.js
@@ -2,7 +2,6 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {clone} from '../../util/WebUtil.js';
 import {RDConst} from '../WebPlot.js';
 
 /**
@@ -25,7 +24,7 @@ import {RDConst} from '../WebPlot.js';
  * @param imageOverlayId
  * @param plotId plot id of image that is overlayed
  * @param {String} title
- * @param imageNumber
+ * @param hduNumber
  * @param maskNumber
  * @param maskValue
  * @param {string} color the color, if overlay is a mask
@@ -34,22 +33,24 @@ import {RDConst} from '../WebPlot.js';
  * @param {string} [fileKey] a file on the server
  * @return {OverlayPlotView}
  */
-export function makeOverlayPlotView(imageOverlayId, plotId, title, imageNumber, maskNumber,
+export function makeOverlayPlotView(imageOverlayId, plotId, title, hduNumber, maskNumber,
                                     maskValue, color, drawingDef, relatedDataId, fileKey) {
 
-    var opv= {
-        imageOverlayId,
+    const opv= {
+        imageOverlayId, // id of the overlay plot view analogous to plotId
         opvType: RDConst.IMAGE_MASK,
-        plotId,
+        plotId, // plotId of the base plot
         title,
         plot: null,
-        drawingDef,
+        primeIdx: 0,
+        plots: [],
+        cube: false,
         makeOverlay : true,
         visible: true,
         wasVisibleWhenReplace: false,
         maskNumber,
         maskValue,
-        imageNumber,
+        imageNumber:hduNumber,
         colorAttributes : {color, srcImageColor: color},
         relatedDataId,
         opacity: .58,
@@ -62,13 +63,18 @@ export function makeOverlayPlotView(imageOverlayId, plotId, title, imageNumber, 
     return opv;
 }
 
-export function replaceOverlayPlots(opv, plot) {
+export function initOverlayPlots(opv) {
 
-    opv= clone(opv, {plot});
-    plot.plotImageId= `${opv.imageOverlayId}--${opv.plotCounter}`;
-    opv.plotCounter++;
+    opv= {...opv};
+    opv.plots.forEach( (plot) => {
+        plot.plotImageId=
+            opv.cube
+                ? `${opv.imageOverlayId}---plane-${plot.cubeCtx.cubePlane}---${opv.plotCounter}`
+                : `${opv.imageOverlayId}--${opv.plotCounter}`;
+        opv.plotCounter++;
+    } );
+    opv.plot= opv.plots[opv.primeIdx];
     opv.visible= true;
-
     opv.plottingStatusMsg='';
     opv.serverCall='success';
 

--- a/src/firefly/js/visualize/reducer/PlotView.js
+++ b/src/firefly/js/visualize/reducer/PlotView.js
@@ -153,12 +153,12 @@ export function makePlotView(plotId, req, pvOptions= {}) {
 
 /**
  *
- * @param {WebPlotRequest} req
- * @param {PVCreateOptions} pvOptions
+ * @param {WebPlotRequest} [req]
+ * @param {PVCreateOptions} [pvOptions]
  * @return {PlotViewContextData}
  */
-function createPlotViewContextData(req, pvOptions={}) {
-    const attributes= req.getAttributes();
+export function createPlotViewContextData(req=undefined, pvOptions={}) {
+    const attributes= req?.getAttributes() ?? {};
     const plotViewCtx= {
         menuItemKeys: {...getDefMenuItemKeys(), ...pvOptions.menuItemKeys},
         userCanDeletePlots: pvOptions?.userCanDeletePlots ?? true,

--- a/src/firefly/js/visualize/task/ImageOverlayTask.js
+++ b/src/firefly/js/visualize/task/ImageOverlayTask.js
@@ -2,24 +2,22 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 import {logger} from '../../util/Logger.js';
-import ImagePlotCntlr, {makeUniqueRequestKey, IMAGE_PLOT_KEY, dispatchPlotMaskLazyLoad} from '../ImagePlotCntlr.js';
-import {
-    primePlot,
-    getOverlayByPvAndId,
-    getPlotViewById,
+import ImagePlotCntlr, {
+    makeUniqueRequestKey, IMAGE_PLOT_KEY, dispatchPlotMaskLazyLoad, visRoot
+} from '../ImagePlotCntlr.js';
+import { primePlot, getOverlayByPvAndId, getPlotViewById,
     getOverlayById,
-    hasLocalStretchByteData,
+    convertImageIdxToHDU,
 } from '../PlotViewUtil.js';
 import {PlotState} from '../PlotState.js';
 import {RequestType} from '../RequestType.js';
 import {ZoomType} from '../ZoomType.js';
-import {clone} from '../../util/WebUtil.js';
 import {WebPlot} from '../WebPlot.js';
 import {callGetWebPlot} from '../../rpc/PlotServicesJson.js';
 import {dispatchAddActionWatcher} from '../../core/MasterSaga';
 import {isPlotIdInPvNewPlotInfoAry} from '../PlotViewUtil';
-import {changeLocalMaskColor} from 'firefly/visualize/rawData/RawDataOps.js';
-import {populateFromHeader} from 'firefly/visualize/task/CreateTaskUtil.js';
+import {changeLocalMaskColorOnOverlayPlotView} from 'firefly/visualize/rawData/RawDataOps.js';
+import {makeCubeCtxAry, populateFromHeader} from 'firefly/visualize/task/CreateTaskUtil.js';
 
 const colorList= [
     '#FF0000','#00FF00', '#0000FF', '#91D33D',
@@ -49,19 +47,19 @@ export function plotImageMaskActionCreator(rawAction) {
     return (dispatcher,getStore) => {
         var vr= getStore()[IMAGE_PLOT_KEY];
 
-        const {plotId,imageOverlayId, maskValue, imageNumber, title,fileKey,
+        const {plotId, imageOverlayId, maskValue, hduNumber, title, fileKey,
                uiCanAugmentTitle= true, maskNumber, relatedDataId, lazyLoad}= rawAction.payload;
         let {color}= rawAction.payload;
         if (!color) color= colorList[maskNumber % colorList.length];
 
 
 
-        var payload= {
+        const payload= {
             fileKey,
             plotId,
             maskValue,
             maskNumber,
-            imageNumber,
+            hduNumber,
             color,
             title,
             imageOverlayId,
@@ -92,7 +90,7 @@ export function plotImageMaskActionCreator(rawAction) {
             }
 
             if (!lazyLoad && plot) {
-                maskCall(vr, dispatcher,payload, color);
+                void maskCall(vr, dispatcher,payload);
             }
         }
     };
@@ -115,7 +113,7 @@ export function plotImageMaskLazyActionCreator(rawAction) {
             fileKey:opv.fileKey,
         };
 
-        maskCall(vr, dispatcher,data);
+        void maskCall(vr, dispatcher,data);
     };
 }
 
@@ -125,15 +123,16 @@ export function plotImageMaskLazyActionCreator(rawAction) {
  * @param dispatcher
  * @param payload
  */
-function maskCall(vr, dispatcher, payload) {
-    const {plotId,imageOverlayId, maskValue, imageNumber, fileKey, color}= payload;
-    const pv= getPlotViewById(vr, plotId);
-    const maskRequest= makeMaskRequest(fileKey,imageOverlayId ,pv,maskValue,imageNumber, color);
-
-    callGetWebPlot(maskRequest).then( (wpResult) => processMaskSuccessResponse(dispatcher,payload,wpResult) )
-        .catch ( (e) => {
-            logger.error(`plot mask error, plotId: ${payload.plotId}`, e);
-        });
+async function maskCall(vr, dispatcher, payload) {
+    try {
+        const {plotId,imageOverlayId, maskValue, imageNumber, fileKey}= payload;
+        const pv= getPlotViewById(vr, plotId);
+        const maskRequest= makeMaskRequest(fileKey,imageOverlayId, pv,maskValue,imageNumber);
+        const wpResult= await callGetWebPlot(maskRequest);
+        processMaskSuccessResponse(dispatcher,payload,wpResult);
+    } catch (e) {
+        logger.error(`plot mask error, plotId: ${payload.plotId}`, e);
+    }
 }
 
 export function overlayPlotChangeAttributeActionCreator(rawAction) {
@@ -146,17 +145,15 @@ export function overlayPlotChangeAttributeActionCreator(rawAction) {
             const opv= getOverlayByPvAndId(vr,plotId, imageOverlayId);
             if (opv)  {
                 const {color}= rawAction.payload.attributes.colorAttributes;
-                if (opv.colorAttributes.color!==color && hasLocalStretchByteData(opv.plot)) {
+                if (opv.colorAttributes.color!==color) {
                     dispatchHandled= true;
-                    changeLocalMaskColor(opv.plot,color)
+                    changeLocalMaskColorOnOverlayPlotView(opv,color)
                         .then( () => dispatcher(rawAction) );
                 }
             }
         }
 
        !dispatchHandled && dispatcher(rawAction);
-        
-        // note - rawAction.payload.doReplot - is deprecated
     };
 }
 
@@ -167,15 +164,14 @@ export function overlayPlotChangeAttributeActionCreator(rawAction) {
  * @param imageOverlayId
  * @param pv
  * @param maskValue
- * @param imageNumber
- * @param color
+ * @param hduNumber
  * @return {*}
  */
-function makeMaskRequest(fileKey, imageOverlayId, pv, maskValue, imageNumber, color) {
+function makeMaskRequest(fileKey, imageOverlayId, pv, maskValue, hduNumber) {
     const plot= primePlot(pv);
     const state= plot ? plot.plotState : null;
 
-    var originalRequest= state ? state.getWebPlotRequest(): pv.request;
+    const originalRequest= state ? state.getWebPlotRequest(): pv.request;
 
     const r= originalRequest.makeCopy();
     if (fileKey) {
@@ -186,7 +182,7 @@ function makeMaskRequest(fileKey, imageOverlayId, pv, maskValue, imageNumber, co
     r.setMaskBits(maskValue);
     r.setPlotId(imageOverlayId);
     r.setPlotAsMask(true);
-    r.setMultiImageIdx(imageNumber);
+    r.setMultiImageExts(hduNumber);
 
     //TODO check flip and set handle flip case
     if (state) {
@@ -203,13 +199,24 @@ function processMaskSuccessResponse(dispatcher, payload, result) {
     if (result.success) {
         const {PlotCreate, PlotCreateHeader}= result;
         populateFromHeader(PlotCreateHeader, PlotCreate);
+        const cubeCtx= makeCubeCtxAry(PlotCreate);
 
         const plotState= PlotState.makePlotStateWithJson(PlotCreate[0].plotState);
         const imageOverlayId= plotState.getWebPlotRequest().getPlotId();
+        const request0= plotState.getWebPlotRequest();
 
-        const plot= WebPlot.makeWebPlotData({plotId:imageOverlayId, wpInit:PlotCreate[0], asOverlay:true, request0:plotState.getWebPlotRequest()});
-        plot.tileData = undefined;
-        const resultPayload= clone(payload, {plot});
+        const resultPayload= {...payload};
+        const pv= getPlotViewById(visRoot(),payload.plotId);
+        const cubeIndex= convertImageIdxToHDU(pv,pv.primeIdx).cubeIdx;
+        const plots= PlotCreate.map( (pc,idx) => {
+            const plot=WebPlot.makeWebPlotData({plotId:imageOverlayId, wpInit:pc, asOverlay:true, cubeCtx:cubeCtx[idx], request0});
+            plot.tileData = undefined;
+            return plot;
+        });
+        resultPayload.plots=plots;
+        resultPayload.cube=PlotCreate.length>1;
+        resultPayload.primeIdx= 0;
+        resultPayload.plot=resultPayload.plots[cubeIndex];
         dispatcher({type: ImagePlotCntlr.PLOT_MASK, payload: resultPayload});
     }
     else {

--- a/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
@@ -11,7 +11,6 @@ import React from 'react';
 import ImageRoot from '../../drawingLayers/ImageRoot.js';
 import {showColorPickerDialog} from '../../ui/ColorPicker.jsx';
 import {showPointShapeSizePickerDialog} from '../../ui/PointShapeSizePicker.jsx';
-import {clone} from '../../util/WebUtil.js';
 import {dispatchDetachLayerFromPlot} from '../DrawLayerCntlr.js';
 import {dispatchDeleteOverlayPlot, dispatchOverlayPlotChangeAttributes, visRoot} from '../ImagePlotCntlr.js';
 import {getAllDrawLayersForPlot, getHDU, getLayerTitle, isDrawLayerVisible, primePlot} from '../PlotViewUtil.js';
@@ -224,7 +223,7 @@ function modifyMaskColor(opv) {
                 operateOnOverlayPlotViewsThatMatch(visRoot(),opv, (aOpv) => {
                     const {plotId, imageOverlayId} = aOpv;
                     const colorAttributes= aOpv.colorAttributes.color!==newColor ?
-                        clone(aOpv.colorAttributes, {color:newColor} ) : aOpv.colorAttributes;
+                        {...aOpv.colorAttributes, color:newColor} : aOpv.colorAttributes;
                     dispatchOverlayPlotChangeAttributes({plotId, imageOverlayId,doReplot:false,
                         attributes:{colorAttributes,opacity:a}});
                 });


### PR DESCRIPTION
#### Firefly-1921: support mask cubes

- mask overlay will support cube mask on cube primary images
- puts the same plane of mask over a plane of the primary images

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1921-mask-grid/firefly
-use the SPHEREx sample mosaic: `sample_mosaic_delivery_v4.fits` 
- upload the fits file, and choose `image` 
- goto the drawing layers popup<img width="40" height="36" alt="Screenshot 2025-12-19 at 12 35 22 PM" src="https://github.com/user-attachments/assets/21c90c6e-8468-43c8-82ce-291fb171671c" /> 
- enable the mask Layers with `Enable`
- turn on `bit # 11 - COLD` - you will see the overlay as a wavelength number that matches the cube wavelength number below it.
- iterate through the cube you will see the overlay change with it. 
-  change the color of the overlay and keep interating

