### PR TITLE
FIREFLY-1830: Apply UWS destruction time for job cleanup and update job retention policy

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
@@ -32,7 +32,6 @@ import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 public class JobInfo implements Serializable {
 
     public enum Phase {PENDING, QUEUED, EXECUTING, COMPLETED, ERROR, ABORTED, HELD, SUSPENDED, ARCHIVED, UNKNOWN}
-    public static final Set<Phase> CLEANUP_PHASES_EXCLUDES = Set.of(Phase.PENDING, Phase.QUEUED, Phase.EXECUTING, Phase.SUSPENDED);
     private static final int LIFE_SPAN = AppProperties.getIntProperty("job.lifespan", 60*60*24);        // default lifespan in seconds; kill job if exceed
 
     // these are uws:job defined properties

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -73,8 +73,7 @@ public class JobManager {
     private static final int KEEP_ALIVE_INTERVAL = AppProperties.getIntProperty("job.keepalive.interval", 60);  // default keepalive interval in seconds
     private static final int WAIT_COMPLETE = AppProperties.getIntProperty("job.wait.complete", 1);              // wait for complete after submit in seconds
     private static final int MAX_PACKAGERS = AppProperties.getIntProperty("job.max.packagers", 10);             // maximum number of simultaneous packaging threads
-    private static final int JOB_EXPIRY_HOURS = AppProperties.getIntProperty("job.expiry.hours", 24*14);        // Time in hours to keep a job after it has ended.  Default to 14 days.
-    private static final int JOB_ARCHIVED_EXPIRY_HOURS = AppProperties.getIntProperty("job.archived.expiry.hours", 24*14);   // Time in hours to keep an archived job after it has ended.  Default to 14 days.
+    private static final int JOB_TTL_DAYS = AppProperties.getIntProperty("job.ttl.days", 7);                    // Time in days to keep a job in redis.  Default to 7 days.
 
     private static final Logger.LoggerImpl LOG = Logger.getLogger();
     private static final ExecutorService packagers = Executors.newFixedThreadPool(MAX_PACKAGERS);
@@ -148,7 +147,7 @@ public class JobManager {
         updateJobInfo(jobId, true, ji -> {      // setting 'true' to add this jobInfo into the datastore
             Instant start = Instant.now();
             ji.setCreationTime(start);
-            ji.setDestruction(start.plus(7, ChronoUnit.DAYS));
+            ji.setDestruction(start.plus(JOB_TTL_DAYS, ChronoUnit.DAYS));
             ji.getMeta().setType(job.getType());
         });
         // update Job after jobInfo has been created
@@ -562,22 +561,23 @@ public class JobManager {
     }
 
     public static void cleanup() {
+        LOG.info("JobInfo cleanup started");
         List<JobInfo> jobs = getAllJobs();
         jobs.forEach(job -> {
             CacheKey k = cacheKey(job);
             if (!job.getMeta().isMonitored() && job.getEndTime().plus(1, ChronoUnit.HOURS).isBefore(Instant.now())) {
-                LOG.info("Removing non-monitored job: " + k);
+                LOG.info("  Removing non-monitored job: " + k);
                 allJobInfos.remove(k);      // remove non-monitored job after 1 hour
-            } else if (job.getPhase() == ARCHIVED) {
-                if (job.getEndTime().plus(JOB_ARCHIVED_EXPIRY_HOURS, ChronoUnit.HOURS).isBefore(Instant.now())) {
-                    LOG.info("Removing expired archived job: " + k);
+            } else {
+                Instant desDate = job.getDestruction();
+                desDate = desDate == null ? job.getCreationTime().plus(JOB_TTL_DAYS, ChronoUnit.DAYS) : desDate;        // ensure destruction date has a value
+                if (desDate.isBefore(Instant.now())) {
+                    LOG.info("  Removing expired job: " + k);
                     allJobInfos.remove(k);
                 }
-            } else if (!CLEANUP_PHASES_EXCLUDES.contains(job.getPhase()) && job.getEndTime().plus(JOB_EXPIRY_HOURS, ChronoUnit.HOURS).isBefore(Instant.now())) {
-                LOG.info("Removing expired job: " + k);
-                allJobInfos.remove(k);
             }
         });
+        LOG.info("JobInfo cleanup finished");
     }
 
     /**

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -236,7 +236,7 @@ const defFireflyOptions = {
             label: 'Job Monitor',    // label for the background monitor button
             note: `
                 Note: The listed jobs are limited to your current session, where "session" may refer to your browser or archive, 
-                or account with which you're currently logged in. Jobs older than 14 days will not appear.
+                or account with which you're currently logged in. Jobs are removed once they reach their destruction time.
             `.trim(),
         }
     },

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -22,7 +22,7 @@ const popupSx = {
     justifyContent: 'space-between',
     resize: 'both',
     overflow: 'auto',
-    minHeight: 200, minWidth: 500,
+    minHeight: 200, minWidth: 525,
     width: '45vh'
 };
 
@@ -121,11 +121,11 @@ function JobInfoDetails({jobInfo={}}) {
         <Stack direction='row' spacing={4}>
             <Stack>
                 <KeywordBlock label='Phase' title='Referred to as "phase" in UWS' value={phase} mb={1}/>
-                <KeywordBlock label='Created' title='Referred to as "creationTime" in UWS' value={toDateString(creationTime, useLocalTime)}  {...dateProps}/>
+                <KeywordBlock label='Creation Time' title='Referred to as "creationTime" in UWS' value={toDateString(creationTime, useLocalTime)}  {...dateProps}/>
                 <KeywordBlock label='Start Time' title='Referred to as "startTime" in UWS' value={toDateString(startTime, useLocalTime)} {...dateProps}/>
                 <KeywordBlock label='End Time' title='Referred to as "endTime" in UWS' value={toDateString(endTime, useLocalTime)} {...dateProps}/>
-                <KeywordBlock label='Planned end' title='Referred to as "quote" in UWS' value={toDateString(quote, useLocalTime)} {...dateProps}/>
-                <KeywordBlock label='Destruction' title='Referred to as "destruction" in UWS' value={toDateString(destruction, useLocalTime)} {...dateProps}/>
+                <KeywordBlock label='Planned End Time' title='Referred to as "quote" in UWS' value={toDateString(quote, useLocalTime)} {...dateProps}/>
+                <KeywordBlock label='Destruction Time' title='Referred to as "destruction" in UWS' value={toDateString(destruction, useLocalTime)} {...dateProps}/>
             </Stack>
             <Stack>
                 <JobIdWrapper jobInfo={jobInfo}/>

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/AsyncTapQueryTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/AsyncTapQueryTest.java
@@ -88,13 +88,11 @@ public class AsyncTapQueryTest extends ConfigTest {
 
 
 			// test bad job
-			try {
-				req.setParam("QUERY", "SELECT * FROM dumm_table where dummy = 'dummy'");
-				new AsyncTapQuery().submitJob(req);
-				Assert.fail("should have thrown exception");
-			} catch (Exception e) {
-				Assert.assertNotNull("should fail with error message", e.getMessage());
-			}
+			req.setParam("QUERY", "SELECT * FROM dumm_table where dummy = 'dummy'");
+			jobUrl = new AsyncTapQuery().submitJob(req);
+			Thread.sleep(2000); // wait for job to process
+			jobInfo = AsyncTapQuery.getUwsJobInfo(jobUrl);
+			Assert.assertEquals(JobInfo.Phase.ERROR, jobInfo.getPhase());
 
 		} catch (Exception e) {
 			Assert.fail("testExecRequestQuery failed with exception: " + e.getMessage());


### PR DESCRIPTION
Ticket: https://fireflydev.ipac.caltech.edu/firefly-1830-cleanup-use-desttime/firefly/

This PR updates job lifecycle handling to align with UWS destruction time semantics.

**Changes**
- Use destruction time for job cleanup.
- Apply a default destruction time of 7 days for Firefly-managed jobs (configurable).
- Update Job Monitor label to reflect the revised job expiration and cleanup policy.

Test: https://fireflydev.ipac.caltech.edu/firefly-1830-cleanup-use-desttime/firefly/
- No testing is needed.  Please review the code changes instead.
- See the updated label.  Suggest changes if needed.
  - Job Monitor -> `Note:` label on the bottom of the page.