### PR TITLE
FIREFLY-1744: Fix ADQL color mode bug in Job Monitor dialog 

### DIFF
--- a/src/firefly/js/ui/AppConfigDrawer.jsx
+++ b/src/firefly/js/ui/AppConfigDrawer.jsx
@@ -1,6 +1,5 @@
 
 import {DialogTitle, Divider, Drawer, IconButton, ModalClose, Stack, Typography} from '@mui/joy';
-import {isObject} from 'lodash';
 import {object, bool, number, oneOfType, string} from 'prop-types';
 import React, {isValidElement, useContext, useState} from 'react';
 import {dispatchHideDialog, isDialogVisible, SIDE_BAR_ID} from '../core/ComponentCntlr.js';
@@ -11,6 +10,7 @@ import {SideBarMenu} from './Menu.jsx';
 import {AccordionPanelView} from './panel/AccordionPanel.jsx';
 import {useStoreConnector} from './SimpleComponent.jsx';
 import {VersionInfo} from './VersionInfo.jsx';
+import DialogRootContainer from 'firefly/ui/DialogRootContainer';
 
 
 
@@ -72,6 +72,7 @@ function SideBarColorModeUI({closeSideBar}) {
             <ListBoxInputFieldView {...{
                 onChange: (ev, newValue) => {
                     setMode(newValue);
+                    DialogRootContainer.refreshDialogs(newValue);//forces a re-render of open dialogs to update their color mode
                     closeSideBar();
                 },
                 slotProps:{label: {sx: {width: '7rem'}}},

--- a/src/firefly/js/ui/DialogRootContainer.jsx
+++ b/src/firefly/js/ui/DialogRootContainer.jsx
@@ -17,13 +17,22 @@ const DIALOG_DIV= 'dialogRootDiv';
 const TMP_ROOT='TMP-';
 const DEFAULT_ZINDEX= 200;
 
-export default {defineDialog, showTmpPopup};
+export default {defineDialog, showTmpPopup, refreshDialogs};
+
+function refreshDialogs(mode) {
+    if (!divElement || !divElementRoot) return;
+    dialogColorMode = mode ?? dialogColorMode;
+    reRender(dialogs, tmpPopups, requestOnTop);
+}
+
 
 let dialogs= [];
 let tmpPopups= [];
 let tmpCount=0;
 let divElement;
 let divElementRoot;
+let dialogColorMode; //'light' | 'dark' | 'system'
+
 
 function init() {
     divElement= createDiv({id: DIALOG_DIV});
@@ -214,7 +223,7 @@ DialogRootComponent.propTypes = {
  */
 function reRender(dialogs,tmpPopups,requestOnTop) {
     divElementRoot.render(
-        <FireflyRoot>
+        <FireflyRoot key={`dlg-root-${dialogColorMode ?? ''}`}>
             <DialogRootComponent dialogs={dialogs} tmpPopups={tmpPopups} requestOnTop={requestOnTop}/>
         </FireflyRoot>
     );


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1744
- The main reason for this bug is that `DialogRootContainer` is essentially a separate root (from the main `FireflyRoot`)
- So when toggling theme, a re-render would not occur inside dialogs 
  - But the rest of the dialog (except ADQL block) would still manage the theme change, because most of the dialog UI uses global Joy UI CSS 
    - The ADQL block, though, uses Prism whose theme is injected via CSS strings, so it required an explicit re-render
       - the code changes in `AppConfigDrawer` and `DialogRootContainer` take care of this, forcing a re-render of the dialog on theme change
- Even after the re-render of the dialog, `useColorMode()` in CssStrThemeWrapper would still not give the correct theme for the dialog (because dialogs are rendered in a separate React root with their own Joy `CssVarsProvider`)
  - This led to relying on getting the Joy scheme from the DOM in the case of dialogs (with ADQL block) specifically

Eventually, this PR could be made redundant if dialogs were not in a separate React Tree. We plan on discussing this change January 27-28. 

**Testing**: 
**Firefly**: https://fireflydev.ipac.caltech.edu/firefly-1744-adql-toggle-bug/firefly
- test toggling dark to light mode and vice-versa upon opening a TAP Job Info dialog from the Job Monitor (described in ticket above) 
  -  ensure the ADQL block changes to dark/light mode as expected when you toggle the theme 
-  test toggling dark to light mode and vice-versa on the **Edit ADQL** page (regression testing)