### PR TITLE
FIREFLY-1833: Fix Python client functions don't switch to Results tab if any other tab is selected

### DIFF
--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -270,7 +270,7 @@ export function dispatchShowDropDown({view, menuItem, initArgs}) {
  * hide the drop down container
  */
 export function dispatchHideDropDown() {
-    flux.process({type: SHOW_DROPDOWN, payload: {visible: false}});
+    flux.process({type: SHOW_DROPDOWN, payload: resultsViewDropdown});
 }
 
 /**
@@ -415,10 +415,18 @@ export function getResultCounts() {
     return {haveResults,tableCnt,tableLoadingCnt,imageCnt,imageLoadingCnt,pinChartCnt,bgTableCnt};
 }
 
+/* layoutInfo.dropdown for the "Results" panel that shows in standard or expanded layout views */
+export const resultsViewDropdown = {
+    visible: false,
+    view: '' // '' is important to avoid `undefined` getting ignored in state objects merging
+};
+/* check if a layoutInfo.dropdown is for the "Results" view */
+export const isResultsViewDropdown = ({view, visible}) => !visible && view === '';
+
 /**
  * This handles the general use case of the drop-down panel.
- * It will collapse the drop-down panel when new tables or images are added.
- * It will expand the drop-down panel when there is no results to be shown.
+ * It will collapse the drop-down panel when new tables, chart, or images are added, i.e., show the results view (standard/expanded).
+ * It will expand the drop-down panel when there is no results to be shown, i.e., show the non-results panels.
  * @param {LayoutInfo} layoutInfo
  * @param {Action} action
  * @returns {LayoutInfo}  return new LayoutInfo if layout was affected.  Otherwise, return the given layoutInfo.
@@ -427,17 +435,18 @@ export function dropDownHandler(layoutInfo, action) {
     // calculate dropDown when new UI elements are added or removed from results
     switch (action.type) {
         case CHART_ADD:
+            return smartMerge(layoutInfo, {dropDown: resultsViewDropdown});
         case TBL_RESULTS_ADDED:
         case TBL_RESULTS_ACTIVE:
         case TABLE_LOADED:
-            const tbl_id= action.type === CHART_ADD ? action.payload.groupId : action.payload.tbl_id;
+            const {tbl_id} = action.payload;
             if (findGroupByTblId(tbl_id)!=='main' || getTblById(tbl_id)?.request?.META_INFO?.[MetaConst.UPLOAD_TABLE]) {
                 return layoutInfo;
             }
-            return smartMerge(layoutInfo, {dropDown: {visible: false}});
+            return smartMerge(layoutInfo, {dropDown: resultsViewDropdown});
         case REPLACE_VIEWER_ITEMS :
         case ImagePlotCntlr.PLOT_IMAGE :
-            return smartMerge(layoutInfo, {dropDown: {visible: false}});
+            return smartMerge(layoutInfo, {dropDown: resultsViewDropdown});
         case ImagePlotCntlr.PLOT_IMAGE_START :
             const VISUALIZED_TABLE_IDS = action.payload?.attributes?.VISUALIZED_TABLE_IDS;
             if (VISUALIZED_TABLE_IDS?.length) {

--- a/src/firefly/js/templates/common/MainPanel.jsx
+++ b/src/firefly/js/templates/common/MainPanel.jsx
@@ -14,13 +14,18 @@ import FOOTER_BG from 'images/ipac_bar.jpg';
 
 /**
  * Main panel of the FireflyLayout.  It handles the 3 possible views: drop-down, standard, expanded.
- * It also add a footer to the drop-down if footerComponent is set.
+ * It also adds a footer to the drop-down view if footerComponent is set.
+ *
+ * Typically, these 3 views render the following:
+ * 1) standard:   LandingPage or ResultsPanel.StandardView.DockLayoutPanel with split view of image, table and chart containers
+ * 2) expanded:   ResultsPanel.ExpandedView with one of image, table or chart container expanded to entire main panel
+ * 3) drop-down:  DropDownContainer containing any panel except the above two like search panel, upload panel, etc.
  * @param p     props
  * @param p.dropDownComponent   drop-down component to show when drop-down is visible
  * @param p.footer     footer component to show
  * @param p.showDropDown        set drop-down state
  * @param p.useDefaultExpandedView  use default ExpandedView
- * @param p.children            main content to show when drop-down is hidden
+ * @param p.children            main content to show when it's not drop-down or expanded view
  * @return {JSX.Element}
  */
 export function MainPanel({dropDownComponent, footer, showDropDown, useDefaultExpandedView=false, children}) {

--- a/src/firefly/js/ui/Menu.jsx
+++ b/src/firefly/js/ui/Menu.jsx
@@ -20,7 +20,7 @@ import {
     dispatchShowDropDown,
     dispatchUpdateMenuTabNodes,
     getLayouInfo, getMenuTabNodes,
-    getResultCounts,
+    getResultCounts, isResultsViewDropdown, resultsViewDropdown,
 } from '../core/LayoutCntlr.js';
 import QuizOutlinedIcon from '@mui/icons-material/QuizOutlined';
 import {AppPropertiesCtx} from './AppPropertiesCtx.jsx';
@@ -62,8 +62,7 @@ export function Menu() {
     const {appTitle, showUserInfo} = useContext(AppPropertiesCtx);
     const menu= useStoreConnector(() => getMenu());
     const {menuItems=[]} = menu;
-    const layoutInfo= getLayouInfo() ?? {};
-    const {dropDown={}}=  layoutInfo;
+    const dropDown=  useStoreConnector(() => getLayouInfo()?.dropDown ?? {});
     const selected= getSelectedMenuItem(menu,dropDown);
 
     useEffect(() => {
@@ -94,6 +93,11 @@ export function Menu() {
             updateMenu(appTitle, {...menu, menuItems:newMenuItems, selected});
         }
     }, [selected,ready]);
+
+    useEffect(() => {
+        // if layoutInfo.dropdown in the store updated to results view, set selected menu tab to '' (results)
+        if (isResultsViewDropdown(dropDown) && menu?.selected !== '') dispatchSetMenu({...menu, selected: ''});
+    }, [dropDown]);
 
     if (!ready) return <div/>;
 
@@ -386,7 +390,7 @@ export function SideBarMenu({closeSideBar, allowMenuHide}) {
     const {haveResults}= useStoreConnector(getCounts);
     const uploadItem= menu.menuItems?.find(({action}) => action===UploadCmd);
     const menuItems= menu.menuItems?.filter(({type,action}) => type !== COMMAND && action!==UploadCmd);
-    const {dropDown={visible:false}}= getLayouInfo() ?? {};
+    const {dropDown=resultsViewDropdown}= getLayouInfo() ?? {};
     const selected= getSelectedMenuItem(menu,dropDown);
     const categoryList= menuItems ? [...new Set(menuItems.map( (mi) => mi.category ?? ''))] : [];
 


### PR DESCRIPTION
Fixes [FIREFLY-1833](https://jira.ipac.caltech.edu/browse/FIREFLY-1833)

This was a two part problem:
1. The Menu tabs were not syncing up with the `layoutInfo` in the store esp when results are available. Added an effect in `Menu` to listen to `layoutInfo.dropdown` and update the selected tab when results view.
2. `dropdownHandler` doesn't update `layoutInfo.dropdown` with recent payload correctly because `view: undefined` used for Results view gets ignored when merging objects and the new state has old view. 


## Testing
Point to this firefly server: https://fireflydev.ipac.caltech.edu/firefly-1833-tab-switch/firefly

Follow the instructions in the ticket. Also try other `fc.show_*` methods (can use [reference guide notebook](https://github.com/Caltech-IPAC/firefly_client/blob/master/examples/reference-guide.ipynb) for testing). The menu tab should switch to "Results" if not already there as the method gets executed.
