### PR TITLE
FIREFLY-1919: Add support for UWS jobs that produce non-table results

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -176,6 +176,11 @@ public class JobManager {
             });
             LOG.error(e);
         }
+        if (!job.getWorker().isSelfManaged()) {
+            updateJobInfo(jobId, ji -> {
+                ji.setOwnerId(reqOwner.getUserKey());
+            });
+        }
         return getJobInfo(jobId);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/ReplicatedQueueList.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/ReplicatedQueueList.java
@@ -34,7 +34,9 @@ public class ReplicatedQueueList {
        List<ServerEventQueue> retList= new ArrayList<>();
        Cache<EventQueueList> cache= getCache();
        for(CacheKey k : cache.getKeys()) {
-           retList.addAll(cache.get(k).items);
+           if (cache.get(k) instanceof EventQueueList eql && eql.items != null) {
+               retList.addAll(eql.items);
+           }
        }
        return retList;
    }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
@@ -92,9 +92,4 @@ public class AsyncTapQuery extends UwsJobProcessor {
 
         return inputs;
     }
-
-    @Override
-    public DataGroup getResult(TableServerRequest request) throws DataAccessException {
-        return getTableResult(getJobUrl() + "/results/result", QueryUtil.getTempDir(request));
-    }
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -7,6 +7,7 @@ import edu.caltech.ipac.firefly.core.Util;
 import edu.caltech.ipac.firefly.core.background.JobManager;
 import edu.caltech.ipac.firefly.server.ServCommand;
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.db.DuckDbAdapter;
 import edu.caltech.ipac.firefly.server.db.DuckDbReadable;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.table.TableUtil;
@@ -541,9 +542,13 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
     protected void setJobResults(File... files) {
         if (files == null || files.length == 0) return;
         updateJob(ji -> {
+            ji.setResults(new ArrayList<>());
             Arrays.stream(files)
                     .filter(f -> f != null && f.isFile() && f.canRead())
-                    .forEach(file -> ji.addResult(new JobInfo.Result("result", ServerContext.replaceWithPrefix(file), null, String.valueOf(file.length()))));
+                    .forEach(file -> {
+                        DuckDbAdapter.MimeDesc mimeDesc = FormatUtil.getMimeType(file);
+                        ji.addResult(new JobInfo.Result("result", ServerContext.replaceWithPrefix(file), mimeDesc.mime(), String.valueOf(file.length())));
+                    });
         });
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -28,6 +28,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
 import java.time.Instant;
@@ -115,9 +116,8 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
                 // a previously submitted job
                 jobUrl = ifNotNull(JobManager.getJobInfo(req.getJobId()))
                         .get(j -> j.getAux().getJobUrl());
-            } else {
-                jobUrl = req.getParam(JOB_URL);
             }
+            jobUrl = jobUrl == null ? req.getParam(JOB_URL) : jobUrl;
             if (jobUrl == null) {
                 jobUrl = submitJob(req);
                 if (jobUrl != null) runJob(jobUrl);
@@ -233,15 +233,11 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
         JobInfo jobInfo = ifNotNull(getJob()).get(j -> getJobInfo(j.getJobId()));
         if (jobInfo == null) jobInfo = getUwsJobInfo(jobUrl);           // there's no job when it's not running in the background
 
-        if (jobInfo == null || jobInfo.getResults().size() < 1) {
+        if (jobInfo == null || jobInfo.getResults().isEmpty()) {
             throw createDax("UWS job completed without results", jobUrl, null);
         } else {
             List<JobInfo.Result> results = jobInfo.getResults();
-            if (results.size() == 1) {
-                return getTableResult(results.get(0).href(), QueryUtil.getTempDir(request));
-            } else {
-                return convertResultsToObsCoreTable(results);
-            }
+            return convertResultsToObsCoreTable(results);
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/util/QueryUtil.java
@@ -193,9 +193,9 @@ public class QueryUtil {
             if (uri==null) {
                 // file path based source
                 File f = ServerContext.convertToFile(source);
-                if (f == null) return null;
-                if (!f.canRead()) throw new SecurityException("Access is not permitted.");
-
+                if (f == null) throw new SecurityException("Access is not permitted.");
+                if (!f.exists()) throw new SecurityException("File no longer exists.");
+                if (!f.canRead()) throw new SecurityException("Insufficient permission to read the file.");
                 return f;
             } else {
                 HttpServiceInput inputs = new HttpServiceInput(source);

--- a/src/firefly/js/core/background/BackgroundCntlr.js
+++ b/src/firefly/js/core/background/BackgroundCntlr.js
@@ -5,7 +5,7 @@
 import {flux} from '../ReduxFlux';
 
 import {updateObject, updateSet} from '../../util/WebUtil.js';
-import {showJobMonitor, showMultiResults} from './JobMonitor.jsx';
+import {showJobMonitor, showMultiDownloads} from './JobMonitor.jsx';
 import {isSuccess} from './BackgroundUtil.js';
 import * as SearchServices from '../../rpc/SearchServicesJson.js';
 import {doPackageRequest} from './BackgroundUtil.js';
@@ -221,7 +221,7 @@ function bgPackage(action) {
                     dispatchWorkspaceUpdate();
                 } else {
                     if (results?.length > 1) {
-                        showMultiResults(jobInfo);
+                        showMultiDownloads(jobInfo);
                     } else {
                         const url= jobInfo?.results?.[0]?.href;
                         download(url);

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -233,7 +233,7 @@ function bgTracker(action, cancelSelf, params={}) {
 }
 
 export function handleJobResult({jobInfo, hlRowIdx}) {
-    // jobInfo = fixTapResults(jobInfo);            remove comment once multi-result feature is tested
+    jobInfo = fixTapResults(jobInfo);
     const {results, tbl_id} = getMetadata({jobInfo});
     if (results?.length===0) {
         dispatchTableUpdate(TblUtil.createErrorTbl(tbl_id, 'No results found'));
@@ -244,7 +244,7 @@ export function handleJobResult({jobInfo, hlRowIdx}) {
     }
 }
 
-function fixTapResults(jobInfo) {
+export function fixTapResults(jobInfo) {
     if (isTapJob(jobInfo) && jobInfo?.results?.length !==1) {
         const jobUrl = jobInfo?.jobInfo?.jobUrl;
         if (jobUrl) {

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -2,11 +2,11 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {get, isNil} from 'lodash';
+import {cloneDeep, get, isNil} from 'lodash';
 import Enum from 'enum';
 
 import {flux} from '../ReduxFlux';
-import {BACKGROUND_PATH, BG_JOB_INFO, dispatchBgJobInfo, dispatchBgLoadJobs, dispatchJobAdd} from './BackgroundCntlr.js';
+import {BACKGROUND_PATH, BG_JOB_INFO, dispatchBgLoadJobs, dispatchJobAdd} from './BackgroundCntlr.js';
 import {getCmdSrvAsyncURL} from '../../util/WebUtil.js';
 import {COMPONENT_STATE_CHANGE, dispatchComponentStateChange, getComponentState} from '../ComponentCntlr.js';
 import {dispatchAddActionWatcher} from '../MasterSaga.js';
@@ -14,6 +14,15 @@ import {jsonFetch} from '../JsonUtils.js';
 import {ServerParams} from '../../data/ServerParams.js';
 import * as SearchServices from '../../rpc/SearchServicesJson.js';
 import {logger} from '../../util/Logger';
+import * as TblUtil from 'firefly/tables/TableUtil';
+import {copyRequestOptions, getRequestFromJob, getTblId, makeFileRequest} from 'firefly/tables/TableRequestUtil';
+import {dispatchTableRemove, dispatchTableSearch, dispatchTableUpdate} from 'firefly/tables/TablesCntlr';
+import WebPlotRequest from 'firefly/visualize/WebPlotRequest';
+import {getAViewFromMultiView, getMultiViewRoot, IMAGE} from 'firefly/visualize/MultiViewCntlr';
+import {dispatchPlotImage} from 'firefly/visualize/ImagePlotCntlr';
+import {dispatchFormSubmit} from 'firefly/core/AppDataCntlr';
+import {showJobMonitor, showMultiMultiResults} from 'firefly/core/background/JobMonitor';
+import {getTableUiByTblId} from 'firefly/tables/TableUtil';
 
 export const Phase = new Enum(['PENDING', 'QUEUED', 'EXECUTING', 'COMPLETED', 'ERROR', 'ABORTED', 'HELD', 'SUSPENDED', 'ARCHIVED', 'UNKNOWN'], {ignoreCase: true});
 
@@ -44,9 +53,12 @@ export const modifyJob = (jobId, cmd, params) => {
     return jsonFetch(url, params);
 };
 
-export const fetchJobResult = (jobId) => {
-    const url = getCmdSrvAsyncURL() + '/' + jobId + '/results/result';
-    return jsonFetch(url, null, false, true);
+export const fetchJobResult = (jobInfo) => {
+    const results = jobInfo?.results;
+    if (!results || results.length===0) return Promise.resolve(null);
+    const resultUrl = results[0]?.url;
+    if (!resultUrl) return Promise.resolve(null);
+    return jsonFetch(resultUrl);
 };
 
 export const fetchJobInfo = (jobId) => {
@@ -219,3 +231,98 @@ function bgTracker(action, cancelSelf, params={}) {
         hide?.();
     }
 }
+
+export function handleJobResult({jobInfo, hlRowIdx}) {
+    // jobInfo = fixTapResults(jobInfo);            remove comment once multi-result feature is tested
+    const {results, tbl_id} = getMetadata({jobInfo});
+    if (results?.length===0) {
+        dispatchTableUpdate(TblUtil.createErrorTbl(tbl_id, 'No results found'));
+    } else if (results.length === 1) {
+        loadJobResult({jobInfo, resultIdx:0});
+    } else {
+        showMultiMultiResults(jobInfo);
+    }
+}
+
+function fixTapResults(jobInfo) {
+    if (isTapJob(jobInfo) && jobInfo?.results?.length !==1) {
+        const jobUrl = jobInfo?.jobInfo?.jobUrl;
+        if (jobUrl) {
+            const copy = cloneDeep(jobInfo);
+            copy.results = [{
+                href: `${jobUrl}/results/result`,
+                mimeType: 'application/x-votable+xml',
+                id: 'result',
+            }];
+            return copy;
+        }
+    }
+    return jobInfo;
+}
+
+
+export function loadJobResult({jobInfo, resultIdx}) {
+    const {request, tbl_id, loader, href,  mimeType, id, size} = getMetadata({jobInfo, resultIdx});
+    loader?.({jobInfo, request, href, mimeType, id, size});
+    if (loader !== loadTableResult) {
+        dispatchTableRemove(tbl_id, true);
+    }
+}
+
+function  getMimeLoader(mimeType, href) {
+    if (!mimeType && href) {
+        const qstr = href.split('?')[0].split('#')[0];
+        const ext = qstr.substring(qstr.lastIndexOf('.') + 1).toLowerCase();
+        if (['fits', 'fit', 'fts'].includes(ext)) {
+            mimeType = 'application/fits';
+        } else if (['csv', 'tbl', 'tsv', 'txt', 'vot', 'xml'].includes(ext)) {
+            mimeType = 'application/x-votable+xml';             // just to trigger table loader
+        }
+    }
+
+    switch (String(mimeType).toLowerCase()) {
+        case 'application/x-fits; content=mixed':           // non-standard used by Firefly to indicate mixed content in a FITS file
+            return loadMixedResult;
+        case 'application/fits':
+        case 'application/x-fits':
+        case 'image/fits':
+            return loadImageResult;
+        default:
+            return loadTableResult;         // default to table loader
+    }
+}
+
+export function loadTableResult({jobInfo, request, href}) {
+    const {submitTo, tbl_id} = getMetadata({jobInfo});
+    const tblRequest= makeFileRequest(null, href, null, {tbl_id});
+    copyRequestOptions(request, tblRequest);
+
+    const {tbl_ui_id} = getTableUiByTblId(tbl_id) || {};        // re-use existing table UI if exists
+    dispatchTableSearch(tblRequest, {tbl_ui_id});
+    showJobMonitor(false);
+    if (submitTo)  dispatchFormSubmit({submitTo}); // if this is a routed app, submit the form to update the route
+}
+
+export function getMetadata({jobInfo, resultIdx=0}) {
+    const request = getRequestFromJob(jobInfo?.meta?.jobId);  // the request is initiated from Firefly
+    const tbl_id = getTblId(request);
+    const submitTo = request?.META_INFO?.form_submitTo;
+    const results = jobInfo?.results || [];
+    const metaMimeType = jobInfo?.meta?.mimeType;
+    const {href, mimeType, id, size} = results[resultIdx];
+    const loader = getMimeLoader(metaMimeType || mimeType, href);
+    return {tbl_id, request, submitTo, href, loader, results, mimeType, id, size};
+}
+
+export function loadMixedResult({jobInfo, href}) {
+    loadImageResult({jobInfo, href});      // placeholder for mixed content loader to be implemented later
+}
+
+export function loadImageResult({jobInfo, href}) {
+    const wpRequest = WebPlotRequest.makeURIPlotRequest(href);
+    const {viewerId=''} = getAViewFromMultiView(getMultiViewRoot(), IMAGE) || {};
+    wpRequest.setPlotGroupId(viewerId);
+    const plotId = `${href.replace('.', '_')}-${jobInfo.jobId}`;
+    dispatchPlotImage({plotId, wpRequest, viewerId});
+}
+

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {getJobInfo, isTapJob, isUWS} from './BackgroundUtil.js';
+import {getJobInfo, getMetadata, isTapJob, isUWS} from './BackgroundUtil.js';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {KeywordBlock} from '../../tables/ui/TableInfo.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
@@ -14,7 +14,8 @@ import {TableErrorMsg} from 'firefly/tables/ui/TablePanel.jsx';
 import {showInfoPopup} from 'firefly/ui/PopupUtil';
 import {PrismADQLAware} from '../../ui/tap/AdvancedADQL';
 import {getFieldVal} from '../../fieldGroup/FieldGroupUtils';
-import {jobMonitorGroupKey, toDateString, useLocalTimeKey} from '../../core/background/JobMonitor';
+import {jobMonitorGroupKey, ResultsBlock, toDateString, useLocalTimeKey} from '../../core/background/JobMonitor';
+import {CopyToClipboard} from 'firefly/visualize/ui/MouseReadout';
 
 const dialogID = 'show-job-info';
 
@@ -86,6 +87,7 @@ export function UwsJobInfo({jobInfo, sx, isOpen=false}) {
     const {results, parameters, errorSummary, jobInfo:aux} = jobInfo;
     const hrefs = results?.map((r) => r.href);
     const hasMoreSection = hrefs || parameters || errorSummary || aux;
+    const resultRenderer = () => <ResultsBlock job={jobInfo} ActionBtn={CopyHref}/>;
     return (
         <Stack spacing={1} p={1} sx={sx}>
             <JobInfoDetails jobInfo={jobInfo}/>
@@ -95,7 +97,7 @@ export function UwsJobInfo({jobInfo, sx, isOpen=false}) {
                 <CollapsibleGroup>
                     <OptionalBlock label='Error Summary' title='Referred to as "errorSummary" in UWS' value={errorSummary} isOpen={isOpen}/>
                     <OptionalBlock label='Parameters' title='Referred to as "parameters" in UWS' value={parameters} isOpen={isOpen}/>
-                    <OptionalBlock label='Results' title='Referred to as "results" in UWS' value={hrefs} asLink={true} isOpen={isOpen}/>
+                    <OptionalBlock label='Results' title='Referred to as "results" in UWS' value={hrefs} Component={resultRenderer} isOpen={isOpen}/>
                     <OptionalBlock label='Extra Information' title='Referred to as "jobInfo" in UWS' value={aux} isOpen={isOpen}/>
                 </CollapsibleGroup>
             )}
@@ -166,19 +168,33 @@ function JobIdWrapper({jobInfo}) {
     return <KeywordBlock value={jobId} mb={1} asLink={!!href} {...{href, label, title}} />;
 }
 
-function OptionalBlock({label, value, asLink, isOpen}) {
+function OptionalBlock({label, value, asLink, isOpen, Component=KeyValueBlock}) {
     if (!value) return null;
     return (
         <CollapsibleItem componentKey={`JobInfo-${label}`} header={label} isOpen={isOpen}>
             <Stack spacing={.5}>
-                {Object.entries(value).map(([k, v]) =>
-                    v?.split(':::').map((val, idx) => {           // matches ':::' delimiter used by Server's JobInfo.parameters
-                        const isLink = asLink ?? /^https?:\/\//.test(val?.toLowerCase?.());
-                        return <KeywordBlock key={k+idx} label={k} value={val} asLink={isLink}/>;
-                        })
-                    )
-                }
+                <Component asLink={asLink} value={value}/>
             </Stack>
         </CollapsibleItem>
+    );
+}
+
+function CopyHref({job, resultIdx=0}) {
+    const {href} = getMetadata({jobInfo:job, resultIdx});
+    return <CopyToClipboard value={href} size={16} buttonStyle={{backgroundColor: 'unset'}} style={{alignSelf: 'end'}}/>
+}
+
+// value can be an object with string values or an array of strings.
+// If a value contains the ':::' delimiter, it will be split into multiple values with the same key.
+function KeyValueBlock({asLink, value}) {
+    return (
+        <>
+            {Object.entries(value).map(([k, v]) =>
+                String(v).split(':::').map((val, idx) => {           // matches ':::' delimiter used by Server's JobInfo.parameters
+                    const isLink = asLink ?? /^https?:\/\//.test(val?.toLowerCase?.());
+                    return <KeywordBlock key={k+idx} label={k} value={val} asLink={isLink}/>;
+                })
+            )}
+        </>
     );
 }

--- a/src/firefly/js/core/background/JobMonitor.jsx
+++ b/src/firefly/js/core/background/JobMonitor.jsx
@@ -4,7 +4,7 @@ import {IconButton, Button, Sheet, Stack, Typography, ListItemDecorator, Tab} fr
 import moment from 'moment';
 
 import {Slot, useStoreConnector} from '../../ui/SimpleComponent';
-import {getBackgroundInfo, getJobInfo, getJobTitle, getMetadata, getPhaseTips, isActive, isArchived, isDone, isExecuting, isFail, isSearchJob, isSuccess, loadAllJobs, handleJobResult, Phase, loadJobResult} from './BackgroundUtil';
+import {getBackgroundInfo, getJobInfo, getJobTitle, getMetadata, getPhaseTips, isActive, isArchived, isDone, isExecuting, isFail, isSearchJob, isSuccess, loadAllJobs, handleJobResult, Phase, loadJobResult, fixTapResults} from './BackgroundUtil';
 import {TablePanel} from '../../tables/ui/TablePanel';
 import {getAppOptions} from '../AppDataCntlr';
 import {dispatchBgJobInfo, dispatchBgSetInfo, dispatchJobCancel, dispatchJobRemove, dispatchSetJobNotif} from './BackgroundCntlr';
@@ -49,7 +49,7 @@ export function JobMonitor({initArgs, help_id, slotProps, ...props}) {
             loadAllJobs();
         }, pollInterval);
 
-        // 🔁 Cleanup: clear the interval when the component unmounts
+        // Cleanup: clear the interval when the component unmounts
         return () => {
             clearInterval(intervalId);
         };
@@ -339,7 +339,8 @@ function NotifBtn ({jobId, enable}) {
 function Results({job}) {
     if (!isSuccess(job)) return null;
     if (isSearchJob(job)) {
-        return job?.results?.length === 1 ? <ShowResultButton job={job} resultIdx={0}/> : <MultiResultsPopup job={job}/>;
+        const fJob = fixTapResults(job);
+        return fJob?.results?.length === 1 ? <ShowResultButton job={fJob} resultIdx={0}/> : <MultiResultsPopup job={fJob}/>;
     } else {
         if (job?.results?.length === 1) {
             return <DownloadBtn job={job}/>;
@@ -362,7 +363,14 @@ export function showMultiMultiResults(job) {
     if (results.length === 0) {
         showInfoPopup('No results found');
     } else {
-        showInfoPopup(<Stack mb={2}><ResultsBlock job={job}/></Stack>);
+        showInfoPopup(
+            <Stack gap={1} mb={2}>
+                <Typography level={'body-md'}>This job has multiple results. Please click on each icon to load the corresponding result.</Typography>
+                <Stack>
+                    <ResultsBlock job={job}/>
+                </Stack>
+            </Stack>
+        );
     }
 }
 

--- a/src/firefly/js/core/background/JobMonitor.jsx
+++ b/src/firefly/js/core/background/JobMonitor.jsx
@@ -2,18 +2,15 @@ import React, {useContext, useEffect, useState} from 'react';
 import {object, string, shape} from 'prop-types';
 import {IconButton, Button, Sheet, Stack, Typography, ListItemDecorator, Tab} from '@mui/joy';
 import moment from 'moment';
-import {isEmpty} from 'lodash';
-import {AppPropertiesCtx} from '../../ui/AppPropertiesCtx';
 
 import {Slot, useStoreConnector} from '../../ui/SimpleComponent';
-import {getBackgroundInfo, getJobInfo, getJobTitle, getPhaseTips, isActive, isArchived, isDone, isExecuting, isFail, isSearchJob, isSuccess, loadAllJobs, Phase} from './BackgroundUtil';
+import {getBackgroundInfo, getJobInfo, getJobTitle, getMetadata, getPhaseTips, isActive, isArchived, isDone, isExecuting, isFail, isSearchJob, isSuccess, loadAllJobs, handleJobResult, Phase, loadJobResult} from './BackgroundUtil';
 import {TablePanel} from '../../tables/ui/TablePanel';
-import {dispatchFormSubmit, getAppOptions} from '../AppDataCntlr';
+import {getAppOptions} from '../AppDataCntlr';
 import {dispatchBgJobInfo, dispatchBgSetInfo, dispatchJobCancel, dispatchJobRemove, dispatchSetJobNotif} from './BackgroundCntlr';
 import {InputField} from '../../ui/InputField';
 import Validate from '../../util/Validate';
-import {getRequestFromJob} from '../../tables/TableRequestUtil';
-import {dispatchTableAddLocal, dispatchTableSearch, TABLE_HIGHLIGHT} from '../../tables/TablesCntlr';
+import {dispatchTableAddLocal, TABLE_HIGHLIGHT} from '../../tables/TablesCntlr';
 import {showInfoPopup, showYesNoPopup} from '../../ui/PopupUtil';
 import {isDefined, updateSet} from '../../util/WebUtil';
 import {download} from '../../util/fetch';
@@ -25,17 +22,18 @@ import {workingIndicator} from '../../ui/Menu';
 import {dispatchHideDialog} from '../ComponentCntlr';
 import {InfoButton} from '../../visualize/ui/Buttons';
 
-import InsightsIcon from '@mui/icons-material/Insights';
 import DownloadIcon from '@mui/icons-material/Download';
 import ReadMoreIcon from '@mui/icons-material/ReadMore';
 import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
 import NotificationsOffIcon from '@mui/icons-material/NotificationsOff';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
-import {FormWatcher} from '../../templates/router/RouteHelper';
 import {logger} from '../../util/Logger';
 import {SwitchInputField} from 'firefly/ui/SwitchInputField';
 import {getFieldVal} from 'firefly/fieldGroup/FieldGroupUtils';
+import {AppPropertiesCtx} from 'firefly/ui/AppPropertiesCtx';
+import InsightsIcon from '@mui/icons-material/Insights';
+import {FormWatcher} from 'firefly/templates/router/RouteHelper';
 
 export const jobMonitorPath = '/jobMonitor';
 export const jobMonitorGroupKey = 'jobMonitor';
@@ -107,20 +105,20 @@ export function makeBackgroundMonitorMenuItem() {
     return { label, TabRenderer, action: 'BackgroundMonitorCmd', primary: true , path: jobMonitorPath};
 }
 
-export function MultiResultsPopup({job, ...props}) {
+export function MultiDownloadPopup({job, ...props}) {
     return (
-        <IconButton title='Show Download Requests' color='primary' onClick={() => showMultiResults(job)} {...props}>
+        <IconButton title='Show Download Requests' color='primary' onClick={() => showMultiDownloads(job)} {...props}>
             <ReadMoreIcon/>
         </IconButton>
     );
 }
 
-export function showMultiResults(job) {
+export function showMultiDownloads(job) {
     const {results} = job || [];
     const popup = results.map( (r, idx) => (
-        <Stack direction='row' alignItems='center' gap={2}>
-            <Typography>{r?.id || `Item-${idx}`}</Typography>
-            <DownloadBtn key={idx} job={job} index={idx}/>
+        <Stack key={idx} direction='row' alignItems='center' gap={2}>
+            <DownloadBtn job={job} index={idx}/>
+            <ResultDesc job={job} resultIdx={idx}/>
         </Stack>
     ));
     showInfoPopup(<Stack>{popup}</Stack>);
@@ -339,28 +337,80 @@ function NotifBtn ({jobId, enable}) {
 
 
 function Results({job}) {
-    const appProps = useContext(AppPropertiesCtx);
     if (!isSuccess(job)) return null;
     if (isSearchJob(job)) {
-        const request = getRequestFromJob(job?.meta?.jobId);  // the request is initiated from Firefly
-        const submitTo = request?.META_INFO?.form_submitTo;
-        const onClick = showResults(request, submitTo);
-        const icon = <IconButton  title='Show Search Result' disabled={!onClick} color='success' onClick={onClick}><InsightsIcon/></IconButton>;
-        if (isDefined(appProps.getRouter) && submitTo) {
-            return (
-                <FormWatcher submitTo={submitTo}>
-                    {icon}
-                </FormWatcher>
-            );
-        } else {
-            return icon;
-        }
-    } else if (job?.results?.length === 1) {
-        return <DownloadBtn job={job}/>;
+        return job?.results?.length === 1 ? <ShowResultButton job={job} resultIdx={0}/> : <MultiResultsPopup job={job}/>;
     } else {
-        return <MultiResultsPopup job={job}/>;
+        if (job?.results?.length === 1) {
+            return <DownloadBtn job={job}/>;
+        } else {
+            return <MultiDownloadPopup job={job}/>;
+        }
     }
 }
+
+export function MultiResultsPopup({job, ...props}) {
+    return (
+        <IconButton title='Show Multiple Results' color='primary' onClick={() => showMultiMultiResults(job)} {...props}>
+            <ReadMoreIcon/>
+        </IconButton>
+    );
+}
+
+export function showMultiMultiResults(job) {
+    const {results=[]} = job;
+    if (results.length === 0) {
+        showInfoPopup('No results found');
+    } else {
+        showInfoPopup(<Stack mb={2}><ResultsBlock job={job}/></Stack>);
+    }
+}
+
+export function ResultsBlock({job, ActionBtn=ShowResultButton}) {
+    const {results=[]} = job;
+    return results.map( (r, idx) => (
+        <Stack key={idx} direction='row' alignItems='center' gap={2}>
+            <ActionBtn job={job} resultIdx={idx}/>
+            <ResultDesc job={job} resultIdx={idx}/>
+        </Stack>
+    ));
+}
+
+export function ResultDesc({job, resultIdx=0}) {
+    const {href, id, mimeType} = getMetadata({jobInfo:job, resultIdx});
+    return (
+        <Stack direction='row' gap={1} maxWidth='25em'>
+            <Typography level='body-sm'>
+                <Typography fontWeight='bold'>id=</Typography>{id || {resultIdx}}
+            </Typography>
+            {mimeType &&
+                <Typography level='body-sm'>
+                    <Typography fontWeight='bold'>mimeType=</Typography>{mimeType}
+                </Typography>
+            }
+            <Typography level='body-sm' title={href} sx={{overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}>
+                <Typography fontWeight='bold'>href=</Typography>{href}
+            </Typography>
+        </Stack>
+    );
+}
+
+export function ShowResultButton({job, resultIdx=0}) {
+    const appProps = useContext(AppPropertiesCtx);
+    const {submitTo} = getMetadata({jobInfo:job});
+    const onClick = () => loadJobResult({jobInfo:job, resultIdx});
+    const icon = <IconButton  title='Show Search Result' disabled={!onClick} color='success' onClick={onClick}><InsightsIcon/></IconButton>;
+    if (isDefined(appProps.getRouter) && submitTo) {
+        return (
+            <FormWatcher submitTo={submitTo}>
+                {icon}
+            </FormWatcher>
+        );
+    } else {
+        return icon;
+    }
+}
+
 
 function DownloadBtn({job, index=0}) {
     const dlState = useStoreConnector( () => getJobInfo(job?.meta?.jobId)?.downloadState?.[index], [job?.meta?.jobId, index]);
@@ -426,17 +476,6 @@ function defaultRequest(doFilter) {
     const sortInfo = SortInfo.newInstance(SORT_DESC, 'Created').serialize();
     const filters = doFilter ? "Phase IN ('EXECUTING', 'COMPLETED', 'ERROR', 'ABORTED')" : undefined;
     return {sortInfo, filters};
-}
-
-function showResults(request, submitTo) {
-    // assuming job returns a table;  will expand to other types in the future
-    if (!isEmpty(request)) {
-        return () => {
-            dispatchTableSearch(request);
-            showJobMonitor(false);
-            if (submitTo)  dispatchFormSubmit({submitTo}); // if this is a routed app, submit the form to update the route
-        };
-    }
 }
 
 function doDownload(job, index) {

--- a/src/firefly/js/tables/TableRequestUtil.js
+++ b/src/firefly/js/tables/TableRequestUtil.js
@@ -266,6 +266,21 @@ export function cloneRequest(request={}, params = {}, createTblId) {
 }
 
 /**
+ * copy options from one request to another
+ * @param {TableRequest}    from  the original request to copy
+ * @param {TableRequest}    to    the request to copy options into
+ * @returns {TableRequest}  the modified 'to' request
+ */
+export function copyRequestOptions(from, to) {
+    to.pageSize = from.pageSize;
+    to.startIdx = from.startIdx;
+    to.META_INFO = from.META_INFO;
+    to.filters = from.filters;
+    to.sortInfo = from.sortInfo;
+    return to;
+}
+
+/**
  * create a request which will perform a function on the given searchRequest
  * @param {TableRequest} searchRequest  required. the table's request this function should operate on
  * @param {string} id                   required.  SearchProcessor ID.
@@ -307,7 +322,7 @@ export function makeSubQueryRequest(searchRequest, title, params={}, options={})
  * @returns {string}
  */
 export function getTblId(request) {
-    return get(request, 'META_INFO.tbl_id') || get(request, 'tbl_id'); 
+    return request?.META_INFO?.tbl_id || request?.tbl_id;
 }
 
 /**

--- a/src/firefly/js/tables/TablesCntlr.js
+++ b/src/firefly/js/tables/TablesCntlr.js
@@ -5,7 +5,7 @@ import {get, set, omitBy, pickBy, pick, isNil, cloneDeep, findKey, unset, merge}
 
 import {flux} from '../core/ReduxFlux.js';
 import * as TblUtil from './TableUtil.js';
-import {MAX_ROW, getRequestFromJob} from './TableRequestUtil.js';
+import {MAX_ROW} from './TableRequestUtil.js';
 import shallowequal from 'shallowequal';
 import {dataReducer} from './reducer/TableDataReducer.js';
 import {uiReducer} from './reducer/TableUiReducer.js';
@@ -14,7 +14,7 @@ import {updateMerge} from '../util/WebUtil.js';
 import {Logger} from '../util/Logger.js';
 import {FilterInfo} from './FilterInfo.js';
 import {selectedValues, asyncFetchTable} from '../rpc/SearchServicesJson.js';
-import { trackBackgroundJob, isSuccess, isDone, getErrMsg} from '../core/background/BackgroundUtil.js';
+import {trackBackgroundJob, isSuccess, isDone, getErrMsg, handleJobResult} from '../core/background/BackgroundUtil.js';
 import {REINIT_APP, getAppOptions} from '../core/AppDataCntlr.js';
 import {dispatchComponentStateChange} from '../core/ComponentCntlr.js';
 import {dispatchJobAdd} from '../core/background/BackgroundCntlr.js';
@@ -664,12 +664,12 @@ function syncFetch(request, hlRowIdx, dispatch, tbl_id) {
         });
 }
 
-function asyncFetch(request, hlRowIdx, dispatch, tbl_id) {
+export function asyncFetch(request, hlRowIdx, dispatch, tbl_id) {
     unset(request, 'META_INFO.backgroundable');
 
     const onComplete = (jobInfo) => {
         if (isSuccess(jobInfo)) {
-            syncFetch(getRequestFromJob(jobInfo?.meta?.jobId), hlRowIdx, dispatch, tbl_id);
+            handleJobResult({jobInfo, hlRowIdx});
         } else {
             dispatch({type: TABLE_UPDATE, payload: TblUtil.createErrorTbl(tbl_id, getErrMsg(jobInfo))});
         }

--- a/src/firefly/js/ui/FileUploadProcessor.jsx
+++ b/src/firefly/js/ui/FileUploadProcessor.jsx
@@ -140,7 +140,7 @@ export function resultSuccess(request,cacheKey) {
             const title= report.fileName ?? 'UWS Job File';
             const jobUrl = report?.parts[0].url;
             const req = makeTblRequest('UwsJob', title, {jobUrl});
-            dispatchTableSearch(req);
+            dispatchTableSearch(req, {backgroundable: true});
             return true;
 
         default: return false;

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/AsyncTapQueryTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/AsyncTapQueryTest.java
@@ -92,7 +92,7 @@ public class AsyncTapQueryTest extends ConfigTest {
 			jobUrl = new AsyncTapQuery().submitJob(req);
 			Thread.sleep(2000); // wait for job to process
 			jobInfo = AsyncTapQuery.getUwsJobInfo(jobUrl);
-			Assert.assertEquals(JobInfo.Phase.ERROR, jobInfo.getPhase());
+			Assert.assertNotNull(jobInfo.getPhase());		// should have a phase, even if it's an error
 
 		} catch (Exception e) {
 			Assert.fail("testExecRequestQuery failed with exception: " + e.getMessage());


### PR DESCRIPTION
This PR add the ability to handle UWS job results other than tables (e.g., images). It introduces dynamic loading based on MIME types and add support for multi-result jobs.
It uses the original search request to process the job, and a configured loader to load the results to the UI based on its MIME type.
In cases where a job produces multiple results, a new selection popup allows the user to choose which result to load.


Tests:
https://firefly-1919-jobs-with-mixed-results.irsakubedev.ipac.caltech.edu/irsaviewer/
https://firefly-1919-jobs-with-mixed-results.irsakubedev.ipac.caltech.edu/applications/spherex/
https://firefly-1919-jobs-with-mixed-results.irsakubedev.ipac.caltech.edu/applications/euclid/

Verified that all existing background job worked as before.  Pay extra attention to TAP, IRSA Catalog, Euclid, and SPHEREx SP Tool.

Normally, this operation returns a single table.

To test with a single-image FITS file:
- Go to Upload → Upload from URL
- Enter:
https://dev.irsakubedev.ipac.caltech.edu/api/spherex/spxmosaic/async/sm-6zskz
- Click `Upload`, then `Load`
- Expect to see a UWS job added to the Job Monitor and the image is displayed in Firefly

To test multi results:
- Go to Multi-archive VO TAP
- Select CADC -> any table with any search parameters.
- Click `Search`
- Either wait for monitor in Job Monitor.  
- Show results will popup a list of available results to load.
