### PR TITLE
FIREFLY-1770: Move pct_complete to progress under uws:jobInfo

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
@@ -52,21 +52,19 @@ public interface Job extends Callable<String> {
         try {
             updateJobInfo(getJobId(), ji -> {
                 ji.setStartTime(Instant.now());
-                ji.getMeta().setProgress(0);
             });
             String results = run();
-            // the worker is set in onStart().
+            // the worker is set at onStart().
             getWorker().onComplete();
             if (Thread.currentThread().isInterrupted()) throw new InterruptedException("Job was aborted");
             updateManagedStatus(ji -> {
                 ji.setPhase(JobInfo.Phase.COMPLETED);
-                ji.getMeta().setProgress(100, "");
             });
             return results;
         } catch (InterruptedException | DataAccessException.Aborted e) {
             updateJobInfo(getJobId(), ji -> {
                 ji.setPhase(JobInfo.Phase.ABORTED);
-                ji.getMeta().setProgress(100, "Job was aborted");
+                ji.getAux().setProgress(new JobInfo.Progress("Job was aborted"));
             });
             getWorker().onAbort();
         } catch (Exception e) {
@@ -78,7 +76,6 @@ public interface Job extends Callable<String> {
         } finally {
             sendUpdate(getJobId(), ji -> {
                 ji.setEndTime(Instant.now());
-                ji.getMeta().setProgress(100);
             });
         }
         return null;

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 
@@ -61,9 +60,7 @@ public class JobInfo implements Serializable {
     // These are additional info that's not in defined in uws:job but is needed by Firefly
     // In serialized form, it will go under uws:jobInfo block
     public static final String PROGRESS = "progress";
-    public static final String PROGRESS_DESC = "progressDesc";
     public static final String JOB_TYPE = "type";
-    public static final String SUMMARY = "summary";
     public static final String JOB_URL = "jobUrl";
     public static final String MONITORED = "monitored";
     public static final String TITLE = "title";
@@ -221,6 +218,7 @@ public class JobInfo implements Serializable {
         this.parameters = new HashMap<>(uws.parameters);
         this.results = new ArrayList<>(uws.results);
         this.errorSummary = uws.errorSummary;
+        this.getAux().setProgress(uws.aux.getProgress());
         ifNotNull(uws.aux.getJobUrl()).apply(aux::setJobUrl);
         ifNotNull(uws.aux.getUserId()).apply(aux::setUserId);
         ifNotNull(uws.aux.getUserName()).apply(aux::setUserName);
@@ -250,9 +248,6 @@ public class JobInfo implements Serializable {
         Map<String, String> parameters = new HashMap<>();
         String userKey;
         Job.Type type;
-        int progress;
-        String progressDesc;
-        String summary;
         boolean monitored;
         String svcId;       // the service id that this job is associated with
         String runHost;     // the host where the job is running on
@@ -277,22 +272,8 @@ public class JobInfo implements Serializable {
         public String getRunHost() { return runHost; }
         public void setRunHost(String runHost) { this.runHost = runHost;}
 
-        public int getProgress() { return progress; }
-        public void setProgress(int progress) { this.progress = Math.min(Math.max(progress, 0), 100); }
-
-        public void setProgress(int progress, String desc) {
-            setProgress(progress);
-            setProgressDesc(desc);
-        }
-
-        public String getProgressDesc() { return progressDesc; }
-        public void setProgressDesc(String progressDesc) { this.progressDesc = progressDesc; }
-
         public Job.Type getType() { return type; }
         public void setType(Job.Type type) { this.type = type; }
-
-        public String getSummary() { return summary; }
-        public void setSummary(String summary) { this.summary = summary; }
 
         public boolean isMonitored() { return monitored; }
         public void setMonitored(boolean monitored) { this.monitored = monitored; }
@@ -321,6 +302,7 @@ public class JobInfo implements Serializable {
         String userEmail;   // may need to be generic so that other user's info can be stored amd passed around
         String title;
         String jobUrl;      // the service URL associated with this job
+        Progress progress;
 
         public String getUserId() { return userId; }
         public void setUserId(String userId) { this.userId = userId;}
@@ -336,6 +318,24 @@ public class JobInfo implements Serializable {
 
         public String getJobUrl() { return jobUrl; }
         public void setJobUrl(String jobUrl) { this.jobUrl = jobUrl; }
+
+        public Progress getProgress() { return progress; }
+        public void setProgress(Progress progress) { this.progress = progress; }
+    }
+
+    public record Progress(int percentComplete, int itemsProcessed, int totalItems, String message) implements Serializable {
+        public Progress() {
+            this(-1, -1, -1, null);
+        }
+        public Progress(String message) {
+            this(-1, message);
+        }
+        public Progress(int percentComplete, String message) {
+            this(percentComplete, -1, -1, message);
+        }
+        public Progress(int itemsProcessed, int totalItems, String message) {
+            this(-1, itemsProcessed, totalItems, message);
+        }
     }
 
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -48,6 +48,7 @@ import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.firefly.core.background.Job.Type.UWS;
 import static edu.caltech.ipac.firefly.core.background.JobInfo.*;
+import static edu.caltech.ipac.firefly.core.background.JobInfo.Phase.EXECUTING;
 import static edu.caltech.ipac.firefly.core.background.JobUtil.*;
 import static edu.caltech.ipac.firefly.data.ServerParams.EMAIL;
 import static edu.caltech.ipac.firefly.server.ServerContext.SCHEDULE_TASK_EXEC;
@@ -158,13 +159,11 @@ public class JobManager {
 
         sendUpdate(jobId, ji -> {
             ji.setPhase(QUEUED);
-            ji.getMeta().setProgress(0);
         });
 
         try {
             Future<String> future = job.getType() == PACKAGE ? packagers.submit(job) : searches.submit(job);
             runningJobs.put(jobId, new JobEntry(future, job));
-
             future.get(WAIT_COMPLETE, TimeUnit.SECONDS);        // wait in seconds for a job to complete
         } catch (TimeoutException e) {
             // it's ok; job may take longer to complete
@@ -172,7 +171,6 @@ public class JobManager {
             // job run() handles exceptions; this only happens if submit or future.get() fails
             sendUpdate(jobId, (ji) -> {
                 ji.setErrorSummary(new ErrorSummary(e.getMessage()));
-                ji.getMeta().setProgress(100, null);
             });
             LOG.error(e);
         }
@@ -283,9 +281,11 @@ public class JobManager {
             info = new JobInfo(jobId);
             initNewJob(info);
         }
-        if (info == null || func == null) return null;
-        func.accept(info);
-        updateJobInfo(info);
+        if (info == null) return null;
+        if (func != null) {
+            func.accept(info);
+            updateJobInfo(info);
+        }
         return info;
     }
 
@@ -298,7 +298,8 @@ public class JobManager {
         JobInfo jobInfo = updateJobInfo(jobId, func);
         if (jobInfo != null) {
             Messenger.publish(new JobEvent(JobEvent.EventType.UPDATED, jobInfo));
-            Logger.getLogger().trace("sendUpdate: " + jobInfo.getMeta().getJobId() + " " + jobInfo.getPhase() + jobInfo.getMeta().getProgressDesc());
+            String progress = jobInfo.getAux().getProgress() == null ? "null" : String.format("%d%% %s", jobInfo.getAux().getProgress().percentComplete(), jobInfo.getAux().getProgress().message());
+            Logger.getLogger().trace("sendUpdate: " + jobInfo.getMeta().getJobId() + " " + jobInfo.getPhase() + progress);
         }
         return jobInfo;
     }
@@ -379,7 +380,7 @@ public class JobManager {
                         ji.getPhase(),
                         ji.getCreationTime() == null ? "" : ji.getCreationTime().truncatedTo(ChronoUnit.SECONDS),
                         startT == null || endT == null ? -1 : Duration.between(startT, endT).toSeconds(),
-                        ji.getMeta().getProgress(),
+                        ifNotNull(ji.getAux().getProgress()).orElse(new Progress()).get(Progress::percentComplete),
                         ji.getMeta().isMonitored(),
                         ji.getMeta().getUserKey()));
             });

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
@@ -37,9 +37,7 @@ import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
 import static edu.caltech.ipac.firefly.server.query.UwsJobProcessor.convertToJobList;
 import static edu.caltech.ipac.firefly.server.query.UwsJobProcessor.getUwsJobInfo;
 import static edu.caltech.ipac.firefly.server.query.UwsJobProcessor.parse;
-import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
-import static edu.caltech.ipac.util.StringUtils.getInt;
-import static edu.caltech.ipac.util.StringUtils.isEmpty;
+import static edu.caltech.ipac.util.StringUtils.*;
 
 public class JobUtil {
     // Services are defined as strings with three fields (url|serviceId|serviceType), separated by commas. Only url is required; the others are optional.
@@ -61,7 +59,8 @@ public class JobUtil {
 
     public static void logJobInfo(JobInfo info) {
         if (info == null) return;
-        LOG.debug(String.format("JOB:%s  userKey:%s  phase:%s  msg:%s", info.getMeta().getJobId(), info.getMeta().getUserKey(), info.getPhase(), info.getMeta().getSummary()));
+        String progress = info.getAux().getProgress() == null ? "null" : String.format("%d%% %s", info.getAux().getProgress().percentComplete(), info.getAux().getProgress().message());
+        LOG.debug(String.format("JOB:%s  userKey:%s  phase:%s  progress:%s", info.getMeta().getJobId(), info.getMeta().getUserKey(), info.getPhase(), progress));
         LOG.trace(String.format("JOB: %s details: %s", info.getMeta().getJobId(), toJson(info)));
     }
 
@@ -243,6 +242,16 @@ public class JobUtil {
         applyIfNotEmpty(info.getAux().getUserEmail(), v -> jsonAux.put(USER_EMAIL, v));
         applyIfNotEmpty(info.getAux().getJobUrl(), v -> jsonAux.put(JobInfo.JOB_URL, v));
 
+        Progress progress = info.getAux().getProgress();
+        if (progress != null) {
+            JSONObject p = new JSONObject();
+            jsonAux.put(PROGRESS, p);
+            ifNotNull(progress.percentComplete()).apply(v -> p.put("percentComplete", v));
+            ifNotNull(progress.message()).apply(v -> p.put("message", v));
+            ifNotNull(progress.itemsProcessed()).apply(v -> p.put("itemsProcessed", v));
+            ifNotNull(progress.totalItems()).apply(v -> p.put("totalItems", v));
+        }
+
         JSONObject jsonMeta = new JSONObject();
         rval.put(META, jsonMeta);
         Meta meta = info.getMeta();
@@ -250,9 +259,6 @@ public class JobUtil {
         applyIfNotEmpty(meta.getRunId(), v -> jsonMeta.put(RUN_ID, v));
         applyIfNotEmpty(meta.getUserKey(), v -> jsonMeta.put(USER_KEY, v));
         applyIfNotEmpty(meta.getType(), v -> jsonMeta.put(JOB_TYPE, v.toString()));
-        applyIfNotEmpty(meta.getProgress(), v -> jsonMeta.put(PROGRESS, v));
-        applyIfNotEmpty(meta.getProgressDesc(), v -> jsonMeta.put(PROGRESS_DESC, v));
-        applyIfNotEmpty(meta.getSummary(), v -> jsonMeta.put(SUMMARY, v));
         applyIfNotEmpty(meta.isMonitored(), v -> jsonMeta.put(MONITORED, v));
         applyIfNotEmpty(meta.getSvcId(), v -> jsonMeta.put(SVC_ID, v));
         applyIfNotEmpty(meta.getAppUrl(), v -> jsonMeta.put(APP_URL, v));
@@ -295,9 +301,6 @@ public class JobUtil {
                 ifNotNull(ji.get(RUN_ID)).apply(s -> rval.getMeta().setRunId(s.toString()));
                 ifNotNull(ji.get(USER_KEY)).apply(s -> rval.getMeta().setUserKey(s.toString()));
                 ifNotNull(ji.get(JOB_TYPE)).apply(t -> rval.getMeta().setType(Job.Type.valueOf(t.toString())));
-                ifNotNull(ji.get(PROGRESS)).apply(p -> rval.getMeta().setProgress(((Long) p).intValue()));
-                ifNotNull(ji.get(PROGRESS_DESC)).apply(d -> rval.getMeta().setProgressDesc(d.toString()));
-                ifNotNull(ji.get(SUMMARY)).apply(s -> rval.getMeta().setSummary(s.toString()));
                 ifNotNull(ji.get(MONITORED)).apply(m -> rval.getMeta().setMonitored((Boolean) m));
                 ifNotNull(ji.get(SVC_ID)).apply(s -> rval.getMeta().setSvcId(s.toString()));
                 ifNotNull(ji.get(APP_URL)).apply(s -> rval.getMeta().setAppUrl(s.toString()));
@@ -314,6 +317,17 @@ public class JobUtil {
                 ifNotNull(ji.get(USER_NAME)).apply(s -> rval.getAux().setUserName(s.toString()));
                 ifNotNull(ji.get(USER_EMAIL)).apply(s -> rval.getAux().setUserEmail(s.toString()));
                 ifNotNull(ji.get(JobInfo.JOB_URL)).apply(o -> rval.getAux().setJobUrl(o.toString()));
+                ifNotNull(ji.get(PROGRESS)).apply(p -> {
+                    if (p instanceof JSONObject jp) {
+                        JobInfo.Progress progress = new JobInfo.Progress(
+                                getInt(jp.get("percentComplete"), -1),
+                                getInt(jp.get("itemsProcessed"), -1),
+                                getInt(jp.get("totalItems"), -1),
+                                ifNotNull(jp.get("message")).get(Object::toString)
+                        );
+                        rval.getAux().setProgress(progress);
+                    }
+                });
             }
         });
         return rval;
@@ -365,14 +379,13 @@ public class JobUtil {
      * @return an array of job IDs under the 'jobs' prop as a json string
      */
     public static String toJsonJobList(List<JobInfo> infos, boolean overflow) {
-        JSONObject rval = new JSONObject();
+        Map<String, Object> rval = new HashMap<>();
         if (infos != null && !infos.isEmpty()) {
             // object with "jobs": array of JobInfo and "overflow: true" if the list exceed 'LAST' or default limit
-            List<JSONObject> jobs = infos.stream().map(JobUtil::toJsonObject).collect(Collectors.toList());
-            rval.put("jobs", jobs);
+            rval.put("jobs", infos);
             if (overflow) rval.put("overflow", true);
         }
-        return rval.toJSONString();
+        return Serializer.toJsonString(rval);
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/ServCmdJob.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/ServCmdJob.java
@@ -71,7 +71,6 @@ public abstract class ServCmdJob extends ServCommand implements Job {
             worker.setJob(this);
             updateManagedStatus(ji -> {     // set these only if it's not a self-managed job
                 ji.setPhase(JobInfo.Phase.EXECUTING);
-                ji.getMeta().setProgress(10);
             });
             sendUpdate(jobId, ji -> {      // needs to update clients, because these values may change after the job has submitted
                 ji.getMeta().setType(worker.getType());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/DownloadScriptWorker.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/DownloadScriptWorker.java
@@ -29,6 +29,7 @@ import static edu.caltech.ipac.firefly.server.servlets.AnyFileDownload.getDownlo
 import static edu.caltech.ipac.firefly.server.util.DownloadScript.makeScriptFilename;
 import static edu.caltech.ipac.firefly.server.ws.WsServerParams.WS_SERVER_PARAMS.CURRENTRELPATH;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
+import edu.caltech.ipac.firefly.core.background.JobInfo.Progress;
 
 /**
  * Downloads a script with products from the List<FileInfo>
@@ -65,19 +66,19 @@ public final class DownloadScriptWorker implements Job.Worker {
         String dataDesc = dlreq.getDataSource();
         String wsDestPath = isEmpty(dlreq.getParam(DownloadRequest.FILE_LOC)) ? null : dlreq.getParam(DownloadRequest.WS_DEST_PATH);
 
-        sendJobUpdate(ji -> ji.getMeta().setProgress(10, "Validating inputs"));
+        sendJobUpdate(ji -> ji.getAux().setProgress(new Progress("Validating inputs")));
 
         SearchProcessor processor = SearchManager.getProcessor(dlreq.getRequestId());
         if (!(processor instanceof FileGroupsProcessor)) {
             throw new DataAccessException("Operation aborted:" + dlreq.getRequestId(), new IllegalArgumentException("Unable to resolve a search processor for this request"));
         }
 
-        sendJobUpdate(ji -> ji.getMeta().setProgress(20, "Processing the request"));
+        sendJobUpdate(ji -> ji.getAux().setProgress(new Progress("Processing the request")));
 
         List<FileGroup> result = ((FileGroupsProcessor) processor).getData(dlreq);
         int totalFiles = result.stream().mapToInt(fg -> fg.getSize()).sum();
 
-        sendJobUpdate(ji -> ji.getMeta().setProgress(80, "Generating the results"));
+        sendJobUpdate(ji -> ji.getAux().setProgress( new Progress("Generating the results")));
 
         File curlScript = makeScript(result, Curl, dataDesc);
         File wgetScript = makeScript(result, Wget, dataDesc);
@@ -96,7 +97,7 @@ public final class DownloadScriptWorker implements Job.Worker {
 
         sendJobUpdate(ji -> {
             String summary = String.format("%,d files were processed.", totalFiles);
-            ji.getMeta().setSummary(summary);
+            ji.getAux().setProgress(new Progress(summary));
             ji.addResult(new JobInfo.Result("curl-script", curlScriptUrl, "text/x-shellscript", curlScript.length() + ""));
             ji.addResult(new JobInfo.Result("wget-script", wgetScriptUrl, "text/x-shellscript", wgetScript.length() + ""));
             ji.addResult(new JobInfo.Result("url-list", urlsFileUrl, "text/plain", urlsFile.length() + ""));

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagingWorker.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/packagedata/PackagingWorker.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipOutputStream;
 
-import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
+import static edu.caltech.ipac.firefly.core.background.JobInfo.Progress;
 import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
 import static edu.caltech.ipac.firefly.core.background.JobUtil.getJobWorkDir;
 import static edu.caltech.ipac.firefly.server.servlets.AnyFileDownload.getDownloadURL;
@@ -124,9 +124,7 @@ public final class PackagingWorker implements Job.Worker {
         updateJobInfo(getJob().getJobId(), ji -> {
             String summary = String.format("%,d files were packaged for a total of %,d B creating %,d zip files.", totalFiles, totalBytes, curZipIdx);
             if (hasErrors) summary += "\nPlease, note:  There were error(s) while processing your request.  See zip's README file for details.";
-            ji.getMeta().setProgress(100);
-            ji.getMeta().setProgressDesc(summary);
-            ji.getMeta().setSummary(summary);
+            ji.getAux().setProgress(new Progress(summary));
         });
 
         return "";
@@ -146,8 +144,7 @@ public final class PackagingWorker implements Job.Worker {
             if ( pct != lastUpdatedPct) {
                 lastUpdatedPct = pct;
                 sendJobUpdate(ji -> {
-                    ji.getMeta().setProgress(pct);
-                    ji.getMeta().setProgressDesc(String.format("%d of %d completed", curFileInfoIdx, totalFiles));
+                    ji.getAux().setProgress(new Progress("%d of %d completed".formatted(curFileInfoIdx, totalFiles)));
                 });
             }
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -137,7 +137,9 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
         var locked = GET_DATA_CHECKER.lock(uniqueID);
         try {
             var dbAdapter = getDbAdapter(treq);
-            sendJobUpdate(ji -> ji.getMeta().setProgress(10, "fetching data..."));
+            if (job != null && !job.getWorker().isSelfManaged()) {
+                sendJobUpdate(ji -> ji.getAux().setProgress( new JobInfo.Progress("fetching data...")));
+            }
 
             DataGroupPart results;
             try {
@@ -151,8 +153,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
                 results = getResultSet(treq, dbAdapter);
                 int totalRows = results.getRowCount();
                 sendJobUpdate(v -> {
-                    v.getMeta().setProgress(90, "generating results...");
-                    sendJobUpdate(ji -> ji.getMeta().setSummary(String.format("%,d rows found", totalRows)));
+                    sendJobUpdate(ji -> ji.getAux().setProgress( new JobInfo.Progress("%,d rows found".formatted(totalRows))));
                 });
             } catch (Exception e) {
                 // table data exists; but, bad grammar when querying for the resultset.
@@ -266,7 +267,7 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
             StopWatch.getInstance().stop("fetchDataGroup: " + req.getRequestId()).printLog("fetchDataGroup: " + req.getRequestId());
             if (dg == null) throw new DataAccessException("Failed to retrieve data");
 
-            sendJobUpdate(v -> v.getMeta().setProgress(70, dg.size() + " rows of data found"));
+            sendJobUpdate(v -> v.getAux().setProgress( new JobInfo.Progress(dg.size() + " rows of data found")));
 
             applyExtraMeta(dg, req);
             return dg;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -35,6 +35,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.firefly.core.background.JobInfo.*;
 import static edu.caltech.ipac.firefly.core.background.JobManager.getJobInfo;
@@ -123,13 +124,11 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
                 if (jobUrl != null) runJob(jobUrl);
                 updateJob(ji -> {
                     ji.setPhase(Phase.QUEUED);
-                    ji.getMeta().setProgress(0, "UWS job submitted");
                 });
             }
         } catch (Exception e) {
             updateJob(ji -> {
                 ji.setErrorSummary(new ErrorSummary(e.getMessage()));
-                ji.getMeta().setProgress(100);
             });
             throw new DataAccessException(e.getMessage());
         } finally {
@@ -148,45 +147,37 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
                     sendJobUpdate(ji -> ji.setErrorSummary(new ErrorSummary(msg)));
                     throw new DataAccessException(msg);
                 }
-
-                sendJobUpdate(ji -> ji.copyFrom(uwsJob));
-                Phase phase = ifNotNull(uwsJob.getPhase()).getOrElse(Phase.UNKNOWN);
-
-                if (phase == Phase.COMPLETED) {
-                    return getResult(req);
-                } else if (phase == Phase.ABORTED) {
-                    throw new DataAccessException.Aborted();        // exit; stop tracking
-                } else if (phase == Phase.HELD) {
-                    updateJob(ji -> ji.setPhase(Phase.HELD));
-                    throw new DataAccessException("The job is HELD pending execution and will not automatically be executed");
-                } else if (phase == Phase.PENDING) {
-                    updateJob(ji -> ji.setPhase(Phase.PENDING));
-                    throw new DataAccessException("The job was submitted, but no execution request has been made.");
-                } else if (phase == Phase.ERROR) {
-                    ErrorSummary error = getError(uwsJob, jobUrl);
-                    updateJob(ji -> ji.setErrorSummary(error));
-                    throw new DataAccessException("Job has failed with the error: " + error.message());
-                } else if (phase == Phase.UNKNOWN) {
-                    updateJob(ji -> ji.setErrorSummary(new ErrorSummary("Unknown phase")));
-                    throw new DataAccessException("The job is in an unknown state");
-                } else {
-                    int wait = cnt < 3 ? 500 : cnt < 20 ? 1000 : 2000;
-                    TimeUnit.MILLISECONDS.sleep(wait);
-                    if (phase == Phase.EXECUTING) {
-                        int progress = (int)(95 * (1 - Math.pow(2.0 / 3.0, cnt)));
-                        sendJobUpdate(ji -> {
-                            ji.getMeta().setProgress(progress, "Job is being processed");
-                            ji.setPhase(phase);
-                        });
+                try {
+                    updateJob(ji -> ji.copyFrom(uwsJob));
+                    Phase phase = ifNotNull(uwsJob.getPhase()).getOrElse(Phase.UNKNOWN);
+                    switch (phase) {
+                        case Phase.COMPLETED:
+                            return getResult(req);
+                        case Phase.ABORTED :
+                            throw new DataAccessException.Aborted();        // exit; stop tracking
+                        case Phase.HELD:
+                            throw new DataAccessException("The job is HELD pending execution and will not automatically be executed");
+                        case Phase.PENDING:
+                            throw new DataAccessException("The job was submitted, but no execution request has been made.");
+                        case Phase.ERROR:
+                            throw new DataAccessException("Job has failed with the error: " + uwsJob.getErrorSummary().message());
+                        case Phase.UNKNOWN: {
+                            if (cnt > 20) {
+                                updateJob(ji -> ji.setErrorSummary(new ErrorSummary("Unknown phase for over 20 seconds")));
+                                throw new DataAccessException("Unknown phase for over 20 seconds");
+                            }
+                        }
+                        default:
+                            // continue to wait
                     }
+                } finally {
+                    sendJobUpdate(null);        // send update to client on each poll.
                 }
+                int wait = cnt < 3 ? 500 : cnt < 20 ? 1000 : 2000;
+                TimeUnit.MILLISECONDS.sleep(wait);
             }
         } catch (InterruptedException e) {
             throw new DataAccessException.Aborted();
-        } finally {
-            sendJobUpdate(ji -> {
-                ji.getMeta().setProgress(100);
-            });
         }
     }
 
@@ -422,7 +413,7 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
                     Node p = plist.item(i);
                     String key = getAttr(p, "id");
                     String val = jobInfo.getParameters().get(key);
-                    val = isEmpty(val) ? p.getTextContent() : val + PARAM_DELIM + p.getTextContent();
+                    val = isEmpty(val) ? getText(p) : val + PARAM_DELIM + getText(p);
                     jobInfo.getParameters().put(key, val);
                 }
             });
@@ -451,6 +442,15 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
                 }
             });
 
+            Element progress = ifNotEmpty(getEl(root, prefix + JOB_INFO))
+                    .get(el -> getEl(el, PROGRESS));
+            if (progress != null) {
+                int pctComplete = getIntVal(progress, "percentComplete", -1);
+                String message = getVal(progress, "message");
+                int itemsProcessed = getIntVal(progress, "itemsProcessed", -1);
+                int itemsTotal = getIntVal(progress, "totalItems", -1);
+                jobInfo.getAux().setProgress(new Progress(pctComplete, itemsProcessed, itemsTotal, message));
+            }
             return jobInfo;
         }
         throw new ParseException("Invalid UWS job document", 0);
@@ -499,7 +499,17 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
      */
     private static String getVal(Element from, String tag) {
         NodeList rval = from.getElementsByTagName(tag);
-        return (rval.getLength() > 0) ? rval.item(0).getTextContent() : null;
+        return (rval.getLength() > 0) ? getText(rval.item(0)) : null;
+    }
+
+    private static int getIntVal(Element from, String tag, int defaultVal) {
+        String val = getVal(from, tag);
+        if (isEmpty(val)) return defaultVal;
+        try {
+            return Integer.parseInt(val.trim());
+        } catch (Exception e) {
+            return defaultVal;
+        }
     }
 
     private static Element getEl(Element from, String tag) {
@@ -509,7 +519,11 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
 
     private static String getAttr(Node from, String name) {
         Node a = from.getAttributes().getNamedItem(name);
-        return a == null ? null : a.getTextContent();
+        return a == null ? null : getText(a);
+    }
+
+    private static String getText(Node from) {
+        return ifNotNull(from.getTextContent()).get(String::trim);
     }
 
 }

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -4,6 +4,7 @@
 
 import {cloneDeep, get, isNil} from 'lodash';
 import Enum from 'enum';
+import moment from 'moment';
 
 import {flux} from '../ReduxFlux';
 import {BACKGROUND_PATH, BG_JOB_INFO, dispatchBgLoadJobs, dispatchJobAdd} from './BackgroundCntlr.js';
@@ -183,6 +184,31 @@ export function getErrMsg(jobInfo) {
     return jobInfo?.errorSummary?.message;
 }
 
+export function getElapsedTime(jobInfo) {
+    const creationTime = jobInfo?.creationTime ? new Date(jobInfo.creationTime) : new Date();
+    const d = moment.duration(new Date() - creationTime);
+    const fmt = d.asHours() < 1 ? 'mm:ss' : 'HH:mm:ss';
+    return moment.utc(d.asMilliseconds()).format(fmt);
+}
+
+export function getJobPctComplete (jobInfo) {
+    const {percentComplete, itemsProcessed, totalItems} = jobInfo?.jobInfo?.progress ?? {};
+    if (percentComplete < 0 && totalItems < 1) return -1;
+    const pct = percentComplete >= 0 ? percentComplete : itemsProcessed / totalItems * 100;
+    return Math.min(Math.round(pct), 100);
+};
+
+export function getProgressMsg(jobInfo) {
+    const {message, itemsProcessed, totalItems} = jobInfo?.jobInfo?.progress ?? {};
+    const pct = getJobPctComplete(jobInfo);
+    const fixCase = (s) => s?.charAt(0).toUpperCase() + s?.slice(1).toLowerCase();
+
+    if (message) return message;
+    if (totalItems > 0) return `${itemsProcessed} of ${totalItems} processed`;
+    if (pct > 0) return `${pct}% complete`;
+    return `${fixCase(jobInfo?.phase ?? '')}...`;
+}
+
 export const SCRIPT_ATTRIB = new Enum(['URLList', 'Unzip', 'Ditto', 'Curl', 'Wget', 'RemoveZip']);
 
 export function doPackageRequest({dlRequest, searchRequest, selectInfo, bgKey, downloadType, onComplete}) {
@@ -223,8 +249,8 @@ function bgTracker(action, cancelSelf, params={}) {
     if ( type === BG_JOB_INFO && jobInfo?.meta?.jobId === jobId) {
         if (isDone(jobInfo)) {
             cancelSelf();
-            dispatchComponentStateChange(key, {inProgress:false});
             onComplete?.(jobInfo);
+            dispatchComponentStateChange(key, {inProgress:false});
         }
     } else if (getComponentState(key)?.hide) {
         cancelSelf();

--- a/src/firefly/js/core/background/BgMaskPanel.jsx
+++ b/src/firefly/js/core/background/BgMaskPanel.jsx
@@ -1,12 +1,12 @@
 import React, {useEffect} from 'react';
 import {bool, string, func, object, element} from 'prop-types';
-import {Button, LinearProgress, Skeleton, Stack, Typography} from '@mui/joy';
+import {Button, Skeleton, Stack, Typography} from '@mui/joy';
 
 import {dispatchComponentStateChange, getComponentState} from '../ComponentCntlr.js';
 import {useStoreConnector, Slot} from '../../ui/SimpleComponent.jsx';
 import {Logger} from '../../util/Logger.js';
-import {showJobInfo} from './JobInfo.jsx';
-import {getJobInfo, isActive} from './BackgroundUtil.js';
+import {JobProgress, showJobInfo} from './JobInfo.jsx';
+import {getJobInfo} from './BackgroundUtil.js';
 import {InfoButton} from 'firefly/visualize/ui/Buttons.jsx';
 import {showJobMonitor} from './JobMonitor';
 import {dispatchJobRemove} from './BackgroundCntlr';
@@ -49,11 +49,11 @@ export const BgMaskPanel = React.memo(({componentKey, onMaskComplete, mask, show
         doHide();
     };
 
-    const msg = jobInfo?.errorSummary?.message || jobInfo?.jobInfo?.progressDesc || 'Working...';
+    const msg = jobInfo?.errorSummary?.message;
     logger.debug(inProgress ? 'show' : 'hide');
     if (inProgress) {
         return (
-            <MaskP msg={msg} jobInfo={jobInfo} mask={mask} {...props}>
+            <MaskP jobInfo={jobInfo} mask={mask} {...props}>
                 <Stack direction='row' spacing={1}>
                     <Button variant='solid' disabled={!jobInfo} color='primary' onClick={doHide}>Send to background</Button>
                     <Button variant='solid' disabled={!jobInfo} color='primary' onClick={doShowMonitor}>Job Monitor</Button>
@@ -78,16 +78,14 @@ function MaskP({msg, jobInfo, children, mask=<Skeleton/>, ...props}) {
             {mask}
             <Stack whiteSpace='nowrap' position='absolute' zIndex={10} top='50%' left='50%' spacing={2} sx={{transform: 'translate(-50%, -50%)'}}>
                 <Stack direction='row' alignItems='center' justifyContent='center' spacing={1}>
-                    <Stack >
-                        <Typography level='title-md' color='warning' fontStyle='italic' noWrap={true}>{msg}</Typography>
-                        {isActive(jobInfo) && <LinearProgress color='neutral'/>}
-                    </Stack>
+                    {<JobProgress jobInfo={jobInfo}/> ||
+                     <Typography level='title-md' color='warning' fontStyle='italic' noWrap={true}>{msg}</Typography>
+                    }
                     <InfoButton enabled={!!jobInfo} onClick={showInfo}/>
                 </Stack>
                 {children}
             </Stack>
         </Slot>
-
     );
 }
 

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 
-import {getJobInfo, getMetadata, isTapJob, isUWS} from './BackgroundUtil.js';
-import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+import {getElapsedTime, getJobInfo, getJobPctComplete, getMetadata, getProgressMsg, isActive, isTapJob, isUWS} from './BackgroundUtil.js';
+import {Slot, useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {KeywordBlock} from '../../tables/ui/TableInfo.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
@@ -9,7 +9,7 @@ import {dispatchHideDialog, dispatchShowDialog, isDialogVisible} from '../Compon
 import {HelpIcon} from '../../ui/HelpIcon.jsx';
 import {CollapsibleItem, CollapsibleGroup} from '../../ui/panel/CollapsiblePanel.jsx';
 import {uwsJobInfo} from 'firefly/rpc/SearchServicesJson.js';
-import {Box, Card, Skeleton, Stack, Typography} from '@mui/joy';
+import {Box, Card, Grid, LinearProgress, Sheet, Skeleton, Stack, Typography} from '@mui/joy';
 import {TableErrorMsg} from 'firefly/tables/ui/TablePanel.jsx';
 import {showInfoPopup} from 'firefly/ui/PopupUtil';
 import {PrismADQLAware} from '../../ui/tap/AdvancedADQL';
@@ -84,8 +84,9 @@ export function JobInfo({jobId, ...props}) {
 }
 
 export function UwsJobInfo({jobInfo, sx, isOpen=false}) {
-    const {results, parameters, errorSummary, jobInfo:aux} = jobInfo;
+    const {results, parameters, errorSummary} = jobInfo;
     const hrefs = results?.map((r) => r.href);
+    const {progress, ...aux} = jobInfo?.jobInfo ?? {};
     const hasMoreSection = hrefs || parameters || errorSummary || aux;
     const resultRenderer = () => <ResultsBlock job={jobInfo} ActionBtn={CopyHref}/>;
     return (
@@ -105,11 +106,39 @@ export function UwsJobInfo({jobInfo, sx, isOpen=false}) {
     );
 }
 
-const toDate = (d) => d && new Date(d);
+export function JobProgress({jobInfo, ...props}) {
+    const [elapsed, setElapsed] = useState(0);
+    const msg = getProgressMsg(jobInfo);
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setElapsed(getElapsedTime(jobInfo)); // triggers re-render
+        }, 1000);
+
+        return () => clearInterval(interval);
+    }, [jobInfo]);
+
+    if (!isActive(jobInfo)) return null;
+
+    const pct = getJobPctComplete(jobInfo);
+    const lpProps =  pct >= 0 ? {determinate:true, value:pct} : {size:'md'};
+    return (
+        <Slot component={Sheet} variant='soft' sx={{flexGrow:1, padding:1}} slotProps={{...props}}>
+            <Stack direction='row' spacing={1} alignItems='center'>
+                <Typography level='title-sm' >Progress:</Typography>
+                <LinearProgress variant='outlined' {...lpProps}/>
+            </Stack>
+            <Stack direction='row' spacing={1}>
+                <Typography level='body-xs' color='warning' sx={{fontVariantNumeric: 'tabular-nums'}}> {elapsed} — </Typography>
+                <Typography level='body-xs' fontStyle='italic' title={msg} sx={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',}}> {msg} </Typography>
+            </Stack>
+        </Slot>
+    );
+}
 
 function JobInfoDetails({jobInfo={}}) {
     const useLocalTime = useStoreConnector(() => getFieldVal(jobMonitorGroupKey, useLocalTimeKey));
-
+    const toDate = (d) => d && new Date(d);
     const {ownerId, phase, executionDuration} = jobInfo;
     const startTime = toDate(jobInfo.startTime);
     const endTime = toDate(jobInfo.endTime);
@@ -120,22 +149,44 @@ function JobInfoDetails({jobInfo={}}) {
     const duration =  executionDuration ? executionDuration + 's' : '';
     const dateProps = {width: '18rem', justifyContent:'space-between'};
     return (
-        <Stack direction='row' spacing={4}>
-            <Stack>
+        <Grid container spacing={.5}>
+            <GridRow>
                 <KeywordBlock label='Phase' title='Referred to as "phase" in UWS' value={phase} mb={1}/>
-                <KeywordBlock label='Creation Time' title='Referred to as "creationTime" in UWS' value={toDateString(creationTime, useLocalTime)}  {...dateProps}/>
-                <KeywordBlock label='Start Time' title='Referred to as "startTime" in UWS' value={toDateString(startTime, useLocalTime)} {...dateProps}/>
-                <KeywordBlock label='End Time' title='Referred to as "endTime" in UWS' value={toDateString(endTime, useLocalTime)} {...dateProps}/>
-                <KeywordBlock label='Planned End Time' title='Referred to as "quote" in UWS' value={toDateString(quote, useLocalTime)} {...dateProps}/>
-                <KeywordBlock label='Destruction Time' title='Referred to as "destruction" in UWS' value={toDateString(destruction, useLocalTime)} {...dateProps}/>
-            </Stack>
-            <Stack>
                 <JobIdWrapper jobInfo={jobInfo}/>
+            </GridRow>
+            <GridRow>
+                <JobProgress jobInfo={jobInfo}/>
+            </GridRow>
+            <GridRow>
+                <KeywordBlock label='Creation Time' title='Referred to as "creationTime" in UWS' value={toDateString(creationTime, useLocalTime)}  {...dateProps}/>
                 <KeywordBlock label='Owner' title='Referred to as "ownerId" in UWS' value={ownerId}/>
+            </GridRow>
+            <GridRow>
+                <KeywordBlock label='Start Time' title='Referred to as "startTime" in UWS' value={toDateString(startTime, useLocalTime)} {...dateProps}/>
                 <KeywordBlock label='Run time limit' title='Referred to as "executionDuration" in UWS' value={duration}/>
+            </GridRow>
+            <GridRow>
+                <KeywordBlock label='End Time' title='Referred to as "endTime" in UWS' value={toDateString(endTime, useLocalTime)} {...dateProps}/>
                 <KeywordBlock label='Actual run time' title='The difference of the "End" and "Start" times.' value={actualRt}/>
-            </Stack>
-        </Stack>
+            </GridRow>
+            <GridRow>
+                <KeywordBlock label='Planned End Time' title='Referred to as "quote" in UWS' value={toDateString(quote, useLocalTime)} {...dateProps}/>
+            </GridRow>
+            <GridRow>
+                <KeywordBlock label='Destruction Time' title='Referred to as "destruction" in UWS' value={toDateString(destruction, useLocalTime)} {...dateProps}/>
+            </GridRow>
+        </Grid>
+    );
+}
+
+function GridRow({children}) {
+    const [left, right] = React.Children.toArray(children);
+    const lw = right ? 7 : 12;
+    return (
+        <>
+            <Grid xs={lw}>{left}</Grid>
+            {right && <Grid xs={5}>{right}</Grid>}
+        </>
     );
 }
 

--- a/src/firefly/js/core/background/JobMonitor.jsx
+++ b/src/firefly/js/core/background/JobMonitor.jsx
@@ -4,7 +4,7 @@ import {IconButton, Button, Sheet, Stack, Typography, ListItemDecorator, Tab} fr
 import moment from 'moment';
 
 import {Slot, useStoreConnector} from '../../ui/SimpleComponent';
-import {getBackgroundInfo, getJobInfo, getJobTitle, getMetadata, getPhaseTips, isActive, isArchived, isDone, isExecuting, isFail, isSearchJob, isSuccess, loadAllJobs, handleJobResult, Phase, loadJobResult, fixTapResults} from './BackgroundUtil';
+import {getBackgroundInfo, getJobInfo, getJobTitle, getMetadata, getPhaseTips, isActive, isArchived, isDone, isExecuting, isFail, isSearchJob, isSuccess, loadAllJobs, Phase, loadJobResult, fixTapResults, getProgressMsg} from './BackgroundUtil';
 import {TablePanel} from '../../tables/ui/TablePanel';
 import {getAppOptions} from '../AppDataCntlr';
 import {dispatchBgJobInfo, dispatchBgSetInfo, dispatchJobCancel, dispatchJobRemove, dispatchSetJobNotif} from './BackgroundCntlr';
@@ -271,8 +271,7 @@ function PhaseRenderer({cellInfo}) {
 
 function ControlRenderer({cellInfo}) {
     const {value:jobId} = cellInfo;
-    const job = getJobInfo(jobId);
-    // const job = useStoreConnector(() => getJobInfo(jobId), [jobId]);
+    const job = useStoreConnector(() => getJobInfo(jobId), [jobId]);
     if (!job?.meta?.jobId) return null;
 
     return  (
@@ -307,9 +306,10 @@ function InfoPopup({job}) {
 
 function Progress({job}) {
     if (!Phase.EXECUTING.is(job?.phase)) return null;
+    const progress = getProgressMsg(job);
     return(
         <>
-            <Button loading title={job?.meta?.progressDesc} variant='plain' color='success'/>
+            <Button loading title={progress} variant='plain' color='success'/>
             <NotifBtn jobId={job.meta?.jobId} enable={job.meta?.sendNotif}/>
         </>
     );

--- a/src/firefly/js/core/core-typedefs.jsdoc
+++ b/src/firefly/js/core/core-typedefs.jsdoc
@@ -153,6 +153,16 @@
  * @prop {string} userId        Firefly user ID associated with the job
  * @prop {string} userName      Firefly username associated with the job
  * @prop {string} userEmail     email associated with the job
+ * @prop {Progess} progress     Job progress information
+ */
+
+/**
+ * Internal job information.  Used by Firefly to manage the job.
+ * @typedef {Object} Progess
+ * @prop {int} percentComplete  progress of the job as a percentage.  0-100, where 100 is done
+ * @prop {int} totalItems       total number of items to process.  -1 means unknown or unlimited
+ * @prop {int} itemsProcessed   number of items processed so far
+ * @prop {string} message       a description of the current progress
  */
 
 /**
@@ -164,8 +174,6 @@
  * @prop {string} type          type of job. One of SEARCH, UWS, TAP, PACKAGE, SCRIPT
  * @prop {string} svcId         an identifier for the service that this job is associated with
  * @prop {boolean} monitored    true if UI is monitoring the job
- * @prop {number} progress      progress of the job as a percentage.  0-100, where 100 is done
- * @prop {string} progressDesc  a description of the current progress
  * @prop {string} summary       summary of the job
  * @prop {boolean} sendNotif    if true, send notification when job is done
  */

--- a/src/firefly/test/edu/caltech/ipac/firefly/core/background/JobUtilTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/core/background/JobUtilTest.java
@@ -3,6 +3,9 @@
  */
 package edu.caltech.ipac.firefly.core.background;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.firefly.core.Util;
 import edu.caltech.ipac.firefly.server.query.UwsJobProcessor;
@@ -17,8 +20,9 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.util.List;
 
-import static edu.caltech.ipac.firefly.core.background.JobManager.updateJobInfo;
 import static edu.caltech.ipac.firefly.core.background.JobUtil.mergeJobInfo;
+import static edu.caltech.ipac.firefly.core.background.JobUtil.toJsonJobList;
+import static edu.caltech.ipac.util.serialization.Serializer.getJsonMapper;
 import static org.junit.Assert.*;
 
 /**
@@ -30,12 +34,49 @@ public class JobUtilTest extends ConfigTest {
     static Logger.LoggerImpl logger = Logger.getLogger();
     static List<JobInfo> jobs;
     static String xmlJobList;
+    static String xmlJob;
 
     @BeforeClass
     public static void setUp() {
         // needed when dealing with code running in a server's context, ie  SearchProcessor, RequestOwner, etc.
         setupServerContext(null);
         Logger.setLogLevel(Level.DEBUG);
+
+        xmlJob = """
+                <uws:job version="1.1" xsi:schemaLocation="http://www.ivoa.net/xml/UWS/v1.0 UWS.xsd" 
+                                       xmlns:xml="http://www.w3.org/XML/1998/namespace" 
+                                       xmlns:uws="http://www.ivoa.net/xml/UWS/v1.0" 
+                                       xmlns:xlink="http://www.w3.org/1999/xlink" 
+                                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uwsc="urn:uwscustom">
+                <uws:jobId>1242749568029</uws:jobId>
+                <uws:runId>myjobref</uws:runId>
+                <uws:ownerId xsi:nil="true"/>
+                <uws:phase>COMPLETED</uws:phase>
+                <uws:creationTime>2009-05-19T17:01:44.038Z</uws:creationTime>
+                <uws:startTime>2009-05-19T17:12:48.038Z</uws:startTime>
+                <uws:endTime>2009-05-19T17:12:49.041Z</uws:endTime>
+                <uws:executionDuration>86400</uws:executionDuration>
+                <uws:destruction>2009-05-29T17:12:48.035Z</uws:destruction>
+                <uws:parameters>
+                <uws:parameter id="scaleFactor">1.8</uws:parameter>
+                <uws:parameter id="image" byReference="true"> http://myserver.org/uws/jobs/jobid123/param/image</uws:parameter>
+                </uws:parameters>
+                <uws:results>
+                <uws:result id="correctedImage" xlink:href="http://myserver.org/uws/jobs/jobid123/result/image" size="3000960" mime-type="image/fits" uwsc:anyattribute="a custom attribute"/>
+                </uws:results>
+                <uws:errorSummary type="transient" hasDetail="true">
+                <uws:message>we have problem</uws:message>
+                </uws:errorSummary>
+                <uws:jobInfo>
+                    <progress>
+                        <percentComplete>77</percentComplete>
+                        <message>77 of 100 items processed</message>
+                        <itemsProcessed>77</itemsProcessed>
+                        <totalItems>100</totalItems>
+                    </progress>
+                </uws:jobInfo>
+                </uws:job>
+        """.stripIndent();
 
         xmlJobList = """
             <uws:jobs xmlns:uws="http://www.ivoa.net/xml/UWS/v1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -152,6 +193,29 @@ public class JobUtilTest extends ConfigTest {
     }
 
     @Test
+    public void parseUwsJob() throws Exception {
+        JobInfo uwsJob = UwsJobProcessor.convertToJobInfo(UwsJobProcessor.parse( new ByteArrayInputStream(xmlJob.getBytes())));
+        assertEquals(uwsJob.getJobId(), "1242749568029");
+        assertEquals(uwsJob.getCreationTime().toString(), "2009-05-19T17:01:44.038Z");
+        assertEquals(uwsJob.getStartTime().toString(), "2009-05-19T17:12:48.038Z");
+        assertEquals(uwsJob.getEndTime().toString(), "2009-05-19T17:12:49.041Z");
+        assertEquals(uwsJob.getExecutionDuration(), 86400);
+        assertEquals(uwsJob.getParameters().get("scaleFactor"), "1.8");
+        assertEquals(uwsJob.getParameters().get("image"), "http://myserver.org/uws/jobs/jobid123/param/image");
+        assertEquals(uwsJob.getResults().getFirst().id(), "correctedImage");
+        assertEquals(uwsJob.getResults().getFirst().href(), "http://myserver.org/uws/jobs/jobid123/result/image");
+        assertEquals(uwsJob.getResults().getFirst().size(), "3000960");
+        assertEquals(uwsJob.getResults().getFirst().mimeType(), "image/fits");
+        assertEquals(uwsJob.getErrorSummary().message(), "we have problem");
+        assertEquals(uwsJob.getErrorSummary().type(), "transient");
+        assertTrue(uwsJob.getErrorSummary().hasDetail());
+        assertEquals(uwsJob.getAux().getProgress().percentComplete(), 77);
+        assertEquals(uwsJob.getAux().getProgress().message(), "77 of 100 items processed");
+        assertEquals(uwsJob.getAux().getProgress().itemsProcessed(), 77);
+        assertEquals(uwsJob.getAux().getProgress().totalItems(), 100);
+    }
+
+    @Test
     public void parseUwsJobs() throws Exception {
         List<JobInfo> uwsJobs = UwsJobProcessor.convertToJobList( UwsJobProcessor.parse( new ByteArrayInputStream(xmlJobList.getBytes())), "http://example.org/uws/jobs");
         assertEquals(2, uwsJobs.size());
@@ -159,6 +223,19 @@ public class JobUtilTest extends ConfigTest {
         assertEquals("http://example.org/uws/jobs/job-001", uwsJobs.get(0).getAux().getJobUrl());
         assertEquals("job-002", uwsJobs.get(1).getJobId());
         assertEquals("http://example.org/uws/jobs/job-002", uwsJobs.get(1).getAux().getJobUrl());
+
+        String userJobs = toJsonJobList(uwsJobs, true);
+        ObjectMapper mapper = getJsonMapper();
+        JsonNode root = Util.Try.it(() -> mapper.readTree(userJobs)).get();
+        boolean overflow = root.get("overflow").asBoolean();
+        List<JobInfo> jobs = mapper.convertValue(root.get("jobs"), new TypeReference<List<JobInfo>>() {});
+        assertTrue(overflow);
+        assertEquals(2, jobs.size());
+        assertEquals("job-001", jobs.get(0).getJobId());
+        assertEquals("http://example.org/uws/jobs/job-001", jobs.get(0).getAux().getJobUrl());
+        assertEquals("job-002", jobs.get(1).getJobId());
+        assertEquals("http://example.org/uws/jobs/job-002", jobs.get(1).getAux().getJobUrl());
+
     }
 
     @Test

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/AsyncTapQueryTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/AsyncTapQueryTest.java
@@ -33,9 +33,10 @@ public class AsyncTapQueryTest extends ConfigTest {
 
 			DataGroup results = new AsyncTapQuery().fetchDataGroup(req);
 
+			// uws job returns an obscore table as the resulting table.  It may contain more than one mixed data products.
 			Assert.assertTrue("has results", results.size() > 0);
-			Assert.assertNotNull("has ra", results.getDataDefintion("ra"));
-			Assert.assertNotNull("has dec", results.getDataDefintion("dec"));
+			Assert.assertNotNull("has access_url", results.getDataDefintion("access_url"));
+			Assert.assertNotNull("has dataproduct_type", results.getDataDefintion("dataproduct_type"));
 
 		} catch (Exception e) {
 			Assert.fail("testExecRequestQuery failed with exception: " + e.getMessage());

--- a/src/firefly/test/edu/caltech/ipac/util/serialization/SerializerTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/serialization/SerializerTest.java
@@ -43,7 +43,6 @@ public class SerializerTest {
                   "creationTime": "2025-01-01T10:00:00Z",
                   "meta": {
                     "summary": "Running",
-                    "progress": 50,
                     "sendNotif": false,
                     "monitored": false
                   },
@@ -66,7 +65,13 @@ public class SerializerTest {
                   ],
                   "jobInfo": {
                     "jobUrl": "http://example/job/123",
-                    "userName": "Jane Doe"
+                    "userName": "Jane Doe",
+                    "progress": {
+                        "percentage": 75,
+                        "itemsProcessed": 75,
+                        "totalItems": 100,
+                        "message": "Processing"
+                    }
                   }
                 }
             """;
@@ -87,12 +92,12 @@ public class SerializerTest {
         assertNotNull(json);
         assertNotNull(msgpack);
         assertNotNull(base64);
-        // Size reduced from 476 to 367 (~23% smaller)
+        // Size reduced from 549 to 436 (~23% smaller)
         assertTrue(
                 "Expected MessagePack payload to be smaller than JSON",
                 msgpack.length < json.length
         );
-        // Size reduced from 2460 to 367 (~85% smaller)
+        // Size reduced from 2768 to 436 (~85% smaller)
         assertTrue(
                 "Expected MessagePack payload to be smaller than base64",
                 msgpack.length < base64.length()
@@ -116,8 +121,8 @@ public class SerializerTest {
         assertEquals(original.getExecutionDuration(), decoded.getExecutionDuration());
         assertEquals(original.getParameters(), decoded.getParameters());
         assertEquals(
-                original.getMeta().getProgress(),
-                decoded.getMeta().getProgress()
+                original.getAux().getProgress(),
+                decoded.getAux().getProgress()
         );
         assertEquals(
                 original.getAux().getUserName(),
@@ -138,10 +143,6 @@ public class SerializerTest {
 
         assertEquals(original.getJobId(), decoded.getJobId());
         assertEquals(original.getPhase(), decoded.getPhase());
-        assertEquals(
-                original.getMeta().getSummary(),
-                decoded.getMeta().getSummary()
-        );
     }
 
     @Test


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-1770

Firefly currently stores job progress in a custom field within the UWS job. This change updates the implementation to persist progress data under the standard <progress> element inside <uws:jobInfo>, making it the official and standard location for tracking UWS job progress in Firefly.

**UI Behavior**
- A determinate LinearProgress is used when a percentage complete can be computed.
- An indeterminate LinearProgress is used when percentage information is unavailable.
- In both cases, the UI displays:
  - Elapsed time
  - A status message from the <progress> block
- If no progress message is provided, the job phase is displayed instead.

**Testing**
https://firefly-1770-progress-ui.irsakubedev.ipac.caltech.edu/irsaviewer/
https://firefly-1770-progress-ui.irsakubedev.ipac.caltech.edu/applications/spherex/

- Submit any background job to verify that progress appears in the mask panel.
- Click the info **(“i”)** icon to open the Job Info dialog.
- Confirm that:
  - Full job details are displayed
  - Progress information is rendered across the dialog