### PR TITLE
IRSA-7589: Allow errorSummary to exist even when the phase is not Error

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/Job.java
@@ -65,11 +65,13 @@ public interface Job extends Callable<String> {
             updateJobInfo(getJobId(), ji -> {
                 ji.setPhase(JobInfo.Phase.ABORTED);
                 ji.getAux().setProgress(new JobInfo.Progress("Job was aborted"));
+                ji.setErrorSummary(new JobInfo.ErrorSummary("Job was aborted", "fatal", false   ));
             });
             getWorker().onAbort();
         } catch (Exception e) {
             updateManagedStatus(ji -> {
                 String msg = combineErrorMsg(e.getMessage(), e.getCause() == null ? null : e.getCause().getMessage());
+                ji.setPhase(JobInfo.Phase.ERROR);
                 ji.setErrorSummary(new JobInfo.ErrorSummary(msg));
             });
             Logger.getLogger().error(e);

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
@@ -134,7 +134,6 @@ public class JobInfo implements Serializable {
     }
 
     public void setErrorSummary(ErrorSummary errorSummary) {
-        setPhase(Phase.ERROR);
         this.errorSummary = errorSummary;
     }
 
@@ -232,7 +231,7 @@ public class JobInfo implements Serializable {
 
     public record ErrorSummary(String message, String type, boolean hasDetail) implements Serializable {
         public ErrorSummary(String message) {
-            this(message, "transient", true);
+            this(message, "fatal", false);
         }
     }
     public record Result(String id, String href, String mimeType, String size) implements Serializable {};

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobManager.java
@@ -170,6 +170,7 @@ public class JobManager {
         } catch (Exception e) {
             // job run() handles exceptions; this only happens if submit or future.get() fails
             sendUpdate(jobId, (ji) -> {
+                ji.setPhase(ERROR);
                 ji.setErrorSummary(new ErrorSummary(e.getMessage()));
             });
             LOG.error(e);
@@ -184,8 +185,8 @@ public class JobManager {
 
     public static JobInfo abort(String jobId, String reason) {
         JobInfo info = updateJobInfo(jobId, (ji) -> {
-            if (reason != null) ji.setErrorSummary(new ErrorSummary(reason));
             ji.setPhase(ABORTED);
+            if (reason != null) ji.setErrorSummary(new ErrorSummary(reason));
         });
         if (info != null) {
             Messenger.publish(new JobEvent(JobEvent.EventType.ABORTED, info));      // notify all instances AFTER jobInfo is updated

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
@@ -290,9 +290,10 @@ public class JobUtil {
 
         ifNotNull(json.get(ERROR_SUMMARY)).apply(v -> {
             if (v instanceof JSONObject jo) {
-                int code = getInt(jo.get(ERROR_TYPE), 500);
+                String type = getStr(jo, ERROR_TYPE);
+                boolean hasDetails = Boolean.parseBoolean(String.valueOf(jo.get(ERROR_HAS_DETAILS)));
                 String msg = String.valueOf(jo.get(ERROR_MSG));
-                rval.setErrorSummary(new ErrorSummary(msg));
+                rval.setErrorSummary(new ErrorSummary(msg, type, hasDetails));
             }
         });
         ifNotNull(json.get(META)).apply(v -> {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -164,7 +164,10 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
                     results = EmbeddedDbUtil.toDataGroupPart(dg, treq);
                     String error = dbAdapter.handleSqlExp("", e).getCause().getMessage(); // get the message describing the cause of the exception.
                     results.setErrorMsg(error);
-                    sendJobUpdate(ji -> ji.setErrorSummary( new JobInfo.ErrorSummary(error)));      // because an error table is returned
+                    sendJobUpdate(ji -> {
+                        ji.setPhase(JobInfo.Phase.ERROR);
+                        ji.setErrorSummary( new JobInfo.ErrorSummary(error));       // because an error table is returned
+                    });
                 } else {
                     throw e;
                 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -99,6 +99,7 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
         if (status.isError()) {
             logger.warn(status.getErrMsg());
             sendJobUpdate(ji -> {
+                ji.setPhase(Phase.ERROR);
                 ji.setErrorSummary(new ErrorSummary(status.getErrMsg()));
             });
         } else {
@@ -128,6 +129,7 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
             }
         } catch (Exception e) {
             updateJob(ji -> {
+                ji.setPhase(Phase.ERROR);
                 ji.setErrorSummary(new ErrorSummary(e.getMessage()));
             });
             throw new DataAccessException(e.getMessage());
@@ -144,7 +146,10 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
                 JobInfo uwsJob = getUwsJobInfo(jobUrl);
                 if (uwsJob == null) {
                     String msg = "Failed to retrieve UWS job info";
-                    sendJobUpdate(ji -> ji.setErrorSummary(new ErrorSummary(msg)));
+                    sendJobUpdate(ji -> {
+                        ji.setPhase(Phase.ERROR);
+                        ji.setErrorSummary(new ErrorSummary(msg));
+                    });
                     throw new DataAccessException(msg);
                 }
                 try {
@@ -162,9 +167,12 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
                         case Phase.ERROR:
                             throw new DataAccessException("Job has failed with the error: " + uwsJob.getErrorSummary().message());
                         case Phase.UNKNOWN: {
-                            if (cnt > 20) {
-                                updateJob(ji -> ji.setErrorSummary(new ErrorSummary("Unknown phase for over 20 seconds")));
-                                throw new DataAccessException("Unknown phase for over 20 seconds");
+                            if (cnt > 70) {
+                                updateJob(ji -> {
+                                    ji.setPhase(Phase.ABORTED);
+                                    ji.setErrorSummary(new ErrorSummary("Job aborted: unknown phase for over 2 minutes"));
+                                });
+                                throw new DataAccessException("Job aborted: unknown phase for over 2 minutes");
                             }
                         }
                         default:

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -318,8 +318,9 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
             }
         });
         if (status.isError()) throw createDax("Fail to fetch UWS job info", jobUrl, status.getException());
-
-        return jInfo.get();
+        JobInfo jobInfo = jInfo.get();
+        if (jobInfo != null) jobInfo.getAux().setJobUrl(jobUrl);
+        return jobInfo;
     }
 
     public static Phase getPhase(String jobUrl) throws DataAccessException {

--- a/src/firefly/js/core/background/JobInfo.jsx
+++ b/src/firefly/js/core/background/JobInfo.jsx
@@ -1,8 +1,8 @@
 import React, {useEffect, useState} from 'react';
 
-import {getElapsedTime, getJobInfo, getJobPctComplete, getMetadata, getProgressMsg, isActive, isTapJob, isUWS} from './BackgroundUtil.js';
+import {getElapsedTime, getJobInfo, getJobPctComplete, getProgressMsg, isActive, isTapJob, isUWS} from './BackgroundUtil.js';
 import {Slot, useStoreConnector} from '../../ui/SimpleComponent.jsx';
-import {KeywordBlock} from '../../tables/ui/TableInfo.jsx';
+import {KeywordBlockOpt, KeywordBlock} from '../../tables/ui/TableInfo.jsx';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
 import {dispatchHideDialog, dispatchShowDialog, isDialogVisible} from '../ComponentCntlr.js';
@@ -15,7 +15,6 @@ import {showInfoPopup} from 'firefly/ui/PopupUtil';
 import {PrismADQLAware} from '../../ui/tap/AdvancedADQL';
 import {getFieldVal} from '../../fieldGroup/FieldGroupUtils';
 import {jobMonitorGroupKey, ResultsBlock, toDateString, useLocalTimeKey} from '../../core/background/JobMonitor';
-import {CopyToClipboard} from 'firefly/visualize/ui/MouseReadout';
 
 const dialogID = 'show-job-info';
 
@@ -88,7 +87,6 @@ export function UwsJobInfo({jobInfo, sx, isOpen=false}) {
     const hrefs = results?.map((r) => r.href);
     const {progress, ...aux} = jobInfo?.jobInfo ?? {};
     const hasMoreSection = hrefs || parameters || errorSummary || aux;
-    const resultRenderer = () => <ResultsBlock job={jobInfo} ActionBtn={CopyHref}/>;
     return (
         <Stack spacing={1} p={1} sx={sx}>
             <JobInfoDetails jobInfo={jobInfo}/>
@@ -96,9 +94,9 @@ export function UwsJobInfo({jobInfo, sx, isOpen=false}) {
             {/*{ meta?.runId && <KeywordBlock key='localRunId' label='local runId' value={meta.runId}/>}*/}
             { hasMoreSection && (
                 <CollapsibleGroup>
-                    <OptionalBlock label='Error Summary' title='Referred to as "errorSummary" in UWS' value={errorSummary} isOpen={isOpen}/>
+                    <OptionalBlock label='Error Summary' title='Referred to as "errorSummary" in UWS' value={errorSummary} Component={ErrorBlock} job={jobInfo} isOpen={isOpen}/>
                     <OptionalBlock label='Parameters' title='Referred to as "parameters" in UWS' value={parameters} isOpen={isOpen}/>
-                    <OptionalBlock label='Results' title='Referred to as "results" in UWS' value={hrefs} Component={resultRenderer} isOpen={isOpen}/>
+                    <OptionalBlock label='Results' title='Referred to as "results" in UWS' value={results} Component={ResultsBlock} job={jobInfo} isOpen={isOpen}/>
                     <OptionalBlock label='Extra Information' title='Referred to as "jobInfo" in UWS' value={aux} isOpen={isOpen}/>
                 </CollapsibleGroup>
             )}
@@ -223,31 +221,41 @@ function JobIdWrapper({jobInfo}) {
     return <KeywordBlock value={jobId} mb={1} asLink={!!href} {...{href, label, title}} />;
 }
 
-function OptionalBlock({label, value, asLink, isOpen, Component=KeyValueBlock}) {
+function OptionalBlock({label, value, asLink, isOpen, Component=KeyValueBlock, ...rest}) {
     if (!value) return null;
     return (
         <CollapsibleItem componentKey={`JobInfo-${label}`} header={label} isOpen={isOpen}>
             <Stack spacing={.5}>
-                <Component asLink={asLink} value={value}/>
+                <Component asLink={asLink} value={value} {...rest}/>
             </Stack>
         </CollapsibleItem>
     );
 }
 
-function CopyHref({job, resultIdx=0}) {
-    const {href} = getMetadata({jobInfo:job, resultIdx});
-    return <CopyToClipboard value={href} size={16} buttonStyle={{backgroundColor: 'unset'}} style={{alignSelf: 'end'}}/>
+export function ErrorBlock({job}) {
+    if (!job?.errorSummary) return null;
+    const {message, type, hasDetail=[]} = job.errorSummary;
+    const detailUrl = hasDetail && job.jobInfo?.jobUrl && `${job.jobInfo?.jobUrl}/error`;
+    return (
+        <>
+            <KeywordBlockOpt label='Message' title={message} value={message}/>
+            <Stack direction='row' alignItems='baseline' spacing={1} overflow='hidden'>
+                <KeywordBlockOpt label='Type' value={type}/>
+                <KeywordBlockOpt label='Details' value={detailUrl} asLink={true} overflow='hidden'/>
+            </Stack>
+        </>
+    );
 }
 
 // value can be an object with string values or an array of strings.
 // If a value contains the ':::' delimiter, it will be split into multiple values with the same key.
-function KeyValueBlock({asLink, value}) {
+function KeyValueBlock({asLink, value, ...rest}) {
     return (
         <>
             {Object.entries(value).map(([k, v]) =>
                 String(v).split(':::').map((val, idx) => {           // matches ':::' delimiter used by Server's JobInfo.parameters
                     const isLink = asLink ?? /^https?:\/\//.test(val?.toLowerCase?.());
-                    return <KeywordBlock key={k+idx} label={k} value={val} asLink={isLink}/>;
+                    return <KeywordBlock key={k+idx} label={k} value={val} asLink={isLink} {...rest}/>;
                 })
             )}
         </>

--- a/src/firefly/js/core/background/JobMonitor.jsx
+++ b/src/firefly/js/core/background/JobMonitor.jsx
@@ -34,6 +34,7 @@ import {getFieldVal} from 'firefly/fieldGroup/FieldGroupUtils';
 import {AppPropertiesCtx} from 'firefly/ui/AppPropertiesCtx';
 import InsightsIcon from '@mui/icons-material/Insights';
 import {FormWatcher} from 'firefly/templates/router/RouteHelper';
+import {KeywordBlockOpt} from 'firefly/tables/ui/TableInfo';
 
 export const jobMonitorPath = '/jobMonitor';
 export const jobMonitorGroupKey = 'jobMonitor';
@@ -367,18 +368,18 @@ export function showMultiMultiResults(job) {
             <Stack gap={1} mb={2}>
                 <Typography level={'body-md'}>This job has multiple results. Please click on each icon to load the corresponding result.</Typography>
                 <Stack>
-                    <ResultsBlock job={job}/>
+                    <ResultsBlock job={job} ActionBtn={ShowResultButton}/>
                 </Stack>
             </Stack>
         );
     }
 }
 
-export function ResultsBlock({job, ActionBtn=ShowResultButton}) {
+export function ResultsBlock({job, ActionBtn}) {
     const {results=[]} = job;
     return results.map( (r, idx) => (
-        <Stack key={idx} direction='row' alignItems='center' gap={2}>
-            <ActionBtn job={job} resultIdx={idx}/>
+        <Stack key={idx} direction='row' alignItems='baseline' gap={1} overflow='hidden'>
+            {ActionBtn && <ActionBtn job={job} resultIdx={idx}/>}
             <ResultDesc job={job} resultIdx={idx}/>
         </Stack>
     ));
@@ -386,19 +387,12 @@ export function ResultsBlock({job, ActionBtn=ShowResultButton}) {
 
 export function ResultDesc({job, resultIdx=0}) {
     const {href, id, mimeType} = getMetadata({jobInfo:job, resultIdx});
+    const idDesc = id || resultIdx;
     return (
-        <Stack direction='row' gap={1} maxWidth='25em'>
-            <Typography level='body-sm'>
-                <Typography fontWeight='bold'>id=</Typography>{id || {resultIdx}}
-            </Typography>
-            {mimeType &&
-                <Typography level='body-sm'>
-                    <Typography fontWeight='bold'>mimeType=</Typography>{mimeType}
-                </Typography>
-            }
-            <Typography level='body-sm' title={href} sx={{overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}>
-                <Typography fontWeight='bold'>href=</Typography>{href}
-            </Typography>
+        <Stack direction='row' gap={1} overflow='hidden'>
+            <KeywordBlockOpt label='id' value={idDesc} title={idDesc}/>
+            <KeywordBlockOpt label='mimeType' value={mimeType} title={mimeType}/>
+            <KeywordBlockOpt label='href' value={href} title={href} asLink={true} overflow='hidden'/>
         </Stack>
     );
 }

--- a/src/firefly/js/tables/ui/TableInfo.jsx
+++ b/src/firefly/js/tables/ui/TableInfo.jsx
@@ -158,6 +158,16 @@ const ShowObjectTreeBtn = ({data, title}) => {
     );
 };
 
+/**
+ * renders a keyword block if value is not empty, otherwise returns null
+ * @param p - props
+ * @param p.value - if this is empty, then nothing will be rendered
+ * @param p.rest - the rest of the props get passed into Keyword component
+ */
+export function KeywordBlockOpt({value, ...rest}) {
+    return value ? <KeywordBlock value={value} {...rest}/> : null;
+}
+
 export function KeywordBlock({label, value, title, asLink, href, ...props}) {
     return (
         <Slot component={Stack} direction='row' whiteSpace='nowrap' alignItems='baseline' slotProps={props}>

--- a/src/firefly/js/ui/FormPanel.jsx
+++ b/src/firefly/js/ui/FormPanel.jsx
@@ -49,7 +49,7 @@ export const FormPanel = function ({groupKey, onSuccess, onError, onCancel, canc
 
     return (
         <Stack component={Sheet} className='ff-FormPanel' spacing={1} p={1} height={1} {...rootProps}>
-            <Slot component={Stack} flexGrow={1} slotProps={slotProps?.input}>
+            <Slot component={Stack} flexGrow={1} overflow='auto' slotProps={slotProps?.input}>
                 {children}
             </Slot>
             <Slot component={Stacker} endDecorator={searchBarEnd} slotProps={slotProps?.searchBar}>


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/IRSA-7589

When Firefly imports a UWS job via URL, it currently treats the presence of an `<errorSummary>` element as an indication of failure and forces the job phase to ERROR.

The presence of an `<errorSummary>` element is not necessarily indicative of a failed job, as it may be included irrespective of the job phase. When importing such jobs, Firefly should respect the phase reported by the service instead of forcing an ERROR state.

Test: https://irsa-7589-handle-errorsummary.irsakubedev.ipac.caltech.edu/irsaviewer/
- Upload -> Upload from URL
- Enter: https://irsa.ipac.caltech.edu/api/spherex/spectrophotometry/async/4c0b58d3-8c8a-40b2-987e-28c0dec0da72
- Click Upload

Verify that `Phase: COMPLETED` and `Error Summary` exists.

Also fixed in this PR:
- Scrollbar appeared when Job information overflow.  The `Load` button correctly rendered on the bottom left of the panel.