### PR TITLE
FIREFLY-1935: Alerts Template

### DIFF
--- a/src/firefly/html/alertviewer.html
+++ b/src/firefly/html/alertviewer.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <link rel="icon" type="image/x-icon" href="images/fftools-logo-16x16.png">
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <title>Alert Viewer</title>
+
+    <script>
+        var pOpts = window.firefly && window.firefly.options || {};
+        window.firefly = {
+            app: {
+                template: 'AlertViewer',           // set to app mode, instead of api.
+                appTitle: 'Alert Viewer',
+                menu: [
+                    {label:'Upload', action:'AlertUpload'},
+                    {label:'Help', action:'app_data.helpLoad', type:'COMMAND'},
+                ],
+            },
+            options : Object.assign(pOpts, {
+                wcsMatchType: 'Target',
+                defNorthUpLock: true,
+                charts: {
+                    singleTraceUI: true
+                }
+            })
+        };
+    </script>
+    <script  type="text/javascript" src="firefly_loader.js"></script>
+</head>
+
+<body style="margin: 0">
+<!-- attached location for firefly app -->
+<div id='app' style="width:100vw;height: 100vh"/>
+
+
+
+
+</body>
+
+</html>
+
+

--- a/src/firefly/html/alertviewer.html
+++ b/src/firefly/html/alertviewer.html
@@ -11,7 +11,7 @@
         var pOpts = window.firefly && window.firefly.options || {};
         window.firefly = {
             app: {
-                template: 'AlertViewer',           // set to app mode, instead of api.
+                template: 'AlertViewer',
                 appTitle: 'Alert Viewer',
                 menu: [
                     {label:'Upload', action:'AlertUpload'},

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -45,6 +45,7 @@ import {loadAllJobs} from './core/background/BackgroundUtil.js';
 import {
     makeDefImageSearchActions, makeDefTableSearchActions, makeDefTapSearchActions, makeExternalSearchActions
 } from './ui/DefaultSearchActions.js';
+import {AlertViewer} from 'firefly/templates/alert/AlertViewer';
 
 let initDone = false;
 const logger = Logger('Firefly-init');
@@ -64,6 +65,7 @@ export const Templates = {
     FireflyViewer,
     FireflySlate,
     LightCurveViewer : LcViewer,
+    AlertViewer,
     HydraViewer,
     [ROUTER]: ROUTER      // root component is passed in via getRouter
 };

--- a/src/firefly/js/templates/alert/AlertManager.js
+++ b/src/firefly/js/templates/alert/AlertManager.js
@@ -37,7 +37,7 @@ export const ALERT = {
     TABLE_PAGESIZE: MAX_ROW,
 };
 
-export function* alertManager({views='tables | images'} = {}) {
+export function* alertManager({views='tables | images | xyPlots'} = {}) {
     const viewMask = LO_VIEW.get(views) || LO_VIEW.none;
     yield fork(dropDownManager);
 

--- a/src/firefly/js/templates/alert/AlertManager.js
+++ b/src/firefly/js/templates/alert/AlertManager.js
@@ -1,0 +1,122 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import {take, fork} from 'redux-saga/effects';
+import {getAppOptions} from '../../core/AppDataCntlr.js';
+import {dispatchUpdateLayoutInfo, dropDownManager, getLayouInfo, LO_VIEW} from '../../core/LayoutCntlr.js';
+import {getTblIdsByGroup, smartMerge} from '../../tables/TableUtil.js';
+import {TBL_RESULTS_ADDED, TABLE_LOADED, TABLE_REMOVE, TBL_RESULTS_REMOVE} from '../../tables/TablesCntlr.js';
+import ImagePlotCntlr from '../../visualize/ImagePlotCntlr.js';
+import {visRoot} from 'firefly/visualize/ImagePlotCntlr';
+import {CHART_ADD, CHART_REMOVE, dispatchChartAdd, getChartData} from '../../charts/ChartsCntlr.js';
+import {getDefaultChartProps} from 'firefly/charts/ChartUtil';
+
+const MAX_ROW = Math.pow(2,31) - 1;
+
+export const ALERT = {
+    TABLE_GROUP_MAIN: 'main',
+    TABLE_GROUP_DETAILS: 'details',
+
+    TABLE_1_ID: 'alert_table_1',
+    TABLE_2_ID: 'alert_table_2',
+
+    IMG_VIEWER_1: 'alert_img_viewer_1',
+    IMG_VIEWER_2: 'alert_img_viewer_2',
+    IMG_VIEWER_3: 'alert_img_viewer_3',
+
+    IMG_PLOT_1: 'alert_plot_1',
+    IMG_PLOT_2: 'alert_plot_2',
+    IMG_PLOT_3: 'alert_plot_3',
+
+    CHART_VIEWER_1: 'alert_chart_viewer_1',
+    CHART_1_ID: 'alert_chart_1',
+
+    FG_UPLOAD: 'ALERT_UPLOAD',
+    MAX_IMAGE_CNT: 3,
+    TABLE_PAGESIZE: MAX_ROW,
+};
+
+export function* alertManager({views='tables | images'} = {}) {
+    const viewMask = LO_VIEW.get(views) || LO_VIEW.none;
+    yield fork(dropDownManager);
+
+    while (true) {
+        const action = yield take([
+            TBL_RESULTS_ADDED, TABLE_LOADED, TABLE_REMOVE, TBL_RESULTS_REMOVE, ImagePlotCntlr.PLOT_IMAGE, ImagePlotCntlr.PLOT_IMAGE_START,
+            ImagePlotCntlr.DELETE_PLOT_VIEW, CHART_ADD, CHART_REMOVE,
+        ]);
+
+        //chart creation trigger
+        if (action.type === TABLE_LOADED && action.payload?.tbl_id === ALERT.TABLE_1_ID) {
+            ensureMainChart();
+        }
+
+        const layoutInfo = getLayouInfo();
+        const next = computeLayout(layoutInfo, viewMask);
+
+        if (!next.coverageSide) next.coverageSide = getAppOptions()?.triViewCoverageSide;
+
+        if (next !== layoutInfo) {
+            dispatchUpdateLayoutInfo(next);
+        }
+    }
+}
+
+function computeLayout(layoutInfo, views) {
+    const hasTables = (getTblIdsByGroup(ALERT.TABLE_GROUP_MAIN) || []).length > 0;
+
+    const vr = visRoot();
+    const hasImages = Boolean(vr?.plotViewAry?.length);
+    const hasXyPlots = Boolean(layoutInfo?.hasXyPlots);
+
+    const showTables = hasTables && views.has(LO_VIEW.tables);
+    const showImages = hasImages && views.has(LO_VIEW.images);
+    const showXyPlots = hasXyPlots && views.has(LO_VIEW.xyPlots);
+
+    const count = [showTables, showImages, showXyPlots].filter(Boolean).length;
+    const closeable = count > 1;
+
+    //preserve expanded + standard; only patch missing defaults
+    let expanded = layoutInfo?.mode?.expanded ?? LO_VIEW.none;
+    const standard = layoutInfo?.mode?.standard ?? views;
+
+    // If expanded points to something no longer available, collapse it.
+    if (expanded !== LO_VIEW.none) {
+        const ok =
+            (expanded === LO_VIEW.tables && showTables) ||
+            (expanded === LO_VIEW.images && showImages) ||
+            (expanded === LO_VIEW.xyPlots && showXyPlots);
+        if (!ok) expanded = LO_VIEW.none;
+    }
+
+    const mode = {expanded, standard, closeable};
+
+    return smartMerge(layoutInfo, {
+        hasTables,
+        hasImages,
+        hasXyPlots,
+        showTables,
+        showImages,
+        showXyPlots,
+        autoExpand: false,
+        mode,
+    });
+}
+
+function ensureMainChart() {
+    //already created?
+    const existing = getChartData(ALERT.CHART_1_ID, null);
+    if (existing) return;
+
+    const def = getDefaultChartProps(ALERT.TABLE_1_ID);
+    if (!def) return;
+
+    dispatchChartAdd({
+        chartId: ALERT.CHART_1_ID,
+        viewerId: ALERT.CHART_VIEWER_1, //this matches MultiProductChoice chartViewerId
+        groupId: ALERT.TABLE_1_ID,  //group charts with that table
+        ...def,
+        deletable: false,
+    });
+}

--- a/src/firefly/js/templates/alert/AlertResultView.jsx
+++ b/src/firefly/js/templates/alert/AlertResultView.jsx
@@ -1,0 +1,196 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React from 'react';
+import {Box, Sheet, Stack, Typography} from '@mui/joy';
+import {MultiImageViewer} from '../../visualize/ui/MultiImageViewer.jsx';
+import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+
+import {getTblIdsByGroup} from '../../tables/TableUtil.js';
+import {visRoot} from 'firefly/visualize/ImagePlotCntlr';
+import {getPlotViewAry} from 'firefly/visualize/PlotViewUtil.js';
+
+import {ALERT} from './AlertManager.js';
+import {PropertySheetAsTable} from 'firefly/tables/ui/PropertySheet';
+import {MultiProductChoice} from 'firefly/visualize/ui/multiProduct/MultiProductChoice';
+import {SHOW_CHART, SHOW_TABLE} from 'firefly/metaConvert/DataProductsType';
+import {dispatchSetLayoutMode, getLayouInfo, LO_MODE, LO_VIEW} from 'firefly/core/LayoutCntlr';
+import {getExpandedChartProps} from 'firefly/charts/ChartsCntlr.js';
+import {ChartsContainer} from 'firefly/charts/ui/ChartsContainer.jsx';
+import {TablesContainer} from 'firefly/tables/ui/TablesContainer.jsx';
+import {ImageExpandedMode} from 'firefly/visualize/iv/ImageExpandedMode.jsx';
+import {DEFAULT_PLOT2D_VIEWER_ID} from 'firefly/visualize/MultiViewCntlr.js';
+
+
+function getAlertData() {
+    const mainIds = getTblIdsByGroup(ALERT.TABLE_GROUP_MAIN) || [];
+    const detailIds = getTblIdsByGroup(ALERT.TABLE_GROUP_DETAILS) || [];
+
+    const plotViews = getPlotViewAry(visRoot()) || [];
+    const hasImages = plotViews.length > 0;
+
+    return {
+        hasMainTable: mainIds.length > 0,
+        hasDetailTable: detailIds.length > 0,
+        hasImages,
+    };
+}
+
+export function AlertResultView() {
+    const {expanded} = useStoreConnector(() => {
+        const {mode} = getLayouInfo();
+        return { expanded: mode?.expanded ?? LO_VIEW.none };
+    });
+
+    const [whatToShow, setWhatToShow] = React.useState(SHOW_TABLE);
+
+    const handleShowChange = (...args) => {
+        const v =
+            (args.length >= 2 ? args[1] : undefined) ??
+            args[0]?.target?.value ??
+            args[0];
+
+        if (v === SHOW_TABLE || v === SHOW_CHART) {
+            setWhatToShow(v);
+        } else {
+            console.warn('[Alert] ignoring unexpected whatToShow:', v, args);
+        }
+    };
+
+    const {hasMainTable, hasDetailTable, hasImages} = useStoreConnector(getAlertData);
+
+    if (expanded !== LO_VIEW.none) {
+        return (
+            <ExpandedView expanded={expanded}/>
+        );
+    }
+
+    return (
+        <Stack sx={{width: 1, height: 1, overflow: 'hidden', minHeight: 0, minWidth: 0, display: 'flex',
+        }}>
+
+            {/* Top: tables */}
+            <Box sx={{display: 'flex', flex: '1 1 0%', gap: 1, p: 1, overflow: 'hidden', minHeight: 0, minWidth: 0,
+            }}>
+                <Box sx={{flex: '1 1 0%', overflow: 'hidden', minHeight: 0, minWidth: 0}}>
+                    {hasMainTable ? (
+                        <MultiProductChoice
+                            dataProductsState={null} //allowed to be null
+                            dpId='alert'
+                            chartViewerId={ALERT.CHART_VIEWER_1}
+                            tableGroupViewerId={ALERT.TABLE_GROUP_MAIN}
+                            whatToShow={whatToShow}
+                            onChange={handleShowChange}
+                            mayToggle={true}
+                        />
+                    ) : (
+                        <EmptySlot label='Table' />
+                    )}
+                </Box>
+
+                <Box sx={{flex: '1 1 0%', overflow: 'hidden', minHeight: 0, minWidth: 0}}>
+                    {hasDetailTable ? (
+                        <PropertySheetAsTable
+                            tbl_id={ALERT.TABLE_2_ID}
+                            tbl_group={ALERT.TABLE_GROUP_DETAILS}
+                            tblOptions={{
+                                showFilters: true,
+                                showToolbar: true,
+                                removable: false,
+                            }}
+                        />
+                    ) : (
+                        <EmptySlot label='Details Table' />
+                    )}
+                </Box>
+            </Box>
+
+
+            {/* Bottom: 3 image viewers */}
+            <Box sx={{display: 'flex', flex: '1 1 0%', gap: 1, p: 1, overflow: 'hidden', minHeight: 0, minWidth: 0,
+            }}>
+                {[ALERT.IMG_VIEWER_1, ALERT.IMG_VIEWER_2, ALERT.IMG_VIEWER_3].map((viewerId, idx) => (
+                    <Box key={viewerId} sx={{flex: '1 1 0%', overflow: 'hidden', minHeight: 0, minWidth: 0}}>
+                        {hasImages ? (
+                            <MultiImageViewer
+                                viewerId={viewerId}
+                                insideFlex={true}
+                                forceRowSize={1}
+                            />
+                        ) : (
+                            <EmptySlot label={`Image ${idx+1}`} />
+                        )}
+                    </Box>
+                ))}
+            </Box>
+
+        </Stack>
+    );
+}
+
+function ExpandedView({expanded}) {
+    let view;
+
+    if (expanded === LO_VIEW.tables) {
+        view = (
+            <TablesContainer
+                mode='both'
+                closeable={true}
+                expandedMode={true}
+                tbl_group={ALERT.TABLE_GROUP_MAIN}
+            />
+        );
+    }
+    else if (expanded === LO_VIEW.xyPlots) {
+        const {expandedViewerId} = getExpandedChartProps();
+        const chartExpandedMode = true;
+
+        view = (
+            <ChartsContainer
+                closeable={true}
+                tbl_group={ALERT.TABLE_GROUP_MAIN}
+                addDefaultChart={false}
+                viewerId={expandedViewerId}
+                useOnlyChartsInViewer={
+                    chartExpandedMode &&
+                    expandedViewerId &&
+                    expandedViewerId !== DEFAULT_PLOT2D_VIEWER_ID
+                }
+                expandedMode={true}
+            />
+        );
+    }
+    else {
+        //images expanded mode uses Firefly’s built-in close rendering
+        view = (
+            <ImageExpandedMode
+                key='alert-images-expanded'
+                closeFunc={closeExpanded}
+            />
+        );
+    }
+
+    return (
+        <Stack direction='row' flexGrow={1} overflow='hidden'>
+            {view}
+        </Stack>
+    );
+}
+
+function closeExpanded() {
+    dispatchSetLayoutMode(LO_MODE.expanded, LO_VIEW.none);
+}
+
+
+function EmptySlot({label}) {
+    return (
+        <Sheet variant='outlined'
+            sx={{height: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', gcolor: 'background.level1'}}
+        >
+            <Typography level='body-sm' color='neutral'>
+                {label} - No data
+            </Typography>
+        </Sheet>
+    );
+}

--- a/src/firefly/js/templates/alert/AlertResultView.jsx
+++ b/src/firefly/js/templates/alert/AlertResultView.jsx
@@ -21,6 +21,7 @@ import {ChartsContainer} from 'firefly/charts/ui/ChartsContainer.jsx';
 import {TablesContainer} from 'firefly/tables/ui/TablesContainer.jsx';
 import {ImageExpandedMode} from 'firefly/visualize/iv/ImageExpandedMode.jsx';
 import {DEFAULT_PLOT2D_VIEWER_ID} from 'firefly/visualize/MultiViewCntlr.js';
+import {MultiViewStandardToolbar} from 'firefly/visualize/ui/MultiViewStandardToolbar';
 
 
 function getAlertData() {
@@ -117,6 +118,7 @@ export function AlertResultView() {
                                 viewerId={viewerId}
                                 insideFlex={true}
                                 forceRowSize={1}
+                                Toolbar={MultiViewStandardToolbar}
                             />
                         ) : (
                             <EmptySlot label={`Image ${idx+1}`} />

--- a/src/firefly/js/templates/alert/AlertViewer.jsx
+++ b/src/firefly/js/templates/alert/AlertViewer.jsx
@@ -2,36 +2,36 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {Button, Stack, Typography} from '@mui/joy';
+import {Stack, Typography} from '@mui/joy';
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 
-import {dispatchNotifyRemoteAppReady, dispatchOnAppReady, dispatchSetMenu} from '../../core/AppDataCntlr.js';
-import {dispatchHideDropDown, getLayouInfo, SHOW_DROPDOWN} from '../../core/LayoutCntlr.js';
 import {ALERT, alertManager} from './AlertManager.js';
 import {AlertResultView} from './AlertResultView.jsx';
 import {makeBannerTitle} from '../../ui/Banner.jsx';
 import {getActionFromUrl} from '../../core/History.js';
 import {dispatchAddSaga} from '../../core/MasterSaga.js';
 import {FieldGroup} from '../../ui/FieldGroup.jsx';
-import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils.js';
 import {FileUpload} from '../../ui/FileUpload.jsx';
 import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
 import {getWorkspaceConfig, initWorkspace} from '../../visualize/WorkspaceCntlr.js';
-import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {setIf as setIfUndefined} from '../../util/WebUtil.js';
-import {flux} from '../../core/ReduxFlux.js';
 import App from 'firefly/ui/App.jsx';
 import {cloneDeep} from 'lodash/lang.js';
 import {showInfoPopup} from 'firefly/ui/PopupUtil';
 import {makeFileRequest} from 'firefly/tables/TableRequestUtil';
-import {upload} from '../../rpc/CoreServices.js';
 import WebPlotRequest from 'firefly/visualize/WebPlotRequest';
 import RangeValues from 'firefly/visualize/RangeValues';
 import {dispatchPlotImage} from 'firefly/visualize/ImagePlotCntlr';
 import {findSingleAxisImages, getSelectedRows, makeSummaryModel} from 'firefly/ui/FileUploadProcessor';
 import {IMAGES, TABLES} from 'firefly/ui/FileUploadUtil';
 import {FileAnalysisType} from 'firefly/data/FileAnalysis';
+import {getField} from '../../fieldGroup/FieldGroupUtils';
+import {LoadingMessage} from 'firefly/visualize/ui/FileUploadViewPanel';
+import {flux} from 'firefly/core/ReduxFlux.js';
+import {dispatchHideDropDown, getLayouInfo, SHOW_DROPDOWN} from 'firefly/core/LayoutCntlr.js';
+import {dispatchNotifyRemoteAppReady, dispatchOnAppReady, dispatchSetMenu} from 'firefly/core/AppDataCntlr.js';
+import {useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
 
 const vFileKey = ALERT.FG_UPLOAD;
 const DEFAULT_TITLE = 'Alert Viewer';
@@ -71,7 +71,7 @@ export function AlertViewer({menu, dropdownPanels=[], appTitle, slotProps, ...ap
 
     return (
         <App slotProps={mSlotProps}
-             dropdownPanels={[...dropdownPanels, <UploadPanel {...{name:'AlertUpload'}}/>]}
+             dropdownPanels={[...dropdownPanels, <UploadPanel key='AlertUpload' name='AlertUpload' />]}
              appTitle={appTitle} {...appProps}
         >
             <MainView {...{error, showTables, showImages, showXyPlots}}/>
@@ -101,7 +101,7 @@ const MainView = ({error, showTables, showImages, showXyPlots}) => {
         );
     }
 
-    //Show result view if we have tables or images, otherwise landing page
+    //show result view if we have tables or images, otherwise landing page
     return (showTables || showImages || showXyPlots) ? <AlertResultView/> : <LandingView/>;
 };
 
@@ -121,95 +121,111 @@ const LandingView = () => {
     );
 };
 
-
-
 function onReady({menu}) {
     if (menu) {
         dispatchSetMenu({menuItems: menu});
     }
-    const {hasImages, hasTables} = getLayouInfo();
-    if (!(hasImages || hasTables)) {
+    const {hasImages, hasTables, hasXyPlots} = getLayouInfo();
+    if (!(hasImages || hasTables || hasXyPlots)) {
         const goto = getActionFromUrl() || {type: SHOW_DROPDOWN};
         if (goto) flux.process(goto);
     }
     dispatchNotifyRemoteAppReady();
 }
 
-export const UploadPanel = () =>{
+let lastProcessedAnalysisResult = '';
+export const UploadPanel = () => {
     const instruction = 'Enter a URL to a FITS file to upload and view in the Alert Viewer.';
+    const [isLoading, setIsLoading] = React.useState(false);
+
+    //pull the fitsUrl field from the store (this is how FileUploadViewPanel does it)
+    const {fld} = useStoreConnector(() => {
+        return { fld: getField(vFileKey, 'fitsUrl') };
+    });
+
+    const onLoading = (loading) => {setIsLoading(loading);};
+
+    //when analysisResult exists, run loader and close dropdown
+    useEffect(() => {
+        const analysisResult = fld?.analysisResult;
+        const message = fld?.message;
+
+        if (message) {
+            //upload or analysis failed
+            showInfoPopup(message, 'Upload Error');
+            return;
+        }
+        if (!analysisResult) return;
+
+        //avoid re-running if store has same value
+        if (analysisResult === lastProcessedAnalysisResult) return;
+        lastProcessedAnalysisResult = analysisResult;
+
+        let report;
+        try {
+            report = JSON.parse(analysisResult);
+        } catch (e) {
+            showInfoPopup('Upload succeeded but analysisResult is not valid JSON', 'Upload Error');
+            return;
+        }
+
+        //file location/source on the server
+        const fileLocation = fld?.value;
+        if (!fileLocation) {
+            showInfoPopup('Upload analysis returned, but no server file key was found (fitsUrl.value).', 'Upload Error');
+            return;
+        }
+
+        const displayName = report?.fileName || fld?.displayValue || 'Uploaded FITS';
+
+        //“load 2 tables + 3 images”
+        loadFromReportAndHide(fileLocation, report, displayName);
+    }, [fld?.analysisResult, fld?.message, fld?.value]);
 
     return (
-
-
-                <Stack {...{width:1, alignItems:'center'}}>
-                    <Stack {...{ml:0, mt:4, spacing:3}}>
-                        <Typography level='body-lg'>{instruction}</Typography>
-                        <FieldGroup groupKey={vFileKey} keepState={true}>
-                            <Stack {...{spacing:2}}>
-                                <FileUpload
-                                    fieldKey='fitsUrl'
-                                    isFromURL={true}
-                                    canDragDrop={false}
-                                    fileAnalysis={false}
-                                    initialState={{
-                                        label: '',
-                                        tooltip: 'Enter a URL to a FITS file'
-                                    }}
-                                />
-                                <Stack direction='row' justifyContent='flex-end'>
-                                    <Button onClick={onSearchSubmit}>Upload</Button>
-                                </Stack>
-                            </Stack>
-                        </FieldGroup>
+        <Stack width={1} alignItems='center'>
+            <Stack ml={0} mt={4} spacing={3} sx={{position: 'relative'}}>
+                <Typography level='body-lg'>{instruction}</Typography>
+                <FieldGroup groupKey={vFileKey} keepState={true}>
+                    <Stack spacing={2}>
+                        <FileUpload
+                            fieldKey='fitsUrl'
+                            isFromURL={true}
+                            canDragDrop={false}
+                            fileAnalysis={onLoading}
+                            initialState={{
+                                label: '',
+                                tooltip: 'Enter a URL to a FITS file'
+                            }}
+                        />
                     </Stack>
-                </Stack>
+                </FieldGroup>
+                {isLoading && <LoadingMessage/>}
+            </Stack>
+        </Stack>
     );
 };
 
 UploadPanel.propTypes = {};
 
-function onSearchSubmit(request) {
-    console.log('onSearchSubmit called with request: ', request);
-
-    const fields = FieldGroupUtils.getGroupFields(vFileKey);
-    const urlVal = fields?.fitsUrl?.value?.trim();
-
-    if (!urlVal) {
-        showInfoPopup('Please enter a URL.', 'Missing URL');
-        return false;
-    }
-
-    const displayName = urlVal.split('/').pop() || 'URL FITS';
-    loadFileAndHide(urlVal, displayName);
-    return false; //don't hide dropdown yet - wait for loadFileAndHide to complete
-}
-
-async function loadFileAndHide(uploadPath, uploadedFileName) {
+function loadFromReportAndHide(fileLocation, report, uploadedFileName) {
     try {
-        // Upload and analyze the file
-        const {cacheKey, analysisResult} = await upload(uploadPath, 'Details');
-
-        const report = analysisResult ? JSON.parse(analysisResult) : null;
         if (!report?.parts) {
-            console.error('No analysis or parts found');
             showInfoPopup('Could not analyze the uploaded file.', 'File Analysis Error');
             dispatchHideDropDown();
             return;
         }
-        const acceptList = [IMAGES, TABLES];          // what AlertViewer supports
-        const summaryModel = makeSummaryModel(report, '', acceptList); // tbl_id can be anything; key point is summaryTblId below is falsy
-        const summaryTblId = '';
 
-        // choose whether you want the Nx1 images to be treated as table/chart
+        const acceptList = [IMAGES, TABLES];
+        const summaryModel = makeSummaryModel(report, '', acceptList);
+        const summaryTblId = '';
         const singleAxisImageAsTable = true;
 
         const tableIdxs = getSelectedRows(FileAnalysisType.Table, summaryTblId, report, summaryModel, singleAxisImageAsTable) ?? [];
         const imageIdxs = getSelectedRows(FileAnalysisType.Image, summaryTblId, report, summaryModel, singleAxisImageAsTable) ?? [];
 
-        //(optional) single-axis image indices the UI would “special case”
         const singleAxisIdxs = (findSingleAxisImages(report) ?? []).map(({index}) => index);
 
-        //pick 2 table part indices
         const pickedTableIdxs = tableIdxs.slice(0, 2);
         if (pickedTableIdxs.length < 2) {
             showInfoPopup(`Need at least 2 tables. Found ${pickedTableIdxs.length}.`, 'Invalid File Format');
@@ -217,10 +233,8 @@ async function loadFileAndHide(uploadPath, uploadedFileName) {
             return;
         }
 
-        //pick 3 image part indices
-        //todo: if you want to treat single-axis images as NOT images, remove them here
         const pickedImageIdxs = imageIdxs
-            .filter((idx) => !singleAxisIdxs.includes(idx)) //optional
+            .filter((idx) => !singleAxisIdxs.includes(idx))
             .slice(0, 3);
 
         if (pickedImageIdxs.length < 3) {
@@ -232,16 +246,16 @@ async function loadFileAndHide(uploadPath, uploadedFileName) {
         const getExtNum = (part, fallbackIdx) =>
             part?.fileLocationIndex ?? part?.index ?? fallbackIdx;
 
-        //Load 2 tables into 2 dedicated viewers
-        console.log('Loading tables...');
+        //---- Load 2 tables ----
         for (let i = 0; i < 2; i++) {
             const partIdx = pickedTableIdxs[i];
             const part = report.parts.find((p) => (p?.index ?? p?.fileLocationIndex) === partIdx);
             const extNum = getExtNum(part, partIdx);
             const desc = part?.desc;
+
             const tblReq = makeFileRequest(
                 desc || `${uploadedFileName} Table ${i + 1}`,
-                cacheKey,
+                fileLocation,
                 null,
                 {
                     tbl_id: i === 0 ? ALERT.TABLE_1_ID : ALERT.TABLE_2_ID,
@@ -250,45 +264,37 @@ async function loadFileAndHide(uploadPath, uploadedFileName) {
                 }
             );
             tblReq.tbl_index = extNum;
-            console.log(`Table ${i + 1} request:`, tblReq);
-            /*dispatchTableSearch(
+
+            dispatchTableSearch(
                 tblReq,
                 {removable: true, tbl_group: i === 0 ? ALERT.TABLE_GROUP_MAIN : ALERT.TABLE_GROUP_DETAILS}
-            );*/
-            if (i === 0) {
-                dispatchTableSearch(tblReq, {removable: true, tbl_group: ALERT.TABLE_GROUP_MAIN});
-            } else {
-                dispatchTableSearch(tblReq, {removable: true, tbl_group: ALERT.TABLE_GROUP_DETAILS});
-            }
-            }
+            );
+        }
 
-            //Load 3 images into 3 dedicated viewers
+        //---- Load 3 images ----
+        const viewerIds = [ALERT.IMG_VIEWER_1, ALERT.IMG_VIEWER_2, ALERT.IMG_VIEWER_3];
+        const plotIds = [ALERT.IMG_PLOT_1, ALERT.IMG_PLOT_2, ALERT.IMG_PLOT_3];
 
-            const viewerIds = [ALERT.IMG_VIEWER_1, ALERT.IMG_VIEWER_2, ALERT.IMG_VIEWER_3];
-            const plotIds = [ALERT.IMG_PLOT_1, ALERT.IMG_PLOT_2, ALERT.IMG_PLOT_3];
+        for (let i = 0; i < 3; i++) {
+            const partIdx = pickedImageIdxs[i];
+            const part = report.parts[partIdx];
+            const extNum = getExtNum(part, partIdx);
+            const desc = part?.desc;
 
-            for (let i = 0; i < 3; i++) {
-                const partIdx = pickedImageIdxs[i];
-                const part = report.parts[partIdx];
-                const extNum = getExtNum(part, partIdx);
-                const desc = part?.desc;
+            const viewerId = viewerIds[i];
+            const plotId = plotIds[i];
 
-                const viewerId = viewerIds[i];
-                const plotId = plotIds[i];
+            const wpRequest = WebPlotRequest.makeFilePlotRequest(fileLocation);
+            wpRequest.setInitialRangeValues(RangeValues.make2To10SigmaLinear());
+            wpRequest.setPlotGroupId(viewerId);
+            wpRequest.setMultiImageExts(`${extNum}`);
+            wpRequest.setTitle(desc || `${uploadedFileName} [ext ${extNum}]`);
 
-                const wpRequest = WebPlotRequest.makeFilePlotRequest(cacheKey);
-                wpRequest.setInitialRangeValues(RangeValues.make2To10SigmaLinear());
-                wpRequest.setPlotGroupId(viewerId);
-                wpRequest.setMultiImageExts(`${extNum}`);
-                wpRequest.setTitle(desc || `${uploadedFileName} [ext ${extNum}]`);
-
-                dispatchPlotImage({plotId, wpRequest, viewerId, setNewPlotAsActive: i === 0});
-            }
+            dispatchPlotImage({plotId, wpRequest, viewerId, setNewPlotAsActive: i === 0});
+        }
 
     } catch (error) {
-        console.error('=== loadFileAndHide ERROR ===');
         console.error('Error loading file:', error);
-        console.error('Error stack:', error.stack);
         showInfoPopup(`Error loading file: ${error.message}`, 'Load Error');
     }
 

--- a/src/firefly/js/templates/alert/AlertViewer.jsx
+++ b/src/firefly/js/templates/alert/AlertViewer.jsx
@@ -1,0 +1,296 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import {Button, Stack, Typography} from '@mui/joy';
+import React, {useEffect} from 'react';
+import PropTypes from 'prop-types';
+
+import {dispatchNotifyRemoteAppReady, dispatchOnAppReady, dispatchSetMenu} from '../../core/AppDataCntlr.js';
+import {dispatchHideDropDown, getLayouInfo, SHOW_DROPDOWN} from '../../core/LayoutCntlr.js';
+import {ALERT, alertManager} from './AlertManager.js';
+import {AlertResultView} from './AlertResultView.jsx';
+import {makeBannerTitle} from '../../ui/Banner.jsx';
+import {getActionFromUrl} from '../../core/History.js';
+import {dispatchAddSaga} from '../../core/MasterSaga.js';
+import {FieldGroup} from '../../ui/FieldGroup.jsx';
+import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils.js';
+import {FileUpload} from '../../ui/FileUpload.jsx';
+import {dispatchTableSearch} from '../../tables/TablesCntlr.js';
+import {getWorkspaceConfig, initWorkspace} from '../../visualize/WorkspaceCntlr.js';
+import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+import {setIf as setIfUndefined} from '../../util/WebUtil.js';
+import {flux} from '../../core/ReduxFlux.js';
+import App from 'firefly/ui/App.jsx';
+import {cloneDeep} from 'lodash/lang.js';
+import {showInfoPopup} from 'firefly/ui/PopupUtil';
+import {makeFileRequest} from 'firefly/tables/TableRequestUtil';
+import {upload} from '../../rpc/CoreServices.js';
+import WebPlotRequest from 'firefly/visualize/WebPlotRequest';
+import RangeValues from 'firefly/visualize/RangeValues';
+import {dispatchPlotImage} from 'firefly/visualize/ImagePlotCntlr';
+import {findSingleAxisImages, getSelectedRows, makeSummaryModel} from 'firefly/ui/FileUploadProcessor';
+import {IMAGES, TABLES} from 'firefly/ui/FileUploadUtil';
+import {FileAnalysisType} from 'firefly/data/FileAnalysis';
+
+const vFileKey = ALERT.FG_UPLOAD;
+const DEFAULT_TITLE = 'Alert Viewer';
+
+/**
+ * Alert Viewer - Upload FITS files and view in custom layout
+ * @param {Object} p
+ * @param {Array} p.menu - menu items
+ * @param {Array} p.dropdownPanels - dropdown panels
+ * @param {string} p.appTitle - application title
+ * @param {Object} p.slotProps - slot properties
+ * @param {Object} p.appProps - additional app properties
+ */
+export function AlertViewer({menu, dropdownPanels=[], appTitle, slotProps, ...appProps}) {
+
+    useEffect(() => {
+        dispatchAddSaga(alertManager, {views: 'tables | images | xyplots'});
+        getWorkspaceConfig() && initWorkspace();
+        dispatchOnAppReady((state) => onReady({state, menu}));
+    }, []);
+
+    const {showTables, showImages, showXyPlots, error} = useStoreConnector(() => {
+        const layoutInfo = getLayouInfo();
+        return {
+            showTables: layoutInfo?.showTables,
+            showImages: layoutInfo?.showImages,
+            showXyPlots: layoutInfo?.showXyPlots,
+            error: layoutInfo?.error
+        };
+    });
+
+    const title = makeBannerTitle(appTitle || DEFAULT_TITLE);
+
+    const mSlotProps = cloneDeep(slotProps || {});
+    setIfUndefined(mSlotProps,'drawer.allowMenuHide', false);
+    setIfUndefined(mSlotProps,'banner.title', title);
+
+    return (
+        <App slotProps={mSlotProps}
+             dropdownPanels={[...dropdownPanels, <UploadPanel {...{name:'AlertUpload'}}/>]}
+             appTitle={appTitle} {...appProps}
+        >
+            <MainView {...{error, showTables, showImages, showXyPlots}}/>
+        </App>
+    );
+}
+
+AlertViewer.propTypes = {
+    title: PropTypes.string,
+    menu: PropTypes.arrayOf(PropTypes.object),
+    appTitle: PropTypes.string,
+    appIcon: PropTypes.element,
+    footer: PropTypes.element,
+    dropdownPanels: PropTypes.arrayOf(PropTypes.element),
+    slotProps: PropTypes.object,
+    style: PropTypes.object
+};
+
+const MainView = ({error, showTables, showImages, showXyPlots}) => {
+    if (error) {
+        return (
+            <div style={{display: 'flex', width: '100%', marginTop: 20, justifyContent: 'center', alignItems: 'baseline'}}>
+                <div style={{display: 'inline-flex', border: '1px solid #a3aeb9', padding:20, fontSize:'150%'}}>
+                    <div>{error}</div>
+                </div>
+            </div>
+        );
+    }
+
+    //Show result view if we have tables or images, otherwise landing page
+    return (showTables || showImages || showXyPlots) ? <AlertResultView/> : <LandingView/>;
+};
+
+const LandingView = () => {
+    return (
+        <Stack sx={{width: 1, height: 1, justifyContent: 'center', alignItems: 'center', p: 4}}>
+            <Stack spacing={3} sx={{maxWidth: 600, textAlign: 'center'}}>
+                <Typography level='h1'>Alert Viewer</Typography>
+                <Typography level='body-lg'>
+                    Upload FITS files to view in a custom layout with 2 tables side-by-side and 3 images below.
+                </Typography>
+                <Typography level='body-md' color='neutral'>
+                    Click the "Upload" tab above or drag and drop files here to get started.
+                </Typography>
+            </Stack>
+        </Stack>
+    );
+};
+
+
+
+function onReady({menu}) {
+    if (menu) {
+        dispatchSetMenu({menuItems: menu});
+    }
+    const {hasImages, hasTables} = getLayouInfo();
+    if (!(hasImages || hasTables)) {
+        const goto = getActionFromUrl() || {type: SHOW_DROPDOWN};
+        if (goto) flux.process(goto);
+    }
+    dispatchNotifyRemoteAppReady();
+}
+
+export const UploadPanel = () =>{
+    const instruction = 'Enter a URL to a FITS file to upload and view in the Alert Viewer.';
+
+    return (
+
+
+                <Stack {...{width:1, alignItems:'center'}}>
+                    <Stack {...{ml:0, mt:4, spacing:3}}>
+                        <Typography level='body-lg'>{instruction}</Typography>
+                        <FieldGroup groupKey={vFileKey} keepState={true}>
+                            <Stack {...{spacing:2}}>
+                                <FileUpload
+                                    fieldKey='fitsUrl'
+                                    isFromURL={true}
+                                    canDragDrop={false}
+                                    fileAnalysis={false}
+                                    initialState={{
+                                        label: '',
+                                        tooltip: 'Enter a URL to a FITS file'
+                                    }}
+                                />
+                                <Stack direction='row' justifyContent='flex-end'>
+                                    <Button onClick={onSearchSubmit}>Upload</Button>
+                                </Stack>
+                            </Stack>
+                        </FieldGroup>
+                    </Stack>
+                </Stack>
+    );
+};
+
+UploadPanel.propTypes = {};
+
+function onSearchSubmit(request) {
+    console.log('onSearchSubmit called with request: ', request);
+
+    const fields = FieldGroupUtils.getGroupFields(vFileKey);
+    const urlVal = fields?.fitsUrl?.value?.trim();
+
+    if (!urlVal) {
+        showInfoPopup('Please enter a URL.', 'Missing URL');
+        return false;
+    }
+
+    const displayName = urlVal.split('/').pop() || 'URL FITS';
+    loadFileAndHide(urlVal, displayName);
+    return false; //don't hide dropdown yet - wait for loadFileAndHide to complete
+}
+
+async function loadFileAndHide(uploadPath, uploadedFileName) {
+    try {
+        // Upload and analyze the file
+        const {cacheKey, analysisResult} = await upload(uploadPath, 'Details');
+
+        const report = analysisResult ? JSON.parse(analysisResult) : null;
+        if (!report?.parts) {
+            console.error('No analysis or parts found');
+            showInfoPopup('Could not analyze the uploaded file.', 'File Analysis Error');
+            dispatchHideDropDown();
+            return;
+        }
+        const acceptList = [IMAGES, TABLES];          // what AlertViewer supports
+        const summaryModel = makeSummaryModel(report, '', acceptList); // tbl_id can be anything; key point is summaryTblId below is falsy
+        const summaryTblId = '';
+
+        // choose whether you want the Nx1 images to be treated as table/chart
+        const singleAxisImageAsTable = true;
+
+        const tableIdxs = getSelectedRows(FileAnalysisType.Table, summaryTblId, report, summaryModel, singleAxisImageAsTable) ?? [];
+        const imageIdxs = getSelectedRows(FileAnalysisType.Image, summaryTblId, report, summaryModel, singleAxisImageAsTable) ?? [];
+
+        //(optional) single-axis image indices the UI would “special case”
+        const singleAxisIdxs = (findSingleAxisImages(report) ?? []).map(({index}) => index);
+
+        //pick 2 table part indices
+        const pickedTableIdxs = tableIdxs.slice(0, 2);
+        if (pickedTableIdxs.length < 2) {
+            showInfoPopup(`Need at least 2 tables. Found ${pickedTableIdxs.length}.`, 'Invalid File Format');
+            dispatchHideDropDown();
+            return;
+        }
+
+        //pick 3 image part indices
+        //todo: if you want to treat single-axis images as NOT images, remove them here
+        const pickedImageIdxs = imageIdxs
+            .filter((idx) => !singleAxisIdxs.includes(idx)) //optional
+            .slice(0, 3);
+
+        if (pickedImageIdxs.length < 3) {
+            showInfoPopup(`Need at least 3 images. Found ${pickedImageIdxs.length}.`, 'Invalid File Format');
+            dispatchHideDropDown();
+            return;
+        }
+
+        const getExtNum = (part, fallbackIdx) =>
+            part?.fileLocationIndex ?? part?.index ?? fallbackIdx;
+
+        //Load 2 tables into 2 dedicated viewers
+        console.log('Loading tables...');
+        for (let i = 0; i < 2; i++) {
+            const partIdx = pickedTableIdxs[i];
+            const part = report.parts.find((p) => (p?.index ?? p?.fileLocationIndex) === partIdx);
+            const extNum = getExtNum(part, partIdx);
+            const desc = part?.desc;
+            const tblReq = makeFileRequest(
+                desc || `${uploadedFileName} Table ${i + 1}`,
+                cacheKey,
+                null,
+                {
+                    tbl_id: i === 0 ? ALERT.TABLE_1_ID : ALERT.TABLE_2_ID,
+                    pageSize: ALERT.TABLE_PAGESIZE,
+                    META_INFO: {}
+                }
+            );
+            tblReq.tbl_index = extNum;
+            console.log(`Table ${i + 1} request:`, tblReq);
+            /*dispatchTableSearch(
+                tblReq,
+                {removable: true, tbl_group: i === 0 ? ALERT.TABLE_GROUP_MAIN : ALERT.TABLE_GROUP_DETAILS}
+            );*/
+            if (i === 0) {
+                dispatchTableSearch(tblReq, {removable: true, tbl_group: ALERT.TABLE_GROUP_MAIN});
+            } else {
+                dispatchTableSearch(tblReq, {removable: true, tbl_group: ALERT.TABLE_GROUP_DETAILS});
+            }
+            }
+
+            //Load 3 images into 3 dedicated viewers
+
+            const viewerIds = [ALERT.IMG_VIEWER_1, ALERT.IMG_VIEWER_2, ALERT.IMG_VIEWER_3];
+            const plotIds = [ALERT.IMG_PLOT_1, ALERT.IMG_PLOT_2, ALERT.IMG_PLOT_3];
+
+            for (let i = 0; i < 3; i++) {
+                const partIdx = pickedImageIdxs[i];
+                const part = report.parts[partIdx];
+                const extNum = getExtNum(part, partIdx);
+                const desc = part?.desc;
+
+                const viewerId = viewerIds[i];
+                const plotId = plotIds[i];
+
+                const wpRequest = WebPlotRequest.makeFilePlotRequest(cacheKey);
+                wpRequest.setInitialRangeValues(RangeValues.make2To10SigmaLinear());
+                wpRequest.setPlotGroupId(viewerId);
+                wpRequest.setMultiImageExts(`${extNum}`);
+                wpRequest.setTitle(desc || `${uploadedFileName} [ext ${extNum}]`);
+
+                dispatchPlotImage({plotId, wpRequest, viewerId, setNewPlotAsActive: i === 0});
+            }
+
+    } catch (error) {
+        console.error('=== loadFileAndHide ERROR ===');
+        console.error('Error loading file:', error);
+        console.error('Error stack:', error.stack);
+        showInfoPopup(`Error loading file: ${error.message}`, 'Load Error');
+    }
+
+    dispatchHideDropDown();
+}

--- a/src/firefly/js/visualize/ui/MultiImageViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewer.jsx
@@ -63,12 +63,6 @@ export class MultiImageViewer extends PureComponent {
         const pv= getActivePlotView(visRoot());
         const viewer = getViewer(getMultiViewRoot(), props.viewerId);
         const {rootWidget}= this;
-        /*if (rootWidget) {
-            console.log('MIV size', this.props.viewerId, {
-                w: rootWidget.offsetWidth,
-                h: rootWidget.offsetHeight,
-            });
-        }*/
         if (!pv || !viewer || !rootWidget || !viewer.lastActiveItemId) return;
         activeViewerMap.set(this.props.viewerId, Boolean(rootWidget.offsetWidth && rootWidget.offsetHeight));
         if (viewer.lastActiveItemId!==pv.plotId && !viewer.itemIdAry.includes(pv.plotId) && rootWidget.offsetWidth && rootWidget.offsetHeight) {
@@ -106,7 +100,6 @@ export class MultiImageViewer extends PureComponent {
         const {viewerId,tableId,gridDefFunc,handleToolbar=true}= this.props;
         const {viewer,visRoot,dlAry}= this.state;
         const layoutType= getLayoutType(getMultiViewRoot(),viewerId,tableId);
-        //console.log('inside MultiImageViewer render, viewerId=', viewerId, ' tableId=', tableId, ' layoutType=', layoutType);
         if (!viewer) return false;
         if (isEmpty(viewer.itemIdAry)) {
             if (!gridDefFunc) return false;

--- a/src/firefly/js/visualize/ui/MultiImageViewer.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewer.jsx
@@ -63,6 +63,12 @@ export class MultiImageViewer extends PureComponent {
         const pv= getActivePlotView(visRoot());
         const viewer = getViewer(getMultiViewRoot(), props.viewerId);
         const {rootWidget}= this;
+        /*if (rootWidget) {
+            console.log('MIV size', this.props.viewerId, {
+                w: rootWidget.offsetWidth,
+                h: rootWidget.offsetHeight,
+            });
+        }*/
         if (!pv || !viewer || !rootWidget || !viewer.lastActiveItemId) return;
         activeViewerMap.set(this.props.viewerId, Boolean(rootWidget.offsetWidth && rootWidget.offsetHeight));
         if (viewer.lastActiveItemId!==pv.plotId && !viewer.itemIdAry.includes(pv.plotId) && rootWidget.offsetWidth && rootWidget.offsetHeight) {
@@ -100,6 +106,7 @@ export class MultiImageViewer extends PureComponent {
         const {viewerId,tableId,gridDefFunc,handleToolbar=true}= this.props;
         const {viewer,visRoot,dlAry}= this.state;
         const layoutType= getLayoutType(getMultiViewRoot(),viewerId,tableId);
+        //console.log('inside MultiImageViewer render, viewerId=', viewerId, ' tableId=', tableId, ' layoutType=', layoutType);
         if (!viewer) return false;
         if (isEmpty(viewer.itemIdAry)) {
             if (!gridDefFunc) return false;

--- a/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
@@ -53,15 +53,8 @@ export function MultiImageViewerView(props)  {
         style= {...style, flex:'1 1 auto', maxWidth:'100%', ...props.style};
     }*/
     if (props.insideFlex) {
-               style= {
-                        ...style,
-                       flex: '1 1 0%',
-                       minHeight: 0,
-                    height: '100%',
-                       maxWidth: '100%',
-                       overflow: 'hidden',
-                        ...props.style
-                };
+               style= {...style, flex: '1 1 0%', minHeight: 0, height: '100%', maxWidth: '100%',
+                       overflow: 'hidden', ...props.style};
             }
 else {
         style=  {...style, width:'100%', height:'100%', ...props.style};

--- a/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
@@ -49,10 +49,21 @@ export function MultiImageViewerView(props)  {
             makeToolbar:handleToolbar?makeToolbar:undefined, makeItemViewer, makeItemViewerFull});
 
     let style= {display:'flex', flexDirection:'column', position:'relative'};
-    if (props.insideFlex) {
+    /*if (props.insideFlex) {
         style= {...style, flex:'1 1 auto', maxWidth:'100%', ...props.style};
-    }
-    else {
+    }*/
+    if (props.insideFlex) {
+               style= {
+                        ...style,
+                       flex: '1 1 0%',
+                       minHeight: 0,
+                    height: '100%',
+                       maxWidth: '100%',
+                       overflow: 'hidden',
+                        ...props.style
+                };
+            }
+else {
         style=  {...style, width:'100%', height:'100%', ...props.style};
     }
     
@@ -73,7 +84,7 @@ export function MultiImageViewerView(props)  {
     if (layoutType===SINGLE || viewerPlotIds?.length===1) {
         return (
             <div style={style} ref={(e) => elementWrapper.element= e}>
-                <MultiItemViewerView {...{...newProps, ref, insideFlex:true, style:props.style}} />
+                <MultiItemViewerView {...{...newProps, ref, insideFlex:true, style: {flex: '1 1 0%', minHeight: 0, overflow: 'hidden', ...props.style}}} />
                 <Stack spacing={1} style={mouseReadoutEmbedded? {position:'absolute', left:3, right:3, bottom:2}:{}} >
                     {bottomUIComponent?.()}
                     {mouseReadout}
@@ -84,7 +95,7 @@ export function MultiImageViewerView(props)  {
     else {
         return (
             <div className={'MultiImageViewer'} style={style} ref={(e) => elementWrapper.element= e}>
-                <MultiItemViewerView {...{...newProps, ref, insideFlex:true, style:props.style}} />
+                <MultiItemViewerView {...{...newProps, ref, insideFlex:true, style: {flex: '1 1 0%', minHeight: 0, overflow: 'hidden', ...props.style}}} />
                 <Stack style={ mouseReadoutEmbedded?{position:'absolute', left:3, bottom:3, right:scrollGrid?15:6}:{}} >
                     {bottomUIComponent?.()}
                     {mouseReadout}

--- a/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
+++ b/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
@@ -3,17 +3,16 @@
  */
 
 
-import React, {useEffect} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import {Divider, Sheet, Stack} from '@mui/joy';
-import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+import {Sheet, Stack} from '@mui/joy';
 import {ToolbarHorizontalSeparator} from '../../ui/ToolbarButton.jsx';
 import {HIDDEN} from '../ImViewFilterDisplay';
 import {ViewerScroll} from '../iv/ExpandedTools.jsx';
 import {
     dispatchChangeViewerLayout, EXPANDED_MODE_RESERVED, getMultiViewRoot, getViewer, getViewerItemIds
 } from '../MultiViewCntlr.js';
-import {dispatchChangeActivePlotView, ExpandType} from '../ImagePlotCntlr.js';
+import {dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
 import {BeforeButton, DisplayTypeButtonGroup, NextButton } from './Buttons.jsx';
 import {ViewOptionsButton} from './ExpandedOptionsPopup.jsx';
 import {VisMiniToolbar} from './VisMiniToolbar.jsx';

--- a/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
@@ -22,11 +22,12 @@ let lastChartDefault= 'Chart';
 
 
 export function MultiProductChoice({ dataProductsState, dpId,
-                                       makeDropDown, chartViewerId, imageViewerId, metaDataTableId,
-                                       tableGroupViewerId, whatToShow, onChange, mayToggle = false, factoryKey
-                                   }) {
-    const {enableCutout, pixelBasedCutout=false, dlData, gridForceRowSize}= dataProductsState;
-    const {serDef, cutoutToFullWarning, dlAnalysis:{cutoutFullPair=false}={}}= dataProductsState.dlData ?? {};
+                                      makeDropDown, chartViewerId, imageViewerId, metaDataTableId,
+                                      tableGroupViewerId, whatToShow, onChange, mayToggle = false, factoryKey
+                                  }) {
+    //handle null dataProductsState for cases where data products workflow is not used
+    const {enableCutout, pixelBasedCutout=false, dlData, gridForceRowSize}= dataProductsState ?? {};
+    const {serDef, cutoutToFullWarning, dlAnalysis:{cutoutFullPair=false}={}}= dataProductsState?.dlData ?? {};
     const primeIdx= useStoreConnector(() => getActivePlotView(visRoot())?.primeIdx ?? -1);
     const {current:showingStatus}= useRef({oldWhatToShow:undefined});
     const stateDef= dlData ? dlData?.dlAnalysis?.isSpectrum ? 'Spectrum' : 'Chart' : lastChartDefault;
@@ -37,26 +38,27 @@ export function MultiProductChoice({ dataProductsState, dpId,
     const tbl_id = getTableGroup(tableGroupViewerId)?.active;
     const table = tbl_id ? getTblById(tbl_id) : undefined;
     useEffect(() => {
+        if (!tbl_id) return;
         onTableLoaded(tbl_id).then(() => {
             const name = (getMetaEntry(tbl_id, 'utype') === 'spec:Spectrum') ? 'Spectrum' : 'Chart';
             setChartName(name);
             lastChartDefault= name;
         });
-    }, [dataProductsState.activate,tbl_id]);
+    }, [dataProductsState?.activate,tbl_id]);
 
-    const activeItemKey= getActiveFileMenuKeyByKey(dpId,dataProductsState?.fileMenu?.activeItemLookupKey);
+    const activeItemKey= dataProductsState ? getActiveFileMenuKeyByKey(dpId,dataProductsState?.fileMenu?.activeItemLookupKey) : undefined;
     const cubeIdx= dataProductsState?.fileMenu?.menu.find( (i) => i.menuKey===activeItemKey)?.cubeIdx ?? -1;
 
     useEffect(() => {
-        if (!imageViewerId) return;
+        if (!imageViewerId || !dataProductsState) return;
         const pv= getActivePlotView(visRoot());
         if (!pv || !hasImageCubes(pv) || cubeIdx<0) return;
         showingStatus.oldWhatToShow= whatToShow;
         showingStatus.cubeSet= false;
-    }, [whatToShow,cubeIdx]);
+    }, [whatToShow,cubeIdx,dataProductsState]);
 
     useEffect(() => {
-        if (!imageViewerId || primeIdx===-1 || cubeIdx<0) return;
+        if (!imageViewerId || primeIdx===-1 || cubeIdx<0 || !dataProductsState) return;
         if (showingStatus.cubeSet) return;
         const pv= getActivePlotView(visRoot());
         if (!pv || !hasImageCubes(pv)) return;
@@ -64,7 +66,7 @@ export function MultiProductChoice({ dataProductsState, dpId,
         const hduIdx= getHDUIndex(pv);
         const newPrimeIdx= convertHDUIdxToImageIdx(pv,hduIdx,cubeIdx) ?? 0;
         if (primeIdx!==newPrimeIdx) dispatchChangePrimePlot({plotId:pv.plotId,primeIdx:newPrimeIdx});
-    }, [table,primeIdx,cubeIdx]);
+    }, [table,primeIdx,cubeIdx,dataProductsState]);
 
 
 


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1935
- Implement Alert Viewer template
- upload a file via URL, and then results view would show two tables (one `Table/Chart` view on the left, and one `PropertySheet/Details` table on the right) and three 3 images 
- Some existing bugs, one of which is: 
  - from the results view, going back to `Upload` tab does not work

**Test build**: Alert Viewer: https://fireflydev.ipac.caltech.edu/firefly-1935-rubin-alert-portal/firefly/alertviewer.html
- files you can use to test upload: 
  - https://web.ipac.caltech.edu/staff/roby/alert-test/al-test-2.fits
  - https://web.ipac.caltech.edu/staff/roby/alert-test/coadd-1-100-thru20210505.fits