### PR TITLE
FIREFLY-1935: Alert Viewer

### DIFF
--- a/config/web.xml
+++ b/config/web.xml
@@ -102,6 +102,16 @@
         <servlet-name>H2Console</servlet-name>
         <url-pattern>/admin/db/*</url-pattern>
     </servlet-mapping>
+
+    <servlet>
+        <servlet-name>alertviewer</servlet-name>
+        <jsp-file>/alertviewer.html</jsp-file>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>alertviewer</servlet-name>
+        <url-pattern>/alertviewer/*</url-pattern>
+    </servlet-mapping>
+
 <!--    Resources                         -->
 
     <resource-ref>

--- a/src/firefly/html/alertviewer.html
+++ b/src/firefly/html/alertviewer.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <link rel="icon" type="image/x-icon" href="images/fftools-logo-16x16.png">
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <title>Alert Viewer</title>
+
+    <script>
+        window.firefly = {
+            app: {
+                template: 'router',
+                page: 'alertviewer',
+            }
+        };
+    </script>
+    <script  type="text/javascript" src="firefly_loader.js"></script>
+</head>
+
+<body style="margin: 0">
+<!-- attached location for firefly app -->
+<div id='app' style="width:100vw;height: 100vh"/>
+
+
+
+
+</body>
+
+</html>
+
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/AlertAnalyzer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/AlertAnalyzer.java
@@ -1,0 +1,178 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.dpanalyze;
+
+import edu.caltech.ipac.firefly.core.FileAnalysisReport;
+import edu.caltech.ipac.firefly.core.FileAnalysisReport.Part;
+import nom.tam.fits.Header;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static edu.caltech.ipac.firefly.core.FileAnalysisReport.ChartTableDefOption.*;
+import static edu.caltech.ipac.firefly.core.FileAnalysisReport.Type.*;
+
+/**
+ * @author Kartik Puri
+ */
+@DataProductAnalyzerImpl(id = "alert")
+public class AlertAnalyzer implements DataProductAnalyzer {
+
+    private static final int REQUIRED_TABLE_COUNT = 2;
+    private static final int REQUIRED_IMAGE_COUNT = 3;
+    private static final String TABLE_FROM_1D_PREFIX = "1D image, load as table, ";
+
+    @Override
+    public FileAnalysisReport analyzeFits(FileAnalysisReport inputReport,
+                                          File inFile,
+                                          String analyzerId,
+                                          Map<String, String> params,
+                                          Header[] headerAry) {
+
+        if (inputReport == null || inputReport.getParts() == null || inputReport.getParts().isEmpty()) {
+            return inputReport;
+        }
+
+        final List<Part> tableCandidates = new ArrayList<>();
+        final List<Part> imageCandidates = new ArrayList<>();
+
+        for (Part p : inputReport.getParts()) {
+            if (p == null) continue;
+
+            if (p.getType() == Table) {
+                tableCandidates.add(copyTablePart(p));
+            }
+            else if (p.getType() == Image) {
+                if (isTableLikeImage(p, headerAry)) {
+                    tableCandidates.add(makeTablePartFrom1DImage(p));
+                }
+                else {
+                    imageCandidates.add(copyImagePart(p));
+                }
+            }
+        }
+
+        if (tableCandidates.size() < REQUIRED_TABLE_COUNT || imageCandidates.size() < REQUIRED_IMAGE_COUNT) {
+            return makeErrorReport(
+                    inputReport,
+                    analyzerId,
+                    "Need at least 2 tables and 3 images. Found " +
+                            tableCandidates.size() + " table-like HDUs and " +
+                            imageCandidates.size() + " image HDUs."
+            );
+        }
+
+        final List<Part> picked = new ArrayList<>(REQUIRED_TABLE_COUNT + REQUIRED_IMAGE_COUNT);
+
+        //table 1: main table/chart
+        Part mainTable = tableCandidates.get(0);
+        mainTable.setChartTableDefOption(showChart);
+        picked.add(mainTable);
+
+        //table 2: details table
+        Part detailsTable = tableCandidates.get(1);
+        detailsTable.setChartTableDefOption(showTable);
+        picked.add(detailsTable);
+
+        //3 images
+        for (int i = 0; i < REQUIRED_IMAGE_COUNT; i++) {
+            Part img = imageCandidates.get(i);
+            img.setChartTableDefOption(showImage);
+            picked.add(img);
+        }
+
+        FileAnalysisReport out = inputReport.copy(false);
+        out.replaceParts(picked);
+        out.setDataProductsAnalyzerId(analyzerId);
+        out.setAnalyzerFound(true);
+
+        return out;
+    }
+
+    /**
+     * Mirror Firefly's current client behavior:
+     * makeSummaryModel treats Image with NAXIS==1 as table-like
+     * findSingleAxisImages/getSelectedRows treats Image with NAXIS2==1 as table-like
+     */
+    private static boolean isTableLikeImage(Part p, Header[] headerAry) {
+        if (p == null || headerAry == null || headerAry.length == 0) return false;
+
+        int hduIdx = getHduIndex(p);
+        if (hduIdx < 0 || hduIdx >= headerAry.length) return false;
+
+        Header h = headerAry[hduIdx];
+        if (h == null) return false;
+
+        int naxis = h.getIntValue("NAXIS", -1);
+        int naxis2 = h.getIntValue("NAXIS2", -1);
+
+        return naxis == 1 || naxis2 == 1;
+    }
+
+    private static int getHduIndex(Part p) {
+        return p.getFileLocationIndex() > -1 ? p.getFileLocationIndex() : p.getIndex();
+    }
+
+    private static Part makeTablePartFrom1DImage(Part src) {
+        String desc = src.getDesc() == null ? "" : src.getDesc();
+        Part p = new Part(Table, TABLE_FROM_1D_PREFIX + desc);
+
+        return getPart(src, p);
+    }
+
+    private static Part getPart(Part src, Part p) {
+        p.setIndex(src.getIndex());
+        p.setFileLocationIndex(src.getFileLocationIndex());
+        p.setDetails(src.getDetails());
+        p.setTotalTableRows(src.getTotalTableRows());
+        p.setTableDataType(src.getTableDataType());
+
+        if (src.getTableColumnNames() != null) {
+            p.setTableColumnNames(src.getTableColumnNames());
+        }
+        if (src.getTableColumnUnits() != null) {
+            p.setTableColumnUnits(src.getTableColumnUnits());
+        }
+        if (src.getChartParams() != null) {
+            p.setChartParams(src.getChartParams());
+        }
+
+        return p;
+    }
+
+    private static Part copyTablePart(Part src) {
+        Part p = new Part(Table, src.getDesc());
+        return getPart(src, p);
+    }
+
+    private static Part copyImagePart(Part src) {
+        Part p = new Part(Image, src.getDesc());
+        p.setIndex(src.getIndex());
+        p.setFileLocationIndex(src.getFileLocationIndex());
+        p.setDetails(src.getDetails());
+
+        if (src.getChartParams() != null) {
+            p.setChartParams(src.getChartParams());
+        }
+
+        return p;
+    }
+
+    private static FileAnalysisReport makeErrorReport(FileAnalysisReport inputReport,
+                                                      String analyzerId,
+                                                      String msg) {
+        FileAnalysisReport out = inputReport.copy(false);
+        Part err = new Part(ErrorResponse, "Invalid FITS for Alert Viewer");
+        err.setDesc(msg);
+        out.replaceParts(List.of(err));
+        out.setDataProductsAnalyzerId(analyzerId);
+        out.setAnalyzerFound(true);
+        return out;
+    }
+}
+
+
+

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/alert/AlertViewerSearchProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/alert/AlertViewerSearchProcessor.java
@@ -1,0 +1,173 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query.alert;
+
+import edu.caltech.ipac.firefly.core.FileAnalysis;
+import edu.caltech.ipac.firefly.core.FileAnalysisReport;
+import edu.caltech.ipac.firefly.data.FileInfo;
+import edu.caltech.ipac.firefly.data.ServerRequest;
+import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.query.DataAccessException;
+import edu.caltech.ipac.firefly.server.query.JsonStringProcessor;
+import edu.caltech.ipac.firefly.server.query.ParamDoc;
+import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
+import edu.caltech.ipac.firefly.server.util.LockingRetrieve;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.util.StringUtils;
+import edu.caltech.ipac.util.download.UriRef;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+import java.util.Collections;
+import java.util.List;
+
+import static edu.caltech.ipac.firefly.core.FileAnalysisReport.ReportType.Details;
+import static edu.caltech.ipac.firefly.core.FileAnalysisReport.Type.ErrorResponse;
+
+@SearchProcessorImpl(id = "AlertViewerSearchProcessor", params = {
+        @ParamDoc(name = "source", desc = "A FITS URL or an Alert ID.")
+})
+public class AlertViewerSearchProcessor extends JsonStringProcessor {
+
+    private static final Logger.LoggerImpl LOGGER = Logger.getLogger();
+
+    public static final String ID = "AlertViewerSearchProcessor";
+    public static final String SOURCE = "source";
+    private static final String ANALYZER_ID = "alert";
+
+    @Override
+    public boolean doCache() {
+        return true;
+    }
+
+    @Override
+    public String fetchData(ServerRequest req) throws DataAccessException {
+        final String source = req.getParam(SOURCE) == null ? null : req.getParam(SOURCE).trim();
+
+        if (StringUtils.isEmpty(source)) {
+            return makeError(source, "A FITS URL is required.");
+        }
+
+        if (!UriRef.isValid(source)) {
+            return makeError(source, "Alert ID lookup is not supported yet. Please enter a full FITS URL.");
+        }
+
+        try {
+            /*todo: future AlertID logic (if source is just an alert ID) and if the service returns FITS directly:
+               //makeAlertServiceUrl would construct a URL to an alert service that returns the FITS file for a given alert ID
+               URL serviceUrl = new URL(makeAlertServiceUrl(alertId));
+               File tmpFits = File.createTempFile("alert-", ".fits");
+               FileInfo fileInfo = URLDownload.getDataToFile(serviceUrl, tmpFits);
+              */
+            FileInfo fileInfo = LockingRetrieve.downloadWithCacheMsg(source);
+            if (fileInfo == null) {
+                return makeError(source, "Unable to retrieve the FITS file.");
+            }
+            final int responseCode = fileInfo.getResponseCode();
+            if (responseCode > 305 || responseCode < 200) {
+                final String responseMsg = StringUtils.isEmpty(fileInfo.getResponseCodeMsg())
+                        ? "Unknown error"
+                        : fileInfo.getResponseCodeMsg();
+                return makeError(source,
+                        "Unable to retrieve the FITS file: " + responseCode + " " + responseMsg);
+            }
+
+            FileAnalysisReport report = FileAnalysis.analyze(fileInfo, Details, ANALYZER_ID, Collections.emptyMap());
+            return makeSuccess(source, fileInfo, report);
+        } catch (Exception e) {
+            throw new DataAccessException("Unable to load alert data: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public String getUniqueID(ServerRequest request) {
+        return ID + ":" + request.getParam(SOURCE, "");
+    }
+
+    private static String makeSuccess(String source, FileInfo fileInfo, FileAnalysisReport report) {
+        JSONObject out = baseResponse(source, true, null);
+        String fileKey = null;
+        String fileName = null;
+
+        try {
+            if (fileInfo != null && fileInfo.getFile() != null) {
+                fileKey = ServerContext.replaceWithPrefix(fileInfo.getFile());
+                fileName = fileInfo.getExternalName();
+                out.put("fileKey", fileKey);
+                out.put("fileName", fileName);
+            }
+
+            if (report == null) {
+                out.put("success", false);
+                out.put("message", "Could not analyze the FITS file.");
+                return out.toJSONString();
+            }
+
+            if (!StringUtils.isEmpty(report.getFileName())) {
+                fileName = report.getFileName();
+                out.put("fileName", fileName);
+            }
+
+            List<FileAnalysisReport.Part> parts = report.getParts();
+            if (parts == null || parts.isEmpty()) {
+                out.put("success", false);
+                out.put("message", "Could not analyze the FITS file.");
+                return out.toJSONString();
+            }
+
+            if (parts.size() == 1 && parts.get(0).getType() == ErrorResponse) {
+                out.put("success", false);
+                out.put("message", parts.get(0).getDesc());
+                return out.toJSONString();
+            }
+
+            JSONArray entries = new JSONArray();
+            for (int i = 0; i < Math.min(parts.size(), 5); i++) {
+                FileAnalysisReport.Part part = parts.get(i);
+                entries.add(makeEntry(part, i, fileKey, fileName));
+            }
+
+            out.put("entries", entries);
+            if (entries.size() != 5) {
+                out.put("success", false);
+                out.put("message", "Expected 5 alert viewer entries but found " + entries.size() + ".");
+                Logger.error("Expected 5 alert viewer entries but found " + entries.size() + ".");
+            }
+        }
+        catch (Exception e) {
+            Logger.error("Error processing the FITS file: " + e.getMessage());
+        }
+        return out.toJSONString();
+    }
+
+    private static JSONObject makeEntry(FileAnalysisReport.Part part, int fallbackIdx, String fileKey, String fileName) {
+        JSONObject entry = new JSONObject();
+        entry.put("type", part.getType().name());
+        entry.put("desc", part.getDesc());
+        entry.put("extNum", getExtNum(part, fallbackIdx));
+        //have each entry take a fileKey and fileName in case the viewer needs to retrieve the file for that specific entry (e.g. if it's an image or a table that can be retrieved as a separate file)
+        if (!StringUtils.isEmpty(fileKey)) entry.put("fileKey", fileKey);
+        if (!StringUtils.isEmpty(fileName)) entry.put("fileName", fileName);
+        return entry;
+    }
+
+    private static int getExtNum(FileAnalysisReport.Part part, int fallbackIdx) {
+        return part.getFileLocationIndex() > -1 ? part.getFileLocationIndex() :
+                part.getIndex() > -1 ? part.getIndex() : fallbackIdx;
+    }
+
+    private static String makeError(String source, String message) {
+        return baseResponse(source, false, message).toJSONString();
+    }
+
+    private static JSONObject baseResponse(String source, boolean success, String message) {
+        JSONObject out = new JSONObject();
+        out.put("success", success);
+        out.put("source", source);
+        if (!StringUtils.isEmpty(message)) {
+            out.put("message", message);
+        }
+        return out;
+    }
+}

--- a/src/firefly/js/FFEntryPoint.js
+++ b/src/firefly/js/FFEntryPoint.js
@@ -10,6 +10,21 @@ import {getLcCommands} from './api/webApiCommands/LcWebApiCommands.js';
 import {getDatalinkUICommands} from './api/webApiCommands/DatalinkUICommands.js';
 import {getDefaultMOCList} from 'firefly/visualize/HiPSMocUtil.js';
 import APP_ICON from 'html/images/fftools-logo-offset-small-42x42.png';
+import {ROUTER} from 'firefly/templates/router/RouteHelper';
+import {alertviewer} from 'firefly/apps/alertviewer/alertviewer';
+
+
+
+/**
+ * Pages are spa within a webapp.  In this case, a page can be alertviewer and a webapp is firefly(applications).
+ * @type {object}
+ * @prop {function} init  an init function to call after firefly completes bootstrap.
+ * @prop {object[]} menu  a list of menu for this page.
+ */
+const pages = {
+    alertviewer,
+};
+
 
 /**
  * @example
@@ -26,7 +41,7 @@ const defProps = {
     appIcon: <img src={APP_ICON} style={{width:38}}/>
 };
 
-const props = mergeObjectOnly(defProps, window?.firefly?.app ?? {});
+let props = mergeObjectOnly(defProps, window?.firefly?.app ?? {});
 const {template}= props;
 
 
@@ -57,17 +72,23 @@ const defOptions = {
     coverage : { }
 };
 
-const options = mergeObjectOnly(defOptions, window?.firefly?.options ?? {});
+let options = mergeObjectOnly(defOptions, window?.firefly?.options ?? {});
 
-let apiCommands;
+let apiCommands, initApp;
 if (template==='FireflyViewer' || template==='FireflySlate') {
     apiCommands= [...getFireflyViewerWebApiCommands(), ...getDatalinkUICommands(false,'DLGeneratedDropDownCmd')];
-}
-else if (template==='LightCurveViewer') {
+} else if (template==='LightCurveViewer') {
     apiCommands= getLcCommands();
+} else if (template === ROUTER) {
+    const pageDef= pages[props.page]; // page id should be defined in html file firefly.app.page
+    props = mergeObjectOnly(props, pageDef?.props);
+    options = mergeObjectOnly(options, pageDef?.options);
+    if (pageDef?.menu) props.menu = pageDef?.menu; // if the page defines a menu then use it
+    apiCommands = pageDef?.webApiCommands;
+    initApp = pageDef?.init;
 }
 
 
 if (!template || template==='LightCurveViewer') options.searchActions= [];
 
-firefly.bootstrap(props, options, apiCommands);
+firefly.bootstrap(props, options, apiCommands).then(() => initApp?.());

--- a/src/firefly/js/apps/alertviewer/AlertIDDialog.jsx
+++ b/src/firefly/js/apps/alertviewer/AlertIDDialog.jsx
@@ -1,0 +1,118 @@
+import React, {useEffect} from 'react';
+import {Box, Button, Card, FormLabel, List, ListItem, ListItemButton, Stack, Typography} from '@mui/joy';
+import {FieldGroup} from 'firefly/ui/FieldGroup';
+import {ValidationField} from 'firefly/ui/ValidationField';
+import CompleteButton from 'firefly/ui/CompleteButton.jsx';
+import DialogRootContainer from 'firefly/ui/DialogRootContainer.jsx';
+import {PopupPanel} from 'firefly/ui/PopupPanel.jsx';
+import {useFieldGroupValue} from 'firefly/ui/SimpleComponent';
+import {dispatchHideDialog, dispatchShowDialog} from 'firefly/core/ComponentCntlr';
+import {dispatchAddPreference, getPreference} from 'firefly/core/AppDataCntlr';
+
+const DIALOG_ID = 'alertIdDialog';
+const ID_KEY = 'alertId';
+const GROUP_KEY = 'ALERT_ID_OPTIONS';
+
+let lastClick = 0;
+
+export const ALERT_ID_LIST_PREF = 'AlertViewer.RecentUrls';
+const MAX_ID_LEN = 40; //todo: arbitrary, confirm later...
+
+export function getRecentAlertIDs() {
+    return getPreference(ALERT_ID_LIST_PREF, []);
+}
+
+export function addToRecentAlertIDs(id) {
+    let idAry = getRecentAlertIDs();
+    if (idAry.includes(id)) {
+        idAry = idAry.filter((u) => u !== id);
+    } else if (idAry.length > MAX_ID_LEN - 1) {
+        idAry = idAry.slice(0, MAX_ID_LEN - 1);
+    }
+    idAry.unshift(id);
+    dispatchAddPreference(ALERT_ID_LIST_PREF, idAry);
+}
+
+export function showAlertIdDialog(currId, onChange) {
+    const popup = (
+        <PopupPanel title={'Recent Alerts'}>
+            <AlertIdPanel {...{currId, onChange}}/>
+        </PopupPanel>
+    );
+    DialogRootContainer.defineDialog(DIALOG_ID, popup);
+    dispatchShowDialog(DIALOG_ID);
+}
+
+function AlertIdPanel({currId, onChange}) {
+    const [getId, setId] = useFieldGroupValue(ID_KEY, GROUP_KEY);
+
+    useEffect(() => {
+        setId(currId || '');
+    }, [currId]);
+
+    return (
+        <FieldGroup groupKey={GROUP_KEY} sx={{minWidth:'40rem', minHeight:'28rem',
+            display:'flex', flexDirection:'column', overflow:'auto', resize:'both'}}>
+            <Stack spacing={2} sx={{p:1, height:1}}>
+                <ValidationField
+                    groupKey={GROUP_KEY}
+                    fieldKey={ID_KEY}
+                    label='Enter Alert URL or ID'
+                    initialState={{value:''}}
+                    onKeyPress={(ev, v) => {
+                        if (ev.key === 'Enter') handleSuccess(v, onChange, true);
+                    }}
+                    showFeedback={true}
+                />
+
+                <Stack spacing={0.5} sx={{flex:'1 1 auto'}}>
+                    <FormLabel>Or choose from recent IDs</FormLabel>
+                    <Card sx={{'--Card-padding':'1px', flex:'1 1 auto'}}>
+                        <Box sx={{width:1, overflow:'auto', height:'17rem'}}>
+                            {getRecentAlertIDs()?.length ? (
+                                <List sx={{'--ListItem-minHeight': '.5rem'}}>
+                                    {getRecentAlertIDs().map((u, idx) => (
+                                        <ListItem key={idx}>
+                                            <ListItemButton onClick={() => {
+                                                if (u === getId() && Date.now() - lastClick < 1000) {
+                                                    handleSuccess(u, onChange, true);
+                                                } else {
+                                                    setId(u);
+                                                    lastClick = Date.now();
+                                                }
+                                            }}>
+                                                {u}
+                                            </ListItemButton>
+                                        </ListItem>
+                                    ))}
+                                </List>
+                            ) : (
+                                <Typography color='warning' level='title-lg' sx={{textAlign:'center', mt:5}}>
+                                    No recent IDs
+                                </Typography>
+                            )}
+                        </Box>
+                    </Card>
+                </Stack>
+
+                <Stack direction='row' justifyContent='space-between' sx={{pt:1}}>
+                    <Stack direction='row' spacing={1}>
+                        <CompleteButton
+                            text='Use ID'
+                            dialogId={DIALOG_ID}
+                            onSuccess={(r) => handleSuccess(r[ID_KEY], onChange, true)}
+                        />
+                        <Button size='md' onClick={() => setId(currId || '')}>Restore current</Button>
+                    </Stack>
+                </Stack>
+            </Stack>
+        </FieldGroup>
+    );
+}
+
+function handleSuccess(url, onChange, close=false) {
+    const u = (url || '').trim();
+    if (u) addToRecentAlertIDs(u);
+    onChange?.(u);
+    if (close) dispatchHideDialog(DIALOG_ID);
+}

--- a/src/firefly/js/apps/alertviewer/AlertIDs.js
+++ b/src/firefly/js/apps/alertviewer/AlertIDs.js
@@ -1,0 +1,21 @@
+const MAX_ROW = Math.pow(2, 31) - 1;
+
+export const ALERT = {
+    TABLE_GROUP_MAIN: 'main',
+    TABLE_GROUP_DETAILS: 'details',
+
+    TABLE_1_ID: 'alert_table_1',
+    TABLE_2_ID: 'alert_table_2',
+
+    IMG_VIEWER: 'alert_img_viewer',
+
+    IMG_PLOT_1: 'alert_plot_1',
+    IMG_PLOT_2: 'alert_plot_2',
+    IMG_PLOT_3: 'alert_plot_3',
+
+    CHART_VIEWER_1: 'alert_chart_viewer_1',
+    CHART_1_ID: 'alert_chart_1',
+
+    FG_UPLOAD: 'ALERT_UPLOAD',
+    TABLE_PAGESIZE: MAX_ROW,
+};

--- a/src/firefly/js/apps/alertviewer/AlertResultView.jsx
+++ b/src/firefly/js/apps/alertviewer/AlertResultView.jsx
@@ -1,0 +1,151 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import React, {useEffect, useState} from 'react';
+import {Sheet, Stack, Typography} from '@mui/joy';
+import {MultiImageViewer} from '../../visualize/ui/MultiImageViewer.jsx';
+import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+
+import {getTblById, getTblIdsByGroup} from '../../tables/TableUtil.js';
+import {visRoot} from 'firefly/visualize/ImagePlotCntlr';
+import {getPlotViewAry} from 'firefly/visualize/PlotViewUtil.js';
+
+import {ALERT} from './AlertIDs.js';
+import {PropertySheetAsTable} from 'firefly/tables/ui/PropertySheet';
+import {MultiProductChoice} from 'firefly/visualize/ui/multiProduct/MultiProductChoice';
+import {SHOW_CHART, SHOW_TABLE} from 'firefly/metaConvert/DataProductsType';
+import {dispatchChartAdd, getChartData} from 'firefly/charts/ChartsCntlr.js';
+import {MultiViewStandardToolbar} from 'firefly/visualize/ui/MultiViewStandardToolbar';
+import {getDefaultChartProps} from 'firefly/charts/ChartUtil';
+import DockLayoutPanel from 'firefly/ui/panel/DockLayoutPanel.jsx';
+
+const ALERT_STANDARD_LAYOUT = {
+    east: {index: 0, defaultSize: '50%'},
+    west: {index: 1},
+    south: {index: 2, defaultSize: '50%'},
+};
+
+function getAlertData() {
+    const mainIds = getTblIdsByGroup(ALERT.TABLE_GROUP_MAIN) || [];
+    const detailIds = getTblIdsByGroup(ALERT.TABLE_GROUP_DETAILS) || [];
+
+    const plotViews = getPlotViewAry(visRoot()) || [];
+    const hasImages = plotViews.length > 0;
+
+    return {
+        hasMainTable: mainIds.length > 0,
+        hasDetailTable: detailIds.length > 0,
+        hasImages,
+    };
+}
+
+function useEnsureMainChart() {
+    const mainTblLoaded = useStoreConnector(() => {
+        const tbl = getTblById?.(ALERT.TABLE_1_ID);
+        return Boolean(tbl && !tbl.isFetching && tbl.tableData);
+    });
+
+    useEffect(() => {
+        if (!mainTblLoaded) return;
+
+        if (getChartData(ALERT.CHART_1_ID, null)) return;
+
+        const def = getDefaultChartProps(ALERT.TABLE_1_ID);
+        if (!def) return;
+
+        dispatchChartAdd({
+            chartId: ALERT.CHART_1_ID,
+            viewerId: ALERT.CHART_VIEWER_1,
+            groupId: ALERT.TABLE_1_ID,
+            ...def,
+            deletable: false,
+        });
+    }, [mainTblLoaded]);
+}
+
+export function AlertResultView() {
+
+    useEnsureMainChart();
+
+    const [whatToShow, setWhatToShow] = useState(SHOW_TABLE);
+
+    const handleShowChange = (...args) => {
+        const v =
+            (args.length >= 2 ? args[1] : undefined) ??
+            args[0]?.target?.value ??
+            args[0];
+
+        if (v === SHOW_TABLE || v === SHOW_CHART) {
+            setWhatToShow(v);
+        } else {
+            console.warn('[Alert] ignoring unexpected whatToShow:', v, args);
+        }
+    };
+
+    const {hasMainTable, hasDetailTable, hasImages} = useStoreConnector(getAlertData);
+
+    const standardPanels = [
+        hasMainTable ? (
+            <MultiProductChoice
+                dataProductsState={null}
+                dpId='alert'
+                chartViewerId={ALERT.CHART_VIEWER_1}
+                tableGroupViewerId={ALERT.TABLE_GROUP_MAIN}
+                whatToShow={whatToShow}
+                onChange={handleShowChange}
+                mayToggle={true}
+            />
+        ) : (
+            <EmptySlot label='Table' />
+        ),
+        hasDetailTable ? (
+            <Stack sx={{width: 1, height: 1, pt: '28px'}}>
+                <PropertySheetAsTable
+                    tbl_id={ALERT.TABLE_2_ID}
+                    tbl_group={ALERT.TABLE_GROUP_DETAILS}
+                    tblOptions={{
+                        showFilters: true,
+                        showToolbar: true,
+                        removable: false,
+                    }}
+                />
+            </Stack>
+        ) : (
+            <Stack sx={{width: 1, height: 1, pt: '28px'}}>
+                <EmptySlot label='Details Table' />
+            </Stack>
+        ),
+        hasImages ? (
+            <Stack sx={{width: 1, height: 1}}>
+                <MultiImageViewer
+                    viewerId={ALERT.IMG_VIEWER}
+                    insideFlex={true}
+                    forceRowSize={1}
+                    Toolbar={MultiViewStandardToolbar}
+                    showViewerScroll={false}
+                />
+            </Stack>
+        ) : (
+            <EmptySlot label='Images' />
+        ),
+    ];
+
+    return (
+        <Sheet sx={{width: 1, height: 1, display: 'flex'}}>
+            <DockLayoutPanel config={ALERT_STANDARD_LAYOUT}>
+                {standardPanels}
+            </DockLayoutPanel>
+        </Sheet>
+    );
+}
+
+function EmptySlot({label}) {
+    return (
+        <Sheet variant='outlined' sx={{height: 1, display: 'flex', alignItems: 'center', justifyContent: 'center'}}>
+            <Typography level='body-sm' color='neutral'>
+                {label} - No data
+            </Typography>
+        </Sheet>
+    );
+}

--- a/src/firefly/js/apps/alertviewer/AlertUploadPanel.jsx
+++ b/src/firefly/js/apps/alertviewer/AlertUploadPanel.jsx
@@ -1,0 +1,185 @@
+import React, {useState} from 'react';
+import {showInfoPopup} from 'firefly/ui/PopupUtil';
+import {Button, IconButton, Input, Stack, Typography} from '@mui/joy';
+import {LoadingMessage} from 'firefly/visualize/ui/FileUploadViewPanel';
+import {makeFileRequest} from 'firefly/tables/TableRequestUtil';
+import {ALERT} from './AlertIDs.js';
+import {dispatchTableSearch} from 'firefly/tables/TablesCntlr';
+import WebPlotRequest from 'firefly/visualize/WebPlotRequest';
+import RangeValues from 'firefly/visualize/RangeValues';
+import {dispatchDeletePlotView, dispatchPlotImage} from 'firefly/visualize/ImagePlotCntlr';
+import {dispatchComponentStateChange} from 'firefly/core/ComponentCntlr';
+import {ROUTER} from 'firefly/templates/router/RouteHelper';
+import {addToRecentAlertIDs, showAlertIdDialog} from 'firefly/apps/alertviewer/AlertIDDialog';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import {removeTablesFromGroup} from 'firefly/tables/TableUtil';
+import {getJsonData} from 'firefly/rpc/SearchServicesJson';
+import {ServerRequest} from 'firefly/data/ServerRequest';
+import {dispatchChartRemove} from 'firefly/charts/ChartsCntlr';
+import {dispatchHideDropDown} from 'firefly/core/LayoutCntlr';
+
+const ALERT_LOAD_REQUEST = 'AlertViewerSearchProcessor';
+
+export const UploadPanel = () => {
+    const instruction = 'Enter an Alert URL or ID to load in the Alert Viewer:';
+    const [isLoading, setIsLoading] = useState(false);
+    const [source, setSource] = useState('');
+
+    const doLoad = async () => {
+        const trimmedSource = source.trim();
+        if (!trimmedSource) {
+            showInfoPopup('Please enter a FITS URL.', 'Load Error');
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            const request = new ServerRequest(ALERT_LOAD_REQUEST);
+            request.setParam('source', trimmedSource);
+
+            const result = await getJsonData(request);
+            if (!result?.success) {
+                showInfoPopup(result?.message || 'Unable to load alert data.', 'Load Error');
+                return;
+            }
+
+            addToRecentAlertIDs(trimmedSource);
+            clearAlertProducts(); //todo: keep this?
+            loadFromEntries(result);
+        } catch (error) {
+            showInfoPopup(`Error loading file: ${error.message}`, 'Load Error');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <Stack width={1} alignItems='center'>
+            <Stack spacing={3} sx={{mt: 4}}>
+                <Typography level='body-lg'>{instruction}</Typography>
+                    <Stack direction='row' spacing={1}>
+                        <Input
+                            sx={{width: '50rem'}}
+                            value={source}
+                            placeholder='Enter a FITS URL or Alert ID'
+                            onChange={(ev) => setSource(ev.target.value)}
+                            onKeyDown={(ev) => ev.key === 'Enter' && doLoad()}
+                        />
+                        <Button onClick={doLoad} loading={isLoading}>Load</Button>
+                        <IconButton
+                            size='sm'
+                            variant='outlined'
+                            title='Recent Alert IDs'
+                            onClick={() => {
+                                showAlertIdDialog(source, (newId) => {
+                                    if (newId) setSource(newId);
+                                });
+                            }}
+                        >
+                            <EditOutlinedIcon/>
+                        </IconButton>
+                    </Stack>
+                    {isLoading && <LoadingMessage/>}
+            </Stack>
+        </Stack>
+    );
+};
+
+UploadPanel.propTypes = {};
+
+function clearAlertProducts() {
+    removeTablesFromGroup(ALERT.TABLE_GROUP_MAIN);
+    removeTablesFromGroup(ALERT.TABLE_GROUP_DETAILS);
+    dispatchChartRemove(ALERT.CHART_1_ID);
+
+    [ALERT.IMG_PLOT_1, ALERT.IMG_PLOT_2, ALERT.IMG_PLOT_3].forEach((plotId) =>
+        dispatchDeletePlotView({plotId, holdWcsMatch: true})
+    );
+}
+
+function loadFromEntries(result) {
+    try {
+        const entries = result?.entries ?? [];
+        const mainTablePart = entries[0];
+        const detailsTablePart = entries[1];
+        const imageParts = entries.slice(2, 5);
+
+        if (entries.length < 5) {
+            showInfoPopup(`Alert viewer response must include 5 entries. Found ${entries.length}.`, 'Load Error');
+            return;
+        }
+
+        if (mainTablePart?.type !== 'Table' || detailsTablePart?.type !== 'Table') {
+            showInfoPopup('Alert viewer response did not return the first two entries as tables.', 'Invalid File Format');
+            return;
+        }
+        if (imageParts.length < 3 || imageParts.some((entry) => entry?.type !== 'Image')) {
+            showInfoPopup('Alert viewer response did not return the last three entries as images.', 'Invalid File Format');
+            return;
+        }
+
+        const getExtNum = (part, fallbackIdx) => part?.extNum ?? fallbackIdx;
+        const getFileLocation = (part) => part?.fileKey ?? result?.fileKey;
+        const getFileName = (part) => part?.fileName ?? result?.fileName ?? result?.source ?? 'Uploaded FITS';
+        const pickedTableParts = [mainTablePart, detailsTablePart];
+
+        for (let i = 0; i < 2; i++) {
+            const part = pickedTableParts[i];
+            const extNum = getExtNum(part, i);
+            const desc = part?.desc;
+            const fileLocation = getFileLocation(part);
+            const uploadedFileName = getFileName(part);
+
+            if (!fileLocation) {
+                showInfoPopup(`Alert viewer table entry ${i + 1} is missing a file key.`, 'Load Error');
+                return;
+            }
+
+            const tblReq = makeFileRequest(
+                desc || `${uploadedFileName} Table ${i + 1}`,
+                fileLocation,
+                null,
+                {
+                    tbl_id: i === 0 ? ALERT.TABLE_1_ID : ALERT.TABLE_2_ID,
+                    pageSize: ALERT.TABLE_PAGESIZE,
+                    META_INFO: {}
+                }
+            );
+            tblReq.tbl_index = extNum;
+
+            dispatchTableSearch(
+                tblReq,
+                {removable: true, tbl_group: i === 0 ? ALERT.TABLE_GROUP_MAIN : ALERT.TABLE_GROUP_DETAILS}
+            );
+        }
+
+        const plotIds = [ALERT.IMG_PLOT_1, ALERT.IMG_PLOT_2, ALERT.IMG_PLOT_3];
+
+        for (let i = 0; i < 3; i++) {
+            const part = imageParts[i];
+            const extNum = getExtNum(part, i);
+            const desc = part?.desc;
+            const fileLocation = getFileLocation(part);
+            const uploadedFileName = getFileName(part);
+            const plotId = plotIds[i];
+
+            if (!fileLocation) {
+                showInfoPopup(`Alert viewer image entry ${i + 1} is missing a file key.`, 'Load Error');
+                return;
+            }
+
+            const wpRequest = WebPlotRequest.makeFilePlotRequest(fileLocation);
+            wpRequest.setInitialRangeValues(RangeValues.make2To10SigmaLinear());
+            wpRequest.setPlotGroupId(ALERT.IMG_VIEWER);
+            wpRequest.setMultiImageExts(`${extNum}`);
+            wpRequest.setTitle(desc || `${uploadedFileName} [ext ${extNum}]`);
+
+            dispatchPlotImage({plotId, wpRequest, viewerId: ALERT.IMG_VIEWER, setNewPlotAsActive: i === 0});
+        }
+        dispatchComponentStateChange(ROUTER, {RESULTS: '/results'});
+        dispatchHideDropDown();
+    } catch (error) {
+        console.error('Error loading file:', error);
+        showInfoPopup(`Error loading file: ${error.message}`, 'Load Error');
+    }
+}

--- a/src/firefly/js/apps/alertviewer/alertviewer.js
+++ b/src/firefly/js/apps/alertviewer/alertviewer.js
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import {createRouter} from 'firefly/templates/router/RoutedApp.jsx';
+import {FormWatcher} from 'firefly/templates/router/RouteHelper';
+import {UploadPanel} from 'firefly/apps/alertviewer/AlertUploadPanel';
+import {AlertResultView} from 'firefly/apps/alertviewer/AlertResultView';
+
+function getBasename() {
+    const p = window.location.pathname || '';
+    //strip route suffixes if present
+    const noRoute = p.replace(/\/(upload|results)(\/.*)?$/, '');
+    //remove trailing slash
+    return noRoute.endsWith('/') ? noRoute.slice(0, -1) : noRoute;
+}
+
+
+const basename = getBasename(); //'/firefly/alertviewer';
+const routes = [
+    {
+        path: '/upload',
+        element: <FormWatcher submitTo='/results'><UploadPanel/></FormWatcher>
+    },
+    {
+        path: '/results',
+        element: <AlertResultView/>
+    },
+];
+
+
+export const alertviewer = {
+    init,
+    props: {
+        appTitle: 'Alert Viewer',
+        getRouter: createRouter(basename, routes),
+        appIcon: 'n/a',
+        slotProps: {
+            drawer: { drawerWidth:'24rem'},
+            landing: {
+                desc: 'Some information about the alert viewer here. This is the landing page. This text will be changed to something more useful in the future.',
+                bgImage: null,
+            }
+        }
+    },
+    menu: [
+        {label:'Alert', action: 'AlertUpload', primary: true, path:'/upload'},
+        {label:'Help', action:'app_data.helpLoad', type:'COMMAND'},
+    ],
+    webApiCommands: {},
+};
+
+
+function init() {}

--- a/src/firefly/js/ui/FileUpload.jsx
+++ b/src/firefly/js/ui/FileUpload.jsx
@@ -1,6 +1,6 @@
 import {Button, CircularProgress, Input, Stack, Tooltip, Typography} from '@mui/joy';
 import React, {memo, useEffect} from 'react';
-import {object, bool, func, number, string, shape} from 'prop-types';
+import {object, bool, func, string, shape} from 'prop-types';
 import {has, isFunction, isNil, isString} from 'lodash';
 import {getHttpErrorMessage} from '../util/HttpErrorMessage.js';
 import {validateUrl} from '../util/Validate.js';
@@ -109,14 +109,14 @@ export const FileUpload= memo( (props) => {
             ...viewProps,
             onChange: (ev) => onUrlChange(ev, viewProps, fireValueChange),
             value:  viewProps.displayValue,
-            onUrlAnalysis: (value) => doUrlAnalysis(value, fireValueChange, fileType, viewProps.fileAnalysis)
+            onUrlAnalysis: (value) => doUrlAnalysis(value, fireValueChange, fileType, viewProps.fileAnalysis, viewProps.uploadParams)
         };
     }
     else {
         modViewProps= {
             ...viewProps,
             value: viewProps.displayValue,
-            onChange: (ev) => handleChange(ev, fireValueChange, fileType, viewProps.fileAnalysis)
+            onChange: (ev) => handleChange(ev, fireValueChange, fileType, viewProps.fileAnalysis, viewProps.uploadParams)
         };
     }
     return <FileUploadView {...{...modViewProps, hasUploadedData:Boolean(modViewProps.analysisResult) }}/> ;
@@ -131,6 +131,7 @@ FileUpload.propTypes = {
     canDragDrop: bool,
     setDropEvent: func,
     dropEvent: object,
+    uploadParams: object,
     initialState: shape({
         tooltip: string,
         label:  string,
@@ -151,12 +152,12 @@ function onUrlChange(ev, store, fireValueChange) {
 }
 
 
-function doUrlAnalysis(value, fireValueChange, type, fileAnalysis) {
-     fireValueChange({value: makeDoUpload(value, type, true, fileAnalysis)()});
+function doUrlAnalysis(value, fireValueChange, type, fileAnalysis,uploadParams={}) {
+    fireValueChange({value: makeDoUpload(value, type, true, fileAnalysis, uploadParams)()});
 }
 
 
-function handleChange(ev, fireValueChange, type, fileAnalysis) {
+function handleChange(ev, fireValueChange, type, fileAnalysis, uploadParams={}) {
     let file = ev?.target?.files?.[0];
     let displayValue;
     if (ev) {
@@ -168,13 +169,14 @@ function handleChange(ev, fireValueChange, type, fileAnalysis) {
     }
     fireValueChange({
         displayValue,
-        value: !fileAnalysis ? makeDoUpload(file, type) : makeDoUpload(file, type, false, fileAnalysis)()
+        value: !fileAnalysis ? makeDoUpload(file, type, false, false, uploadParams)()
+                                        : makeDoUpload(file, type, false, fileAnalysis, uploadParams)()
     });
 }
 
-function makeDoUpload(file, type, isFromURL, fileAnalysis) {
+function makeDoUpload(file, type, isFromURL, fileAnalysis, uploadParams={}) {
     return () => {
-        return doUpload(isFromURL, file, fileAnalysis, {}).then(({status, message, cacheKey, fileFormat, analysisResult}) => {
+        return doUpload(isFromURL, file, fileAnalysis, uploadParams).then(({status, message, cacheKey, fileFormat, analysisResult}) => {
             let valid = status === '200';
             if (valid) {        // json file is not supported currently (among many others)
                 if (!isNil(fileFormat)) { // TODO: doUpload is not returning fileFormat field (analysisResult JSON string has this field though), has to be refactored

--- a/src/firefly/js/ui/SimpleComponent.jsx
+++ b/src/firefly/js/ui/SimpleComponent.jsx
@@ -38,30 +38,26 @@ export function useStoreConnector(stateGetter, deps=[], markAsTransition=false) 
     const [val, setter] = useState(stateGetter());
     const [isPending,startTransition]= useTransition();
 
-    let isMounted = true;
     useEffect(() => {
         let cState = val;
-        const remover = flux.addListener(() => {
-            if (isMounted) {
-                const nState = stateGetter(cState);      // if getter returns oldState then no state update
-                if (nState===cState) return;             // comparator might be overridden, use === first for efficiency
-                if ( !comparator(cState, nState) ) {
-                    cState = nState;
-                    if (markAsTransition) {
-                        startTransition(() =>{
-                           setter(cState);
-                        });
-                    }
-                    else {
-                        setter(cState);
-                    }
-                }
+        const syncFromStore = () => {
+            const nState = stateGetter(cState);      // if getter returns oldState then no state update
+            if (nState===cState || comparator(cState, nState)) return; // comparator might be overridden, use === first for efficiency
+            cState = nState;
+            if (markAsTransition) {
+                startTransition(() =>{
+                   setter(cState);
+                });
             }
-        });
-        return () => {
-            isMounted = false;
-            remover && remover();
+            else {
+                setter(cState);
+            }
         };
+        const remover = flux.addListener(syncFromStore);
+        //call syncFromStore once in case there were updates between the first call to stateGetter and the time the listener was added
+        //re-read once in case the store changed after the initial snapshot but before subscription attached.
+        syncFromStore();
+        return () => remover?.();
     }, deps);     // defaults to run only once
 
     return val;

--- a/src/firefly/js/visualize/iv/ImageViewer.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewer.jsx
@@ -65,7 +65,7 @@ const TEN_SECONDS= 10000;
 export const ImageViewer= memo( ({showWhenExpanded=false, plotId, makeToolbar, makeLegend}) => {
 
     const [mousePlotId, setMousePlotId] = useState(lastMouseCtx().plotId);
-    const {plotView:unused1,vr:unused2,drawLayersAry} = useStoreConnector( (oldState) => getStoreState(plotId,oldState) ); // see useState bug comment below
+    const {plotView,vr,drawLayersAry} = useStoreConnector( (oldState) => getStoreState(plotId,oldState) );
     const {current:timeoutRef} = useRef({timeId:undefined});
 
     const deferredDrawLayersAry= useDeferredValue(drawLayersAry);
@@ -90,11 +90,6 @@ export const ImageViewer= memo( ({showWhenExpanded=false, plotId, makeToolbar, m
     }, [mousePlotId, plotId]);
 
 
-    // these next two lines are a workaround for a bug (I think) in getState (via useStoreConnector)
-    // in a certain cases it appears to be returning an old state even after unmount and remount
-    const vr= visRoot();
-    const plotView= getPlotViewById(vr,plotId);
-    //-------
     if (!showWhenExpanded  && vr.expandedMode!==ExpandType.COLLAPSE) return false;
     if (!plotView) return false;
 

--- a/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
+++ b/src/firefly/js/visualize/ui/MultiImageViewerView.jsx
@@ -48,7 +48,7 @@ export function MultiImageViewerView(props)  {
         makeToolbar:handleToolbar?makeToolbar:undefined, makeItemViewer, makeItemViewerFull:makeItemViewer};
 
     const insideStyle= props.insideFlex ? {flex:'1 1 auto', maxWidth:'100%'} : {width:'100%', height:'100%'};
-    const style= { display:'flex', flexDirection:'column', position:'relative', ...insideStyle, ...props.style };
+    const style= { display: 'flex', flexDirection: 'column', position: 'relative', ...insideStyle, ...props.style };
 
     const pvToUseForReadout= isLockByClick(readout) ? primePlot(visRoot) : primePlot(visRoot,lastMouseCtx().plotId);
     const one= layoutType===SINGLE || viewerPlotIds?.length===1;
@@ -58,7 +58,7 @@ export function MultiImageViewerView(props)  {
         bottom:one ? 2 : 3, 
         right: one ? 3 : scrollGrid? 15 : 6, 
     };
-    
+
     return (
         <div className='MultiImageViewer' style={style} ref={(e) => elementWrapper.element= e}>
             <MultiItemViewerView {...{...newProps, ref, insideFlex:true, style:props.style}} />

--- a/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
+++ b/src/firefly/js/visualize/ui/MultiViewStandardToolbar.jsx
@@ -3,17 +3,16 @@
  */
 
 
-import React, {useEffect} from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import {Divider, Sheet, Stack} from '@mui/joy';
-import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
+import {Sheet, Stack} from '@mui/joy';
 import {ToolbarHorizontalSeparator} from '../../ui/ToolbarButton.jsx';
 import {HIDDEN} from '../ImViewFilterDisplay';
 import {ViewerScroll} from '../iv/ExpandedTools.jsx';
 import {
     dispatchChangeViewerLayout, EXPANDED_MODE_RESERVED, getMultiViewRoot, getViewer, getViewerItemIds
 } from '../MultiViewCntlr.js';
-import {dispatchChangeActivePlotView, ExpandType} from '../ImagePlotCntlr.js';
+import {dispatchChangeActivePlotView} from '../ImagePlotCntlr.js';
 import {BeforeButton, DisplayTypeButtonGroup, NextButton } from './Buttons.jsx';
 import {ViewOptionsButton} from './ExpandedOptionsPopup.jsx';
 import {VisMiniToolbar} from './VisMiniToolbar.jsx';
@@ -22,7 +21,7 @@ import {getActivePlotView} from '../PlotViewUtil.js';
 
 export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, toolbarVariant,
                                           layoutType= 'grid', makeDropDown, useImageList= false,
-                                             toolbarStyle={}}) {
+                                             toolbarStyle={}, showViewerScroll=true}) {
     
     let cIdx= viewerPlotIds.findIndex( (plotId) => plotId===visRoot.activePlotId);
 
@@ -60,7 +59,7 @@ export function MultiViewStandardToolbar({visRoot, viewerId, viewerPlotIds, tool
                         ]
                     }}/>}
                     {useImageList && multipleForImageList && <ViewOptionsButton title='Pinned Images' viewerId={viewerId}/> }
-                    {moreThanOne && layout==='grid' &&
+                    {showViewerScroll && moreThanOne && layout==='grid' &&
                         <>
                             <ToolbarHorizontalSeparator/>
                             <ViewerScroll {...{viewerId,checked:scroll,count:viewerPlotIds.length}}/>
@@ -96,4 +95,5 @@ MultiViewStandardToolbar.propTypes= {
     useImageList: PropTypes.bool,
     toolbarStyle: PropTypes.object,
     toolbarVariant: PropTypes.string,
+    showViewerScroll: PropTypes.bool,
 };

--- a/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
+++ b/src/firefly/js/visualize/ui/multiProduct/MultiProductChoice.jsx
@@ -23,11 +23,12 @@ let lastChartDefault= 'Chart';
 
 
 export function MultiProductChoice({ dataProductsState, dpId,
-                                       makeDropDown, chartViewerId, imageViewerId, metaDataTableId,
-                                       tableGroupViewerId, whatToShow, onChange, mayToggle = false, factoryKey
-                                   }) {
-    const {enableCutout, pixelBasedCutout=false, dlData, gridForceRowSize}= dataProductsState;
-    const {serDef, cutoutToFullWarning, dlAnalysis:{cutoutFullPair=false}={}}= dataProductsState.dlData ?? {};
+                                      makeDropDown, chartViewerId, imageViewerId, metaDataTableId,
+                                      tableGroupViewerId, whatToShow, onChange, mayToggle = false, factoryKey
+                                  }) {
+    //handle null dataProductsState for cases where data products workflow is not used
+    const {enableCutout, pixelBasedCutout=false, dlData, gridForceRowSize}= dataProductsState ?? {};
+    const {serDef, cutoutToFullWarning, dlAnalysis:{cutoutFullPair=false}={}}= dataProductsState?.dlData ?? {};
     const primeIdx= useStoreConnector(() => getActivePlotView(visRoot())?.primeIdx ?? -1);
     const {current:showingStatus}= useRef({oldWhatToShow:undefined});
     const stateDef= dlData ? dlData?.dlAnalysis?.isSpectrum ? 'Spectrum' : 'Chart' : lastChartDefault;
@@ -38,14 +39,15 @@ export function MultiProductChoice({ dataProductsState, dpId,
     const tbl_id = getTableGroup(tableGroupViewerId)?.active;
     const table = tbl_id ? getTblById(tbl_id) : undefined;
     useEffect(() => {
+        if (!tbl_id) return;
         onTableLoaded(tbl_id).then(() => {
             const name = (getMetaEntry(tbl_id, 'utype') === 'spec:Spectrum') ? 'Spectrum' : 'Chart';
             setChartName(name);
             lastChartDefault= name;
         });
-    }, [dataProductsState.activate,tbl_id]);
+    }, [dataProductsState?.activate,tbl_id]);
 
-    const activeItemKey= getActiveFileMenuKeyByKey(dpId,dataProductsState?.fileMenu?.activeItemLookupKey);
+    const activeItemKey= dataProductsState ? getActiveFileMenuKeyByKey(dpId,dataProductsState?.fileMenu?.activeItemLookupKey) : undefined;
     const cubeIdx= dataProductsState?.fileMenu?.menu.find( (i) => i.menuKey===activeItemKey)?.cubeIdx ?? -1;
 
     useEffect(() => {


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1935
- Implement Alert Viewer template
- Improved server side logic by adding a search processor based on feedback
- The processor retrieves & downloads the file, and then uses the existing `AlertAnalyzer`, then returns the parts (2 tables and 3 images) back to client as JSON
  - each JSON entry also includes the file location, in case we support multiple (more than one) files later 
- This in turn simplifies the client-side code inside `AlertUploadPanel` 
- Using the same `viewerId` and only one call to `MultiImageViewer` for images now
- **_ToDo_**: some basic cleanup left to do including fixing heights of the 2 tables 
- **_Note_**: The search processor currently only supports URLs, but I have some commented out code (marked with a `todo`) ready to accept Alert IDs as well. This should be pretty easy to enable once we have working examples of Alert IDs (and the service to call with those IDs). 

**Test build**: Alert Viewer: https://fireflydev.ipac.caltech.edu/firefly-1935-alert-viewer/firefly/alertviewer
- files you can use to test upload: 
  - https://web.ipac.caltech.edu/staff/roby/alert-test/al-test-2.fits
  - https://web.ipac.caltech.edu/staff/roby/alert-test/coadd-1-100-thru20210505.fits