### PR TITLE
FIREFLY-1943: React Compiler bugs

### DIFF
--- a/src/firefly/js/ui/SimpleComponent.jsx
+++ b/src/firefly/js/ui/SimpleComponent.jsx
@@ -152,6 +152,17 @@ export function useFieldGroupValue(fieldKey, gk) {
     return [ getter, setter];
 }
 
+/**
+ * Convenience hook for components that only need the current field value and not the setter.
+ *
+ * @param {String} fieldKey - field key to read
+ * @param {*} def - default value to return when the field value is nullish
+ * @param {String} [gk] - optional group key; defaults to the current FieldGroup context
+ * @return {*} current field value or the provided default
+ */
+export function useFieldValueOnly(fieldKey, def, gk) {
+    return useFieldGroupValue(fieldKey, gk)[0]() ?? def;
+}
 
 
 /**

--- a/src/firefly/js/ui/tap/Constraints.js
+++ b/src/firefly/js/ui/tap/Constraints.js
@@ -3,10 +3,27 @@ import React from 'react';
 
 export const ConstraintContext = React.createContext({});
 
+export function hasAdqlConstraint(constraintObj) {
+    return Boolean(
+        constraintObj?.adqlConstraint ||
+        constraintObj?.adqlConstraintsAry?.length
+    );
+}
+
+function getAdqlConstraintsList(constraintObj) {
+    if (constraintObj?.adqlConstraintsAry?.length) return constraintObj.adqlConstraintsAry;
+    if (constraintObj?.adqlConstraint) return [constraintObj.adqlConstraint];
+    return [];
+}
+
+function isConstraintsValid(constraintObj) {
+    return !constraintObj?.constraintErrors?.length;
+}
+
 export function isTapUpload(tapBrowserState) {
     const {constraintFragments}= tapBrowserState;
     return [...constraintFragments.values()]
-        .some( (c) => Boolean(c.uploadFile && c.TAP_UPLOAD && c.adqlConstraint));
+        .some((c) => Boolean(c.uploadFile && c.TAP_UPLOAD && hasAdqlConstraint(c)));
 }
 
 /**
@@ -16,7 +33,8 @@ export function isTapUpload(tapBrowserState) {
  */
 export function getUploadConstraint(tapBrowserState) {
     const {constraintFragments}= tapBrowserState;
-    return [...constraintFragments.values()].find( (c) => Boolean(c.uploadFile && c.TAP_UPLOAD && c.adqlConstraint));
+    return [...constraintFragments.values()]
+        .find((c) => Boolean(c.uploadFile && c.TAP_UPLOAD && hasAdqlConstraint(c)));
 }
 
 export function getTapUploadSchemaEntry(tapBrowserState) {
@@ -38,26 +56,17 @@ export function getHelperConstraints(tapBrowserState) {
     const {constraintFragments}= tapBrowserState;
     const adqlConstraints = [];
     const adqlConstraintErrorsArray = [];
-    const siaConstraints = [];
-    // adqlComponents can apparently be modified during iteration in the forEach...
+
     Array.from(constraintFragments.values()).forEach((constraintObj) => {
-        if (!constraintObj.adqlConstraintErrors?.length) {
-            if (constraintObj.adqlConstraint) {
-                adqlConstraints.push(constraintObj.adqlConstraint);
-            }
+        if (isConstraintsValid(constraintObj)) {
+            adqlConstraints.push(...getAdqlConstraintsList(constraintObj));
         } else {
-            adqlConstraintErrorsArray.push(constraintObj.constraintErrors);
-        }
-        if (!constraintObj.constraintErrors?.length) {
-            if (constraintObj.siaConstraints?.length > 0) {
-                siaConstraints.push(...constraintObj.siaConstraints);
-            }
-        } else {
-            adqlConstraintErrorsArray.push(constraintObj.constraintErrors);
+            adqlConstraintErrorsArray.push(...constraintObj.constraintErrors);
         }
     });
+
     return {
-        valid: adqlConstraintErrorsArray?.length === 0,
+        valid: adqlConstraintErrorsArray.length === 0,
         messages: adqlConstraintErrorsArray,
         where: adqlConstraints.join('\n      AND ')
     };

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -22,19 +22,15 @@ import {calcCornerString, PolygonDataArea} from '../CatalogSearchMethodType.jsx'
 import {FieldGroupCtx, ForceFieldGroupValid} from '../FieldGroup.jsx';
 import {ListBoxInputField} from '../ListBoxInputField.jsx';
 import {RadioGroupInputField} from '../RadioGroupInputField.jsx';
-import {useFieldGroupRerender, useFieldGroupValue, useFieldGroupWatch} from '../SimpleComponent.jsx';
+import {useFieldGroupRerender, useFieldGroupValue, useFieldGroupWatch,
+    useFieldValueOnly} from '../SimpleComponent.jsx';
 import {SizeInputFields} from '../SizeInputField.jsx';
 import {DEF_TARGET_PANEL_KEY} from '../TargetPanel.jsx';
 import {ConstraintContext} from './Constraints.js';
 import {ROW_POSITION, SEARCH_POSITION} from './Cutout';
 import {getDataServiceOption} from './DataServicesOptions';
-import {
-    DebugObsCore,
-    getPanelPrefix,
-    makeCollapsibleCheckHeader,
-    makeFieldErrorList,
-    makePanelStatusUpdater,
-} from './TableSearchHelpers.jsx';
+import {DebugObsCore, getPanelPrefix, makeCollapsibleCheckHeader, makeConstraintEntry, makeEmptyConstraints,
+    makeFieldErrorList} from './TableSearchHelpers.jsx';
 import {showUploadTableChooser} from '../UploadTableChooser.js';
 import {
     getAsEntryForTableName, getColumnAttribute, getTapServiceByURL, makeUploadSchema, maybeQuote,
@@ -134,15 +130,12 @@ export function SpatialSearch({sx, cols, serviceUrl, serviceLabel, serviceId, co
 
     const {setConstraintFragment}= useContext(ConstraintContext);
     const {setVal,getVal,makeFldObj}= useContext(FieldGroupCtx);
-    const [constraintResult, setConstraintResult] = useState({});
     const [getUploadInfo, setUploadInfo]= useFieldGroupValue('uploadInfo');
     const [posDefaultOpenMsg, setPosDefaultOpenMsg]= useState(true);
 
     useFieldGroupRerender([...fldListAry, ...collapsibleCheckHeaderKeys]); // force rerender on any change
 
     const uploadInfo= getUploadInfo() || undefined;
-
-    const updatePanelStatus= makePanelStatusUpdater(checkHeaderCtl.isPanelActive(), Spatial);
 
     useEffect(() => {
         if (!canUpload) setVal(SPATIAL_TYPE,SINGLE);
@@ -236,15 +229,23 @@ export function SpatialSearch({sx, cols, serviceUrl, serviceLabel, serviceId, co
 
     useFieldGroupWatch([cornerCalcType], () => onChangeToPolygonMethod());
 
-    useEffect(() => {
-        const constraints= makeSpatialConstraints(columnsModel, obsCoreEnabled, makeFldObj(fldListAry), uploadInfo, tableName, canUpload,useSIAv2);
-        updatePanelStatus(constraints, constraintResult, setConstraintResult,useSIAv2);
-    });
-    
+    const isSpatialPanelActive = checkHeaderCtl?.isPanelActive();
+
+    const constraintResult = React.useMemo(() => {
+        if (!isSpatialPanelActive) return makeEmptyConstraints();
+
+        const constraints = makeSpatialConstraints(
+            columnsModel, obsCoreEnabled, makeFldObj(fldListAry),
+            uploadInfo, tableName, canUpload, useSIAv2
+        );
+
+        return makeConstraintEntry(constraints);
+    }, [...fldListAry.map((v) => getVal(v))]);
+
     useEffect(() => {
         setConstraintFragment(panelPrefix, constraintResult);
         return () => setConstraintFragment(panelPrefix, '');
-    }, [constraintResult]);
+    }, [panelPrefix, setConstraintFragment, constraintResult]);
 
     if (disablePanel) {
         return (
@@ -320,14 +321,11 @@ function getSpacialLayoutMode(spacialType, obsCoreEnabled, canUpload) {
 
 const SpatialSearchLayout = ({initArgs, obsCoreEnabled, uploadInfo, setUploadInfo, serviceLabel, serviceId,
                                  hipsUrl, centerWP, fovDeg, capabilities, embeddedInHiPS, slotProps}) => {
-
-    const {getVal}= useContext(FieldGroupCtx);
-
-    const spacialType= getVal(SPATIAL_TYPE) ?? SINGLE;
-    const spatialMethod= getVal(SpatialMethod)??CONE_CHOICE_KEY;
-    const closest= getVal(Closest)??'';
-    const cornerCalcTypeValue= getVal(cornerCalcType)??'image';
-    const spatialRegOpValue= getVal(SpatialRegOp) ?? SpatialRegOpType.CONTAINS_POINT;
+    const spacialType = useFieldValueOnly(SPATIAL_TYPE, SINGLE);
+    const spatialMethod = useFieldValueOnly(SpatialMethod, CONE_CHOICE_KEY);
+    const closest = useFieldValueOnly(Closest, '');
+    const cornerCalcTypeValue = useFieldValueOnly(cornerCalcType, 'image');
+    const spatialRegOpValue = useFieldValueOnly(SpatialRegOp, SpatialRegOpType.CONTAINS_POINT);
     const layoutMode= getSpacialLayoutMode(spacialType,obsCoreEnabled,capabilities?.canUpload);
     const isCone= spatialMethod === CONE_CHOICE_KEY;
     const containsPoint= spatialRegOpValue === SpatialRegOpType.CONTAINS_POINT;

--- a/src/firefly/js/ui/tap/TableSearchHelpers.jsx
+++ b/src/firefly/js/ui/tap/TableSearchHelpers.jsx
@@ -63,6 +63,22 @@ function getPanelAdqlConstraint(panelActive, panelTitle,constraintsValid,adqlCon
     }
 }
 
+export function makeEmptyConstraints() {
+    return {
+        adqlConstraintsAry: [],
+        constraintErrors: [],
+        simpleError: '',
+    };
+}
+
+export function makeConstraintEntry(constraints = {}) {
+    return {
+        ...constraints,
+        constraintErrors: [...(constraints.errAry ?? [])],
+        simpleError: constraints.errAry?.[0] ?? '',
+    };
+}
+
 /**
  *
  * @param {boolean} panelActive

--- a/src/firefly/js/ui/tap/TapSearchSubmit.js
+++ b/src/firefly/js/ui/tap/TapSearchSubmit.js
@@ -9,7 +9,7 @@ import {
     getHelperConstraints,
     getTapUploadSchemaEntry,
     getUploadServerFile,
-    getUploadTableName,
+    getUploadTableName, hasAdqlConstraint,
     isTapUpload
 } from 'firefly/ui/tap/Constraints';
 import {makeTblRequest, setNoCache} from 'firefly/tables/TableRequestUtil';
@@ -105,9 +105,9 @@ export function onTapSearchSubmit({request, serviceUrl, tapBrowserState, additio
 
 function getCutoutType(tapBrowserState) {
     const spatial= tapBrowserState?.constraintFragments?.get('spatial');
-    if (spatial?.adqlConstraint?.length) return spatial.cutoutType;
+    if (hasAdqlConstraint(spatial)) return spatial.cutoutType;
     const location= tapBrowserState?.constraintFragments?.get('location');
-    if (location?.adqlConstraint?.length) return location.cutoutType;
+    if (hasAdqlConstraint(location)) return location.cutoutType;
     return ROW_POSITION;
 }
 
@@ -129,7 +129,7 @@ export function getAdqlQuery(tapBrowserState, additionalClauses, allowColumnCons
     if (isUpload) { //check for more than one upload file (in Spatial and in ObjectID col) - should this be a utility function in constraints.js?
         const { constraintFragments } = tapBrowserState;
         const entries = [...constraintFragments.values()];
-        const matchingEntries = entries.filter((c) => Boolean(c.uploadFile && c.TAP_UPLOAD && c.adqlConstraint));
+        const matchingEntries = entries.filter((c) => Boolean(c.uploadFile && c.TAP_UPLOAD && hasAdqlConstraint(c)));
         if (matchingEntries.length > 1) {
             if (showErrors) showInfoPopup('We currently do not support searches with more than one uploaded table.', 'Error');
             return;


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1943
- Fixes bugs introduced in code after enabling react compiler. See ticket for list of bugs. 
- Reason for most bugs: before react compiler, incidental re-renders would make some of the logic work, but with react compiler enabled, state renders became more obvious (and would happen only when necessary), often leading to stale values and exposing existing bugs (or rather bad code, because everything still worked fine). 
- **Bug 1: SIA Search**:
  - The issue with `constraints` is probably related to `makePanelStatusUpdater`. The way we update constraints here is really complicated, and `constraints` were not updated properly after enabling react compiler and led to stale values. 
    - I simplified it by reading the current field values that we calculate constraints from and depending on those changing to calculate/update `constraintResult`. 
  - if this refactor looks good, I will address the remaining usage of `makePanelStatusUpdater` in the new compiler ticket (see note below for other bugs found for this ticket). It's used in `ObjectIDSearch`, `ObsCore`, and a few other components. 
    - While there are no bugs there yet, it'll just make for better code to repeat the above there and not rely on the `makePanelStatusUpdater` flow. 

- **Bug 2**: **Spherex TAP Search**:
  - This is also related to `constraints`. By the time we called `getAdqlQuery`, the spatial constraint fragment was missing (after enabling react compiler). The above fix (stopped relying on `makePanelStatusUpdater`) and directly computing and updated `constraintResult` from the values it depends on fixed this as well 
    - (BTW, explicit use of `useMemo` helps make sure we use the previous constraintResult value of none of the spatial inputs it relies on change, kind of similar to `makePanelStatusUpdater` logic of checking if new/old values differ)

- **Bug 3**: fixed by Trey in a previous PR

**_Note_**: I found 2 more bugs: The TAP service dropdown and moving between Single and Multi-Object in Spatial Search. The fix for both is likely the same (in `TapSearchRootPanel` and `TapUtil`). I attempted fixing them in this PR, but the changes were a bit complex & out of scope for this PR. I will address those 2 in a new React Compiler ticket. 

I will turn off React Compiler before merging. 

**Testing**:
[Firefly](https://fireflydev.ipac.caltech.edu/firefly-1943-react-compiler-bugs/firefly), [Euclid](https://firefly-1943-react-compiler-bugs.irsakubedev.ipac.caltech.edu/applications/euclid) and [Spherex](https://firefly-1943-react-compiler-bugs.irsakubedev.ipac.caltech.edu/applications/spherex)
- Test bugs found in ticket for Firefly and Spherex
  - TAP search, SIAv2 search, Spectral Image Search on Spherex
- For Euclid, test TAP to do a search and check ADQL in job history to ensure the search was correct
- I tested the apps with react compiler turned off as well, they work as expected with the changes above. 