### PR TITLE
Firefly-1958: new URI(s).toURL() is not backward compatable to new URL

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/URIFileRetriever.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/imageretrieve/URIFileRetriever.java
@@ -13,13 +13,11 @@ import edu.caltech.ipac.util.download.GcsRef;
 import edu.caltech.ipac.util.download.ResponseMessage;
 import edu.caltech.ipac.util.download.RetrieveUtil;
 import edu.caltech.ipac.util.download.S3Ref;
+import edu.caltech.ipac.util.download.URLDownload;
 import edu.caltech.ipac.util.download.UriRef;
 import edu.caltech.ipac.util.download.UriRefParams;
 import edu.caltech.ipac.visualize.plot.plotdata.GeomException;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -102,9 +100,11 @@ public class URIFileRetriever implements FileRetriever {
             }
         }
         try  {
-            return new URI(urlStr).toURL();
-        } catch (URISyntaxException | MalformedURLException | IllegalArgumentException e) {
-            throw new FailedRequestException("Could not find file", "request.getURL() returned Exception", e);
+            URL url= URLDownload.makeURL(urlStr);
+            if (url==null) throw new FailedRequestException("Could not parse URL", "Could not parse url: "+urlStr);
+            return url;
+        } catch (IllegalArgumentException e) {
+            throw new FailedRequestException("Could not find file", "request.getURL() returned Exception",e);
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/table/io/FITSExtractToTable.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/FITSExtractToTable.java
@@ -150,7 +150,8 @@ public class FITSExtractToTable {
             aRow.setDataElement("plane",i+1);
             if (wlAry!=null) aRow.setDataElement("wavelength",rnd(wlAry[i],7));
             for(FitsExtract.ExtractionResults result : results) {
-                aRow.setDataElement(makeKeyByHDU(result),result.aryData().get(i));
+                DataType dt= dataGroup.getDataDefintion(makeKeyByHDU(result));
+                setDataElementWithNanCleanup(aRow, dt, result.aryData().get(i));
             }
             dataGroup.add(aRow);
         }
@@ -167,6 +168,22 @@ public class FITSExtractToTable {
             insertZaxisGenericChartMeta(dataGroup, results, wlAry!=null?"wavelength":"plane");
         }
         return dataGroup;
+    }
+
+    private static void setDataElementWithNanCleanup(DataObject aRow, DataType dt, Object value) {
+        if (value instanceof Double d) {
+            if (!Double.isNaN(d)) aRow.setDataElement(dt,value);
+            else if (dt.getDataType()==Double.class) aRow.setDataElement(dt,Double.NaN);
+            else aRow.setDataElement(dt,Float.NaN);
+        }
+        else if (value instanceof Float f) {
+            if (!Double.isNaN(f)) aRow.setDataElement(dt,value);
+            else if (dt.getDataType()==Float.class) aRow.setDataElement(dt,Float.NaN);
+            else aRow.setDataElement(dt,Float.NaN);
+        }
+        else {
+            aRow.setDataElement(dt,value);
+        }
     }
 
     private static Object getWithEnsuredType(Object obj, Class<?> type) {

--- a/src/firefly/java/edu/caltech/ipac/util/download/ConcurrentDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/ConcurrentDownload.java
@@ -13,9 +13,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
@@ -66,16 +63,13 @@ public class ConcurrentDownload {
         }
         if (status == HttpURLConnection.HTTP_NOT_MODIFIED) return notModified(url,outfile,result);
 
-        try {
-            URL finalUrl= result.isRedirected() ? new URI(result.getLocation()).toURL() : url;
-            if (partialDownloadQualified(result)) {
-                return doMultiThreadedDownload(finalUrl,outfile,cookies,requestHeaders,ops,result);
-            }
-            else {
-                return URLDownload.getDataToFile(finalUrl,outfile,cookies,requestHeaders,ops);
-            }
-        } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
-            throw new FailedRequestException("redirect URL could not be parsed");
+        URL finalUrl= result.isRedirected() ? URLDownload.makeURL(result.getLocation()) : url;
+        if (finalUrl==null) throw new FailedRequestException("redirect URL could not be parsed");
+        if (partialDownloadQualified(result)) {
+            return doMultiThreadedDownload(finalUrl,outfile,cookies,requestHeaders,ops,result);
+        }
+        else {
+            return URLDownload.getDataToFile(finalUrl,outfile,cookies,requestHeaders,ops);
         }
     }
 

--- a/src/firefly/java/edu/caltech/ipac/util/download/GcsRef.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/GcsRef.java
@@ -6,11 +6,10 @@ package edu.caltech.ipac.util.download;
  */
 
 
-import edu.caltech.ipac.firefly.core.Util;
-
-import java.net.URI;
 import java.net.URL;
 import java.util.Objects;
+
+import static edu.caltech.ipac.util.download.URLDownload.makeURL;
 
 /**
  * @author Trey Roby
@@ -37,9 +36,7 @@ public record GcsRef(String projectId, String bucket, String objName, URL source
     }
 
     public URL toUrl() {
-        return sourceUrl!=null
-                ? sourceUrl
-                : Util.Try.it(() -> new URI(toUrlStr()).toURL()).getOrElse((URL)null);
+        return sourceUrl!=null ? sourceUrl : makeURL(toUrlStr());
     }
 
     public static GcsRef makeFromUri(Object uri) {
@@ -56,7 +53,7 @@ public record GcsRef(String projectId, String bucket, String objName, URL source
     private static GcsRef makeFromString(String s) {
         if (s.length() < 10) return null;
         if (s.toLowerCase().startsWith("http") && s.toLowerCase().contains(GOOGLE)) {
-            URL url= Util.Try.it(() -> new URI(s).toURL()).getOrElse((URL)null);
+            URL url= makeURL(s);
             if (url == null) return null;
             var path = url.getPath();
             if (path.length() < 2) return null;

--- a/src/firefly/java/edu/caltech/ipac/util/download/S3Ref.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/S3Ref.java
@@ -6,14 +6,13 @@ package edu.caltech.ipac.util.download;
  */
 
 
-import edu.caltech.ipac.firefly.core.Util;
 import edu.caltech.ipac.util.StringUtils;
 
-import java.net.URI;
 import java.net.URL;
 import java.util.Objects;
 
 import static edu.caltech.ipac.util.download.URLDownload.firstParamValUsingKeyList;
+import static edu.caltech.ipac.util.download.URLDownload.makeURL;
 
 /**
  * @author Trey Roby
@@ -77,7 +76,7 @@ public record S3Ref(String region, String bucket, String key, String accessKey, 
             String bucket = path.substring(0, idx);
             return new S3Ref(null, bucket, key);
         } else if (s.toLowerCase().startsWith("https")) {
-            URL url= Util.Try.it(() -> new URI(s).toURL()).getOrElse((URL)null);
+            URL url= makeURL(s);
             if (url == null) return null;
             var path = url.getPath();
             if (path.length() < 2) return null;
@@ -120,7 +119,7 @@ public record S3Ref(String region, String bucket, String key, String accessKey, 
     public static boolean isS3SignedURL(String s) {
         if (s==null) return false;
         if (!s.toLowerCase().startsWith("https")) return false;
-        URL url = Util.Try.it(() -> new URI(s).toURL()).getOrElse((URL) null);
+        URL url = makeURL(s);
         if (url == null) return false;
         var path = url.getPath();
         if (path.length() < 2) return false;

--- a/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/URLDownload.java
@@ -108,6 +108,13 @@ public class URLDownload {
         return null;
     }
 
+    public static URL makeURL(String s) {
+        if (s == null) return null;
+        URL url= Util.Try.it(() -> new URI(s.trim()).toURL()).get();
+        if (url!=null) return url;
+        return Util.Try.it(() -> new URL(s.trim())).get();
+    }
+
     public static String getSuggestedFileName(URLConnection conn) {
         if (conn == null) return null;
         String disposition = conn.getHeaderField("Content-disposition");
@@ -257,10 +264,6 @@ public class URLDownload {
         } catch (IOException e) {
             return -1;
         }
-    }
-
-    private static URL makeURL(String urlStr) {
-        return Util.Try.it(() -> new URI(urlStr).toURL()).getOrElse((URL)null);
     }
 
     private static URL urlFromLocation(HttpURLConnection conn) { return makeURL(conn.getHeaderField("Location")); }

--- a/src/firefly/java/edu/caltech/ipac/util/download/UriRef.java
+++ b/src/firefly/java/edu/caltech/ipac/util/download/UriRef.java
@@ -1,11 +1,9 @@
 package edu.caltech.ipac.util.download;
 
-import edu.caltech.ipac.firefly.core.Util;
-
-import java.net.URI;
 import java.net.URL;
 import java.util.Objects;
 
+import static edu.caltech.ipac.util.download.URLDownload.makeURL;
 import static edu.caltech.ipac.util.download.UriRef.ResourceType.GcsCloud;
 import static edu.caltech.ipac.util.download.UriRef.ResourceType.OnPrimUrl;
 import static edu.caltech.ipac.util.download.UriRef.ResourceType.S3Cloud;
@@ -57,7 +55,7 @@ public record UriRef(Object ref, Object sourceForRef) {
         if (S3Ref.isS3Ref(obj)) return S3Cloud;
         else if (GcsRef.isGcsRef(obj)) return GcsCloud;
         else if (obj instanceof URL) return OnPrimUrl;
-        else if (obj instanceof String s) return makeURLFromStr(s)!=null ? OnPrimUrl : null;
+        else if (obj instanceof String s) return makeURL(s)!=null ? OnPrimUrl : null;
         else return null;
 
     }
@@ -83,15 +81,9 @@ public record UriRef(Object ref, Object sourceForRef) {
         var resourceType= determineType(uriStr);
         if (resourceType == null) return null;
         return switch (resourceType) {
-            case OnPrimUrl -> new UriRef(makeURLFromStr(uriStr), uriStr);
+            case OnPrimUrl -> new UriRef(makeURL(uriStr), uriStr);
             case S3Cloud -> new UriRef(S3Ref.makeFromUri(uriStr), uriStr);
             case GcsCloud -> new UriRef(GcsRef.makeFromUri(uriStr), uriStr);
         };
     }
-
-    private static URL makeURLFromStr(String urlStr) {
-        if (urlStr == null) return null;
-        return Util.Try.it(() -> new URI(urlStr.trim()).toURL()).getOrElse((URL)null);
-    }
-
 }

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -40,7 +40,7 @@ import {recordHistory} from './core/History.js';
 import {GatorProtocolRootPanel} from './visualize/ui/GatorProtocolRootPanel';
 import {setDefaultImageColorTable} from './visualize/WebPlotRequest.js';
 import {initWorkerContext} from './threadWorker/WorkerAccess.js';
-import {getTAPServicesByName} from './ui/tap/TapKnownServices.js';
+import {makeTAPDefaultServicesByName} from './ui/tap/TapKnownServices.js';
 import {loadAllJobs} from './core/background/BackgroundUtil.js';
 import {
     makeDefImageSearchActions, makeDefTableSearchActions, makeDefTapSearchActions, makeExternalSearchActions
@@ -219,7 +219,7 @@ const defFireflyOptions = {
         ...makeDefImageSearchActions(),
     ],
     tap : {
-        services: getTAPServicesByName( ['IRSA', 'NED', 'ExoplanetArchive', 'KOA', 'HEASARC', 'MASTImages',
+        services: makeTAPDefaultServicesByName( ['IRSA', 'NED', 'ExoplanetArchive', 'KOA', 'HEASARC', 'MASTImages',
                                    'CADC', 'CANFARyoucat', 'VizieR', 'Simbad', 'Gaia', 'GAVO', 'HSA', 'NOIRLab'] ),
         defaultMaxrec: 50000
     },

--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -1571,6 +1571,7 @@ export function splitVals(values='') {
 }
 
 export function parseError(error) {
+    if (!error) return {message: 'Unknown error', cause: 'Unknown error'};
     const message = error?.message ?? error;
     const colonRegex = /^((?:\S+\s*){1,3}?):(.+)/s; // colon appears at most 3 words after the beginning of the string
 

--- a/src/firefly/js/ui/tap/AdvancedADQL.jsx
+++ b/src/firefly/js/ui/tap/AdvancedADQL.jsx
@@ -20,9 +20,10 @@ import {InputFieldView} from '../InputFieldView.jsx';
 import {SplitContent} from '../panel/DockLayoutPanel';
 import {useFieldGroupValue} from '../SimpleComponent.jsx';
 import {showUploadTableChooser} from '../UploadTableChooser.js';
+import {defaultADQLExamples} from './TapKnownServices';
 import {
-    loadTapSchemas, loadTapTables, loadTapColumns, getTapServices, maybeQuote, TAP_UPLOAD_SCHEMA,
-    ADQL_UPLOAD_TABLE_NAME, defaultADQLExamples, makeUploadSchema, loadTapKeys, searchNodeBy
+    loadTapSchemas, loadTapTables, loadTapColumns, maybeQuote, TAP_UPLOAD_SCHEMA,
+    ADQL_UPLOAD_TABLE_NAME, makeUploadSchema, loadTapKeys, searchNodeBy, getTapServiceByURL
 } from './TapUtil';
 import {getColumnIdx} from '../../tables/TableUtil.js';
 import {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
@@ -83,9 +84,9 @@ PrismADQLAware.propTypes= {
 
 
 function getExamples(serviceUrl) {
-    const configEx = getTapServices().find(({value}) => value === serviceUrl)?.examples;
+    const configEx = getTapServiceByURL(serviceUrl)?.examples;
     const ex= isArray(configEx) ?
-        defaultADQLExamples.map( (e,idx) => (isObject(configEx?.[idx])) ? configEx[idx] : e) : defaultADQLExamples;
+        defaultADQLExamples().map( (e,idx) => (isObject(configEx?.[idx])) ? configEx[idx] : e) : defaultADQLExamples();
 
     return ex.map( ({description, statement},idx) =>
         (<Stack {...{key:description}}>

--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -37,7 +37,8 @@ import {
 } from './TableSearchHelpers.jsx';
 import {showUploadTableChooser} from '../UploadTableChooser.js';
 import {
-    getAsEntryForTableName, getColumnAttribute, getTapServices, makeUploadSchema, maybeQuote, tapHelpId
+    getAsEntryForTableName, getColumnAttribute, getTapServiceByURL, makeUploadSchema, maybeQuote,
+    tapHelpId
 } from './TapUtil.js';
 import {
     CenterColumns,
@@ -127,7 +128,7 @@ export function SpatialSearch({sx, cols, serviceUrl, serviceLabel, serviceId, co
     const panelTitle = !obsCoreEnabled ? Spatial : 'Location';
     const panelPrefix = getPanelPrefix(panelTitle);
     const posOpenKey= 'pos-columns';
-    const {hipsUrl,centerWP,fovDeg}= getTapServices().find( ({value}) => value===serviceUrl) ?? {};
+    const {hipsUrl,centerWP,fovDeg}= getTapServiceByURL(serviceUrl);
     const {canUpload=false}= capabilities ?? {};
     const showCenterColumns = !obsCoreEnabled && cols;
 

--- a/src/firefly/js/ui/tap/TapKnownServices.js
+++ b/src/firefly/js/ui/tap/TapKnownServices.js
@@ -3,10 +3,31 @@
  */
 import {Logger} from 'firefly/util/Logger.js';
 
-const tapEntry= (serviceId, label,url,hipsUrl, fovDeg,centerWP, schemaLabel, examples) =>
-    ({ serviceId, label, value: url, examples, fovDeg, hipsUrl, centerWP, schemaLabel});
 
-export function getTAPServicesByName(nameList) {
+
+const defEntry= (serviceId, label,url) => ({ serviceId, label, value: url});
+
+/**
+ * @typedef {Object} TapService
+ * @prop {String} serviceId
+ * @prop {String} label
+ * @prop {String} value the url
+ * @prop {Array.<TapExample>} examples
+ * @prop {Number} fovDeg
+ * @prop {String} hipsUrl
+ * @prop {String} centerWP - world point serialized string
+ * @prop {String} schemaLabel - label to show instead of "Schema'
+ * @prop {boolean} schemaLoadManual - label to show instead of "Schema'
+ */
+
+/**
+ * @typedef {Object} TapExample
+ * @prop {String} description -
+ * @prop {String} statement
+ */
+
+
+export function makeTAPDefaultServicesByName(nameList) {
     const services= makeServices();
     if (!nameList) return services;
 
@@ -18,30 +39,35 @@ export function getTAPServicesByName(nameList) {
         .filter( (v) => v);
 }
 
+/**
+ *
+ * @return {Array.<TapService>}
+ */
 function makeServices() {
     return [
-        tapEntry('IRSA', 'IRSA', 'https://irsa.ipac.caltech.edu/TAP', undefined,undefined,undefined, 'Project', irsaExamples() ),
-        tapEntry('NED', 'NED', 'https://ned.ipac.caltech.edu/tap/',undefined,undefined,undefined,undefined, nedExamples()),
-        tapEntry('ExoplanetArchive', 'NASA Exoplanet Archive', 'https://exoplanetarchive.ipac.caltech.edu/TAP/'),
-        tapEntry('KOA', 'KOA', 'https://koa.ipac.caltech.edu/TAP/'),
-        tapEntry('HEASARC', 'HEASARC', 'https://heasarc.gsfc.nasa.gov/xamin/vo/tap'),
-        tapEntry('MASTImages', 'MAST Images', 'https://mast.stsci.edu/vo-tap/api/v0.1/caom'),
-        tapEntry('CADC', 'CADC', 'https://ws.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/argus/'),
-        tapEntry('CANFARyoucat', 'CANFAR youcat', 'https://ws-uv.canfar.net/youcat'),
+        {...defEntry('IRSA', 'IRSA', 'https://irsa.ipac.caltech.edu/TAP'), schemaLabel: 'Project', examples:irsaExamples()},
+        {...defEntry('NED', 'NED', 'https://ned.ipac.caltech.edu/tap/'), examples:nedExamples()},
+        defEntry('ExoplanetArchive', 'NASA Exoplanet Archive', 'https://exoplanetarchive.ipac.caltech.edu/TAP/'),
+        defEntry('KOA', 'KOA', 'https://koa.ipac.caltech.edu/TAP/'),
+        {...defEntry('HEASARC', 'HEASARC', 'https://heasarc.gsfc.nasa.gov/xamin/vo/tap'), schemaLoadManual:true},
+        defEntry('MASTImages', 'MAST Images', 'https://mast.stsci.edu/vo-tap/api/v0.1/caom'),
+        defEntry('CADC', 'CADC', 'https://ws.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/argus/'),
+        defEntry('CANFARyoucat', 'CANFAR youcat', 'https://ws-uv.canfar.net/youcat'),
         // CDS???
-        tapEntry('VizieR', 'VizieR (CDS)', 'https://tapvizier.u-strasbg.fr/TAPVizieR/tap/'),
-        tapEntry('Simbad', 'Simbad (CDS)', 'https://simbad.u-strasbg.fr/simbad/sim-tap'),
+        {...defEntry('VizieR', 'VizieR (CDS)', 'https://tapvizier.u-strasbg.fr/TAPVizieR/tap/'), schemaLoadManual:true},
+        defEntry('Simbad', 'Simbad (CDS)', 'https://simbad.u-strasbg.fr/simbad/sim-tap'),
         // more ESA??
-        tapEntry('Gaia', 'Gaia', 'https://gea.esac.esa.int/tap-server/tap',undefined,undefined,undefined, undefined, gaiaExamples()),
-        tapEntry('GAVO', 'GAVO', 'https://dc.g-vo.org/tap'),
-        tapEntry('HSA', 'HSA',  'https://archives.esac.esa.int/hsa/whsa-tap-server/tap'),
-        tapEntry('NOIRLab', 'NOIR Lab',  'https://datalab.noirlab.edu/tap'),
+        {...defEntry('Gaia', 'Gaia', 'https://gea.esac.esa.int/tap-server/tap'), examples:gaiaExamples()},
+        defEntry('GAVO', 'GAVO', 'https://dc.g-vo.org/tap'),
+        defEntry('HSA', 'HSA',  'https://archives.esac.esa.int/hsa/whsa-tap-server/tap'),
+        defEntry('NOIRLab', 'NOIR Lab',  'https://datalab.noirlab.edu/tap'),
     ];
 }
 
 
-
-
+/**
+ * @return {Array.<TapExample>}
+ */
 const irsaExamples= () => [
     {
         description: 'From the IRSA TAP service, a 1 degree cone search of the 2MASS point source catalog around M101 would be:',
@@ -64,6 +90,9 @@ WHERE CONTAINS (POINT('J2000' , ra , dec) , POLYGON('J2000' , 209.80225 , 54.348
     }
 ];
 
+/**
+ * @return {Array.<TapExample>}
+ */
 const nedExamples= () => [
     {
         description: 'From the NED TAP service, a 100 arcsec radius around m16:',
@@ -92,6 +121,9 @@ AND z < 0
     },
 ];
 
+/**
+ * @return {Array.<TapExample>}
+ */
 const gaiaExamples= () => [
     {
         description: 'From the Gaia TAP service, a .25 degree cone search Gaia data release 3 point source catalog around M31 would be:',
@@ -110,5 +142,27 @@ WHERE CONTAINS(POINT('ICRS', ra, dec), BOX('ICRS', 210.80225, 54.34894, 1.0, 1.0
         statement:
             `SELECT source_id, designation, ra, dec, phot_g_mean_mag FROM gaiaedr3.gaia_source 
 WHERE CONTAINS (POINT('ICRS' , ra , dec) , POLYGON('ICRS' , 209.80225 , 54.34894 , 209.80225 , 55.34894 , 210.80225 , 54.34894))=1`,
+    }
+];
+
+export const defaultADQLExamples= ()=> [
+    {
+        description: 'From the IRSA TAP service, a 1 degree cone search of the 2MASS point source catalog around M101 would be:',
+        statement:
+            `SELECT * FROM fp_psc 
+WHERE CONTAINS(POINT('J2000', ra, dec), CIRCLE('J2000', 210.80225, 54.34894, 1.0)) = 1`
+    },
+    {
+        description: 'From the Gaia TAP service, a 1 degree by 1 degree box of the Gaia data release 3 point source catalog around M101 would be:',
+        statement:
+            `SELECT * FROM gaiaedr3.gaia_source 
+WHERE CONTAINS(POINT('ICRS', ra, dec), BOX('ICRS', 210.80225, 54.34894, 1.0, 1.0))=1`
+    },
+    {
+        description: 'From the IRSA TAP service, a triangle search of the AllWISE point source catalog around M101 would be:',
+        statement:
+            `SELECT designation, ra, dec, w2mpro 
+FROM allwise_p3as_psd 
+WHERE CONTAINS (POINT('J2000' , ra , dec), POLYGON('J2000' , 209.80225 , 54.34894 , 209.80225 , 55.34894 , 210.80225 , 54.34894))=1`,
     }
 ];

--- a/src/firefly/js/ui/tap/TapUtil.js
+++ b/src/firefly/js/ui/tap/TapUtil.js
@@ -4,15 +4,12 @@ import {isArray, memoize, omit, sortBy, uniqBy} from 'lodash';
 import {getCapabilities} from '../../rpc/SearchServicesJson.js';
 import {sortInfoString} from '../../tables/SortInfo.js';
 import {makeFileRequest, makeTblRequest, MAX_ROW} from '../../tables/TableRequestUtil.js';
-import {
-    alterFalsyVal, doFetchTable, getColumnIdx, getTblById, getTblIdsByGroup, sortTableData
-} from '../../tables/TableUtil.js';
+import {alterFalsyVal, doFetchTable, getColumnIdx, sortTableData } from '../../tables/TableUtil.js';
 import {Logger} from '../../util/Logger.js';
 import {getProp, hashCode} from '../../util/WebUtil.js';
-import {getTAPServicesByName} from './TapKnownServices';
+import {makeTAPDefaultServicesByName} from './TapKnownServices';
 
 const logger = Logger('TapUtil');
-const qFragment = '/sync?REQUEST=doQuery&LANG=ADQL&RUNID=TAP_SCHEMA&';
 
 export const ADQL_LINE_LENGTH = 100;
 export const ADQL_UPLOAD_TABLE_NAME= 'upload_table';
@@ -33,7 +30,14 @@ const columnCache={};
 const obsCoreMetadataCache={};
 // end cache objects
 
-
+function makeSyncQueryURL(serviceUrl, query) {
+    const url= new URL(serviceUrl+'/sync');
+    url.searchParams.append('REQUEST', 'doQuery');
+    url.searchParams.append('LANG', 'ADQL');
+    url.searchParams.append('RUNID', 'TAP_SCHEMA');
+    url.searchParams.append('QUERY', query);
+    return url.toString();
+}
 
 export function getMaxrecHardLimit() {
     const defaultValue = Number.parseInt(getProp('tap.maxrec.hardlimit'));
@@ -280,12 +284,10 @@ export async function loadTapColumns(serviceUrl, schemaName, tableName) {
 
 async function doLoadTapColumns(serviceUrl, schemaName, tableName) {
 
-    const url = serviceUrl + qFragment +
-        'QUERY=SELECT+*+FROM+TAP_SCHEMA.columns+WHERE+table_name+like+\'' + tableName + '\'';
-        // 'QUERY=SELECT+column_name,description,unit,datatype,ucd,utype,principal+' +
-        // 'FROM+TAP_SCHEMA.columns+WHERE+table_name+like+\'' + tableName + '\'';
+    const url = makeSyncQueryURL(serviceUrl,`SELECT * FROM TAP_SCHEMA.columns WHERE table_name like '${tableName}'`);
 
-    const request = makeFileRequest('columns', url, undefined, {tbl_id: getColumnsTblId(serviceUrl, tableName), pageSize: MAX_ROW});
+    const request = makeFileRequest('columns', url, undefined,
+        {tbl_id: getColumnsTblId(serviceUrl, tableName), pageSize: MAX_ROW});
 
     try {
         const tableModel= await doFetchTable(request);
@@ -337,16 +339,15 @@ async function doLoadObsCoreMetadata(serviceUrl, obscoreTable) {
 }
 
 function makeTapSchemaRequest(serviceUrl, QUERY, title) {
-    const url = serviceUrl + qFragment +  'QUERY=' + encodeURIComponent(QUERY);
+    const url= makeSyncQueryURL(serviceUrl,QUERY.trim());
     return makeFileRequest(title, url, undefined, {pageSize: MAX_ROW});
-
 }
 
 async function loadSchemaDefJoin(serviceUrl) {
     const QUERY = ` SELECT *
                     FROM tap_schema.schemas
                     INNER JOIN tap_schema.tables ON  tap_schema.tables.schema_name = tap_schema.schemas.schema_name
-                `.replace(/\s+/g, ' ').trim();
+                `;
 
     const tableModel= await doFetchTable(makeTapSchemaRequest(serviceUrl, QUERY, 'loadSchemaDefJoin'));
 
@@ -390,8 +391,13 @@ async function loadSchemaDefNoJoin(serviceUrl) {
     const schemasQuery = 'SELECT * FROM tap_schema.schemas';
     const tablesQuery  = 'SELECT * FROM tap_schema.tables';
 
-    const schemas = await doFetchTable(makeTapSchemaRequest(serviceUrl, schemasQuery, 'loadSchemaDefNoJoin-schemas'));
-    const tables  = await doFetchTable(makeTapSchemaRequest(serviceUrl, tablesQuery, 'loadSchemaDefNoJoin-tables'));
+
+    const [schemas,tables]= await Promise.all([
+        doFetchTable(makeTapSchemaRequest(serviceUrl, schemasQuery, 'loadSchemaDefNoJoin-schemas')),
+        doFetchTable(makeTapSchemaRequest(serviceUrl, tablesQuery, 'loadSchemaDefNoJoin-tables'))
+    ]);
+
+
 
     const schemaIdx = getColumnIdx(schemas, 'schema_index');
     const schemaNameIdx = getColumnIdx(schemas, 'schema_name');
@@ -420,14 +426,6 @@ async function loadSchemaDefNoJoin(serviceUrl) {
     return tables;
 }
 
-function supportJoin(serviceUrl) {
-    // Vizier doesn't support schema.*, table.*.  returning a table of blank rows.
-    // heasarc doesn't support schema.*, table.* nor *. need to handle separately.
-    // most services does not have schema_index and/or table_index.
-    // to make it work for most services, had to use 'select *'.
-    return !serviceUrl.toLowerCase().includes('heasarc.gsfc.nasa.gov');
-}
-
 function isOldTap(serviceUrl) {
     // norlab is using an old version of TAP and there is no other way to recognize it
     return serviceUrl.toLowerCase().includes('datalab.noirlab.edu');
@@ -437,9 +435,10 @@ export const loadSchemaDef = memoize(async (serviceUrl) => {
 
     try {
         if (!serviceUrl) return;
-        const tableModel= supportJoin(serviceUrl)
-                ? await loadSchemaDefJoin(serviceUrl)
-                : await loadSchemaDefNoJoin(serviceUrl);
+
+        const tableModel= getTapServiceByURL(serviceUrl)?.schemaLoadManual
+            ? await loadSchemaDefNoJoin(serviceUrl)
+            : await loadSchemaDefJoin(serviceUrl);
 
         if (tableModel.error) throw new Error(tableModel.error);
 
@@ -482,9 +481,9 @@ export const loadTapKeys = memoize(async (serviceUrl) => {
                tap_schema.key_columns.from_column,
                tap_schema.key_columns.target_column
         FROM tap_schema.keys INNER JOIN tap_schema.key_columns ON tap_schema.keys.key_id = tap_schema.key_columns.key_id
-        `.replace(/\s+/g, ' ').trim();
+        `;
 
-    const url = serviceUrl + qFragment + 'QUERY=' + encodeURIComponent(QUERY);
+    const url= makeSyncQueryURL(serviceUrl,QUERY.trim());
     const request = makeFileRequest('loadTapKeys', url, undefined, {pageSize: MAX_ROW});
 
     try {
@@ -566,7 +565,7 @@ export function mergeServices(startingServices, additional) {
 
 export function getTapServices() {
     const {tap} = getAppOptions();
-    const startingTapServices= hasElements(tap?.services) ? [...tap.services] : getTAPServicesByName();
+    const startingTapServices= hasElements(tap?.services) ? [...tap.services] : makeTAPDefaultServicesByName();
     const mergedServices= mergeServices(startingTapServices,tap?.additional?.services);
     mergedServices.push(...getUserServiceAry());
     return mergedServices;
@@ -580,9 +579,7 @@ function getUserServiceAry() {
 
 export function addUserService(serviceUrl) {
     const userServices= getUserServiceAry();
-    if (getTapServices().some( (({value}) => value===serviceUrl))) { // don't add if service already exist
-        return;
-    }
+    if (getTapServiceByURL(serviceUrl)) return; // don't add if service already exist
     const usedNumAry= userServices
         .map( (s) => s.label)
         .filter((title) => title && title.startsWith(baseName))
@@ -626,30 +623,6 @@ export function maybeQuote(name, isTable=false) {
 
 
 
-export const defaultADQLExamples=[
-    {
-        description: 'From the IRSA TAP service, a 1 degree cone search of the 2MASS point source catalog around M101 would be:',
-        /* eslint-disable-next-line quotes */
-        statement:
-            `SELECT * FROM fp_psc 
-WHERE CONTAINS(POINT('J2000', ra, dec), CIRCLE('J2000', 210.80225, 54.34894, 1.0)) = 1`
-    },
-    {
-        description: 'From the Gaia TAP service, a 1 degree by 1 degree box of the Gaia data release 3 point source catalog around M101 would be:',
-        /* eslint-disable-next-line quotes */
-        statement:
-            `SELECT * FROM gaiaedr3.gaia_source 
-WHERE CONTAINS(POINT('ICRS', ra, dec), BOX('ICRS', 210.80225, 54.34894, 1.0, 1.0))=1`
-    },
-    {
-        description: 'From the IRSA TAP service, a triangle search of the AllWISE point source catalog around M101 would be:',
-        /* eslint-disable-next-line quotes */
-        statement:
-            `SELECT designation, ra, dec, w2mpro 
-FROM allwise_p3as_psd 
-WHERE CONTAINS (POINT('J2000' , ra , dec), POLYGON('J2000' , 209.80225 , 54.34894 , 209.80225 , 55.34894 , 210.80225 , 54.34894))=1`,
-    }
-];
 
 function getTableNameFromADQL(adql) {
     if (!adql) return;
@@ -698,11 +671,6 @@ export function getAvailableColumns(columnsModel){
     });
 }
 
-export function getServiceLabel(serviceUrl) {
-    const tapOps= getTapServiceOptions();
-    return (serviceUrl && (tapOps.find( (e) => e.value===serviceUrl)?.labelOnly)) || '';
-}
-
 export function getServiceId(serviceUrl) {
     const tapOps= getTapServices();
     const id= (serviceUrl && (tapOps.find( (e) => e.value===serviceUrl)?.serviceId));
@@ -710,10 +678,26 @@ export function getServiceId(serviceUrl) {
     return getServiceLabel(serviceUrl).replaceAll(/\s/g,'');
 }
 
-export function getServiceHiPS(serviceUrl) {
-    const tapOps= getTapServices();
-    return (serviceUrl && (tapOps.find( (e) => e.value===serviceUrl)?.hipsUrl)) || '';
-}
+
+/**
+ * @param serviceUrl
+ * @return {TapService}
+ */
+export const getTapServiceByURL= (serviceUrl) => getTapServices()?.find( (e) => e.value===serviceUrl);
+
+/**
+ * @param serviceUrl
+ * @return {String} label
+ */
+export const getServiceLabel= (serviceUrl) => getTapServiceByURL(serviceUrl)?.labelOnly ?? '';
+
+/**
+ * @param serviceUrl
+ * @return {String} HiPS url
+ */
+export const getServiceHiPS= (serviceUrl) => getTapServiceByURL(serviceUrl)?.hipsUrl ?? '';
+
+
 
 export const getTapServiceOptions= () =>
     getTapServices().map(({label,value,userAdded=false})=>({label:value, value, labelOnly:label, userAdded}));

--- a/src/firefly/js/ui/tap/TapViewType.jsx
+++ b/src/firefly/js/ui/tap/TapViewType.jsx
@@ -21,7 +21,8 @@ import {
 import {TableSearchMethods} from './TableSearchMethods.jsx';
 import {
     defTapBrowserState, getLoadedCapability, getTapServices, isCapabilityLoaded, loadTapCapabilities, loadTapColumns,
-    loadTapSchemas, loadTapTables, tapHelpId, loadObsCoreMetadata, ADQL_QUERY_KEY, SERVICE_EXIST_ERROR, getServiceId
+    loadTapSchemas, loadTapTables, tapHelpId, loadObsCoreMetadata, ADQL_QUERY_KEY, SERVICE_EXIST_ERROR, getServiceId,
+    getTapServiceByURL
 } from './TapUtil.js';
 
 import MoreVertRoundedIcon from '@mui/icons-material/MoreVertRounded';
@@ -161,7 +162,7 @@ function BasicUI(props) {
     const [tableTableModel, setTableTableModel] = useState();
     const [columnsModel, setColumnsModel] = useState();
     const [obsCoreMetadataModel, setObsCoreMetadataModel] = useState(undefined);
-    const {schemaLabel}= getTapServices().find( ({value}) => value===serviceUrl) ?? {};
+    const {schemaLabel}= getTapServiceByURL(serviceUrl) ?? {};
 
     const schemaIsLocked= !forceLockObsCore && Boolean(lockedSchemaName);
     const tableIsLocked= !forceLockObsCore && Boolean(lockedTableName);


### PR DESCRIPTION
#### [Firefly-1958](https://jira.ipac.caltech.edu/browse/FIREFLY-1958): new URI(s).toURL() is not backward compatible to new URL

- create a utility function to make URLs
- clean up TapUtil.js, all url build consistently  with new URL()
- other clean up of tap utilities as well
- [Firefly-1956](https://jira.ipac.caltech.edu/browse/FIREFLY-1956): fixed


#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1958-url/firefly
- choose VizieR, it should come up.