### PR TITLE
FIREFLY-1945: Table column resizes after multiple sorts

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/HealpixProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/HealpixProcessor.java
@@ -5,14 +5,13 @@ package edu.caltech.ipac.firefly.server.query;
 
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.server.db.DbAdapter;
+import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
 import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.DataGroupPart;
+import edu.caltech.ipac.table.DataType;
 import edu.caltech.ipac.util.AppProperties;
-import edu.caltech.ipac.util.StringUtils;
-
-import java.util.Arrays;
 
 import static edu.caltech.ipac.firefly.server.query.HealpixProcessor.*;
 import static edu.caltech.ipac.table.DataGroup.HEALPIX_IDX;
@@ -113,10 +112,10 @@ public class HealpixProcessor extends TableFunctionProcessor {
         if (!dbAdapter.hasTable(healpixTable)) {
 
             // create healpix index at BASE_ORDER
+            DataType healpixCol = makeHealPixColumn();
             StopWatch.getInstance().start("HealpixProcessor: create index");
-            dbAdapter.execUpdate("ALTER TABLE %s DROP COLUMN IF EXISTS %s".formatted(dataTable, HEALPIX_IDX));  // remove existing index
-            dbAdapter.execUpdate("ALTER TABLE %s ADD COLUMN %s LONG".formatted(dataTable, HEALPIX_IDX));
-            dbAdapter.execUpdate("UPDATE %s SET %s = deg2pix(%s, %s, %s)".formatted(dataTable, HEALPIX_IDX, BASE_ORDER, ra, dec));
+            dbAdapter.execUpdate("ALTER TABLE %s DROP COLUMN IF EXISTS %s".formatted(dataTable, healpixCol.getKeyName()));  // remove existing index
+            EmbeddedDbUtil.addColumn(dbAdapter, healpixCol, "deg2pix(%s, %s, %s)".formatted(BASE_ORDER, ra, dec), null, dataTable, null);
             StopWatch.getInstance().printLog("HealpixProcessor: create index");
 
             // create healpix map at BASE_ORDER
@@ -125,6 +124,12 @@ public class HealpixProcessor extends TableFunctionProcessor {
             StopWatch.getInstance().printLog("HealpixProcessor: create pixel map");
 
         }
+    }
+
+    private static DataType makeHealPixColumn() {
+        DataType dt = new DataType(HEALPIX_IDX, Long.class);
+        dt.setVisibility(DataType.Visibility.hidden);
+        return dt;
     }
 
 }

--- a/src/firefly/js/tables/reducer/TableUiReducer.js
+++ b/src/firefly/js/tables/reducer/TableUiReducer.js
@@ -190,5 +190,11 @@ function adjustColInfo({uiData, tableModel, columns, previous}) {
 }
 
 function hasSameCnames(tableModel, columns=[]) {
-    return getAllColumns(tableModel).map((c) => c.name).join() === columns.map((c) => c.name).join();
+    const tm = getAllColumns(tableModel)
+        .filter((c) => c.visibility !== 'hidden')
+        .map((c) => c.name).join();
+    const cols = columns
+        .filter((c) => c.visibility !== 'hidden')
+        .map((c) => c.name).join();
+    return tm === cols;
 }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1945

This occurs when the healpix index adds a new column. The column should be set to hidden to prevent it from affecting the UI.

Test: https://firefly-1945-table-column-resize-bug.irsakubedev.ipac.caltech.edu/applications/Gator/
- Select `Herschel Space Observatory`
- Select `Rejected Source 160 micron Catalog`
- Select `All Sky Search`
- Sort on column `f160` 4 times

The column's width should remain unchanged.  In `irsadev`, it shrank on the 4th attempt.