### PR TITLE
FIREFLY-1942: Add a new box mode to Search Select Tools in EmbeddedPositionSearchPanel

### DIFF
--- a/src/firefly/js/drawingLayers/SearchSelectTool.js
+++ b/src/firefly/js/drawingLayers/SearchSelectTool.js
@@ -16,6 +16,8 @@ import ShapeDataObj, {UnitType} from '../visualize/draw/ShapeDataObj.js';
 import {makeImagePt, makeScreenPt, pointEquals} from 'firefly/visualize/Point.js';
 import {getScreenPixScaleArcSec} from '../visualize/WebPlot';
 import {SelectedShape} from './SelectedShape.js';
+import {clampInRange} from 'firefly/util/MathUtil';
+import {logger} from 'firefly/util/Logger';
 
 const ID= 'SEARCH_SELECT_TOOL';
 const TYPE_ID= 'SEARCH_SELECT_TOOL_TYPE';
@@ -69,6 +71,13 @@ function dispatchSelectPoint(mouseStatePayload) {
                 }});
         }
     }
+    else if (plot.attributes[PlotAttribute.USE_BOX]) {
+        dispatchAttributeChange( {plotId, changes:{
+                [PlotAttribute.SELECTION_TYPE]: SelectedShape.rect.key,
+                [PlotAttribute.USER_SEARCH_WP]:wp
+            }
+        });
+    }
     else {
         dispatchAttributeChange( {plotId, changes:{
                 [PlotAttribute.SELECTION_TYPE]: SelectedShape.circle.key,
@@ -96,8 +105,9 @@ function creator({minSize=1/3600,maxSize=100, searchType=RADIUS}={}, presetDefau
     const drawingDef= { ...makeDrawingDef(color), symbol: DrawSymbol.DIAMOND, size: 8, ...presetDefaults };
     idCnt++;
     const pairs= {
-        [MouseState.UP.key]: dispatchSelectPoint,
+        [MouseState.UP.key]: dispatchSelectPoint, // point selection event on image will move the search region to that point
         [MouseState.DOWN.key]: saveLastDown
+        // TODO: add events and listeners for interaction with rotation and resize handles
     };
     const actionTypes= [DrawLayerCntlr.SELECT_POINT];
     const options = {
@@ -134,8 +144,9 @@ function drawSearchSelection(drawLayer, action, active, plotId) {
     const {plotIdAry}= action.payload;
     const plot= primePlot(visRoot(),plotId||plotIdAry?.[0]);
     if (!plot) return [];
-    return plot.attributes[PlotAttribute.USE_POLYGON] ?
-        drawSearchSelectionPolygon(plot, drawLayer) : drawSearchSelectionCircle(plot, drawLayer);
+    if (plot.attributes[PlotAttribute.USE_POLYGON]) return drawSearchSelectionPolygon(plot, drawLayer);
+    if (plot.attributes[PlotAttribute.USE_BOX]) return drawSearchSelectionTransformBox(plot, drawLayer);
+    return drawSearchSelectionCircle(plot, drawLayer);
 }
 
 function drawSearchSelectionCircle(plot, drawLayer) {
@@ -144,14 +155,14 @@ function drawSearchSelectionCircle(plot, drawLayer) {
     if (!wp) return [];
     const radius= plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG];
     const drawAry= [];
-    const drawRadius= radius<=maxSize ? (radius >= minSize ? radius : minSize) : maxSize;
+    const drawRadius = clampInRange(radius, minSize, maxSize);
     const shadow={offX:1,offY:1,color:'black',blur:1};
-    if (drawLayer.isInteractive) {
+    if (drawLayer.isInteractive) { // dispatchSelectPoint will move the draw layer on a point selection event
         const x= PointDataObj.make(wp,7, DrawSymbol.EMP_SQUARE_X,undefined,{shadow});
         drawAry.push(x);
         radius && drawAry.push( {...ShapeDataObj.makeCircleWithRadius(wp, drawRadius*3600,UnitType.ARCSEC), lineWidth:3, renderOptions:{shadow}} );
     }
-    else {
+    else { // dispatchSelectPoint will do nothing (isInteractive=false in search refinement tool)
         const cross= PointDataObj.make(wp,3, DrawSymbol.CROSS, undefined, {shadow});
         drawAry.push(cross);
         radius && drawAry.push(
@@ -167,6 +178,22 @@ function drawSearchSelectionPolygon(plot, drawLayer) {
     const wpAry= plot?.attributes[PlotAttribute.POLYGON_ARY];
     if (!wpAry || wpAry.length<3) return [];
     return [ drawLayer.isInteractive ?
-        {...ShapeDataObj.makePolygon(wpAry), lineWidth:3 } :
-        {...ShapeDataObj.makePolygon(wpAry), lineWidth:1,  renderOptions:{lineDash:[5,5]}}];
+        {...ShapeDataObj.makePolygon(wpAry), lineWidth:3 } : // movable layer
+        {...ShapeDataObj.makePolygon(wpAry), lineWidth:1,  renderOptions:{lineDash:[5,5]}}]; // locked layer
+}
+
+function drawSearchSelectionTransformBox(plot, drawLayer) {
+    const wp= plot.attributes[PlotAttribute.USER_SEARCH_WP];
+    // const box = plot.attributes[PlotAttribute.USER_SEARCH_BOX];
+    const wpAry = plot?.attributes[PlotAttribute.POLYGON_ARY];
+    const rotAxisWp = plot.attributes[PlotAttribute.USER_SEARCH_BOX_AXIS_WP];
+    if (!wp || !wpAry) return [];
+    logger.debug('Box SearchSelectTool Draw Layer:', {center: wp.toString(), corners: wpAry.map((wp)=>wp.toString()), rotAxis: rotAxisWp.toString()});
+
+    // TODO: draw rotate and resize handles when the box is selected (similar to footprint selection behavior)
+    return [
+        PointDataObj.make(wp,7, DrawSymbol.EMP_SQUARE_X,undefined),
+        {...ShapeDataObj.makePolygon(wpAry), lineWidth:3},
+        {...ShapeDataObj.makeLine(wp, rotAxisWp, true), lineWidth:2, renderOptions:{lineDash:[5,5]}},
+    ];
 }

--- a/src/firefly/js/drawingLayers/SelectArea.js
+++ b/src/firefly/js/drawingLayers/SelectArea.js
@@ -57,6 +57,7 @@ export function selectAreaEndActionCreator(rawAction) {
             const selectBox= drawLayer.drawData.data.find( (drawObj) => drawObj.type===SelectBox.SELECT_BOX);
             const sel= {pt0:selectBox.pt1,pt1:selectBox.pt2};
             const imBoundSel= getImageBoundsSelection(sel,CsysConverter.make(plot), drawLayer.selectedShape, pv.rotation);
+            // update plot attributes with selection info retrieved from a SelectArea drawing layer drawn by the user
             dispatchAttributeChange({plotId,changes: {
                     [PlotAttribute.SELECTION] : sel,
                     [PlotAttribute.SELECTION_TYPE] : drawLayer.selectedShape ?? SelectedShape.rect.key,

--- a/src/firefly/js/ui/BoxSearchInputFields.jsx
+++ b/src/firefly/js/ui/BoxSearchInputFields.jsx
@@ -1,0 +1,119 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+import {Stack} from '@mui/joy';
+import PropTypes, {bool, number, object, string} from 'prop-types';
+import React from 'react';
+import {SelectedShape} from '../drawingLayers/SelectedShape';
+import {
+    DEFAULT_INSTRUCTIONS_RECT, DEFAULT_SELECTION_TEXT, SelectAreaForEmbedded
+} from '../visualize/ui/SelectAreaUIComponents';
+import {ANGULAR_SIZE_UNITS, SizeInputFields} from './SizeInputField.jsx';
+
+
+const ROT_MIN = -360;
+const ROT_MAX = 360;
+const ROT_STEP = 10;
+
+function RotationInputField({fieldKey, label='Rotation', initialState={value:'0'}, sx}) {
+    return (
+        <SizeInputFields {...{
+            fieldKey,
+            showFeedback: true,
+            nullAllowed: false,
+            label,
+            quantityName: 'Angle',
+            quantityUnitOptions: [{value: 'deg', label: ANGULAR_SIZE_UNITS.deg.name}],
+            initialState: {
+                unit: 'deg',
+                min: ROT_MIN,
+                max: ROT_MAX,
+                ...initialState,
+            },
+            sx,
+            slotProps: {
+                // to show numeric increment/decrement controls in the inner HTML <input> element
+                inputField: {
+                    slotProps: {
+                        input: { // joy-ui Input
+                            type: 'number',
+                            slotProps: { // HTML <input>
+                                input: { min: ROT_MIN, max: ROT_MAX, step: ROT_STEP }
+                            }
+                        }
+                    }
+                },
+                feedback:{sx: {alignSelf:'center'} },
+            }
+        }} />
+    );
+}
+
+export function BoxSearchInputFields({
+    boxSizeXKey,
+    boxSizeXLabel='Search Box X Size',
+    boxSizeYKey,
+    boxSizeYLabel='Search Box Y Size',
+    boxRotationKey,
+    boxRotationLabel='Search Box Y Rotation (E of N)',
+    min,
+    max,
+    initSizeXState,
+    initSizeYState,
+    initRotationState,
+    fieldSx={},
+    selectButtonText=DEFAULT_SELECTION_TEXT,
+    instructionsText=DEFAULT_INSTRUCTIONS_RECT,
+}) {
+    const defaultFieldSx = {width: '16rem'};
+    return (
+        <Stack spacing={1}>
+            <Stack spacing={2} direction='row'>
+                <SizeInputFields {...{
+                    fieldKey: boxSizeXKey, showFeedback: true, nullAllowed: false,
+                    label: boxSizeXLabel,
+                    initialState: {unit: 'arcsec', ...initSizeXState, min, max},
+                    sx: {...defaultFieldSx, ...fieldSx},
+                    slotProps: {
+                        feedback:{sx: {alignSelf:'center'} },
+                    }
+                }} />
+                <SizeInputFields {...{
+                    fieldKey: boxSizeYKey, showFeedback: true, nullAllowed: false,
+                    label: boxSizeYLabel,
+                    initialState: {unit: 'arcsec', ...initSizeYState, min, max},
+                    sx: {...defaultFieldSx, ...fieldSx},
+                    slotProps: {
+                        feedback:{sx: {alignSelf:'center'} },
+                    }
+                }} />
+            </Stack>
+            <Stack spacing={2} direction='row'>
+                <RotationInputField fieldKey={boxRotationKey} label={boxRotationLabel}
+                                    initialState={initRotationState}
+                                    sx={{...defaultFieldSx, ...fieldSx}} />
+                {Boolean(selectButtonText) &&
+                    <SelectAreaForEmbedded {...{selectButtonText, instructionsText, shape: SelectedShape.rect,
+                        sx: { maxWidth: defaultFieldSx.width }}}/>}
+            </Stack>
+        </Stack>
+    );
+}
+
+BoxSearchInputFields.propTypes = {
+    boxSizeXKey: string,
+    boxSizeXLabel: string,
+    boxSizeYKey: string,
+    boxSizeYLabel: string,
+    boxRotationKey: string,
+    boxRotationLabel: string,
+    min: number,
+    max: number,
+    initSizeXState: object,
+    initSizeYState: object,
+    initRotationState: object,
+    fieldSx: object,
+    selectButtonText: string,
+    instructionsText: PropTypes.oneOfType([string, bool]),
+};

--- a/src/firefly/js/ui/QuantityInputField.jsx
+++ b/src/firefly/js/ui/QuantityInputField.jsx
@@ -128,6 +128,7 @@ export function QuantityInputFieldView({min, max, sx, slotProps, inputStyle = {}
                 orientation={orientation}
                 connectedMarker={connectedMarker}
                 sx={{ '& .MuiInput-root': { paddingInlineEnd: 0 } }}
+                { ...slotProps?.inputField }
                 endDecorator={
                     <QuantityUnitsPicker unit={unit} onChange={handleUnitChange}
                                          unitOptions={quantityUnitOptions}
@@ -154,6 +155,7 @@ QuantityInputFieldView.propTypes = {
     max: PropTypes.number,
     sx: PropTypes.object,
     slotProps: PropTypes.shape({
+        inputField: PropTypes.object,
         units: PropTypes.object,
         feedback: PropTypes.object,
     }),

--- a/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
+++ b/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
@@ -4,9 +4,12 @@ import PropTypes, {oneOf, bool, string, number, arrayOf, object, func, shape, el
 import {defaultsDeep, isString} from 'lodash';
 import {SelectedShape} from '../../drawingLayers/SelectedShape';
 import CoordinateSys from '../../visualize/CoordSys.js';
-import {CONE_CHOICE_KEY, POLY_CHOICE_KEY, UPLOAD_CHOICE_KEY} from '../../visualize/ui/CommonUIKeys.js';
-import { DEFAULT_INSTRUCTIONS_CIRCLE,
-    DEFAULT_SELECTION_TEXT, SelectAreaForEmbedded } from '../../visualize/ui/SelectAreaUIComponents';
+import {BOX_CHOICE_KEY, CONE_CHOICE_KEY, POLY_CHOICE_KEY, UPLOAD_CHOICE_KEY} from '../../visualize/ui/CommonUIKeys.js';
+import {BoxSearchInputFields} from '../BoxSearchInputFields.jsx';
+import {
+    DEFAULT_INSTRUCTIONS_CIRCLE, DEFAULT_INSTRUCTIONS_RECT,
+    DEFAULT_SELECTION_TEXT, SelectAreaForEmbedded
+} from '../../visualize/ui/SelectAreaUIComponents';
 import {HiPSTargetView} from '../../visualize/ui/TargetHiPSPanel.jsx';
 import {showInfoPopup} from '../PopupUtil';
 import {RadioGroupInputField} from '../RadioGroupInputField.jsx';
@@ -34,8 +37,13 @@ const DEFAULT_HIPS= 'ivo://CDS/P/DSS2/color';
 const DEFAULT_PLOT_ID= 'defaultHiPSTargetSearch';
 const DEFAULT_TARGET_PANEL_WIDTH= '34rem';
 const DEFAULT_SIZE_KEY= 'radius';
-const DEFAULT_INIT_SIZE_VALUE= .005;
+const DEFAULT_INIT_SIZE_VALUE= .005; //deg
+const DEFAULT_MIN_SIZE_VALUE= 1/3600; // deg
+const DEFAULT_MAX_SIZE_VALUE= 1; //deg
 const DEFAULT_POLYGON_KEY= 'Polygon';
+const DEFAULT_BOX_SIZE_X_KEY= 'boxSizeX';
+const DEFAULT_BOX_SIZE_Y_KEY= 'boxSizeY';
+const DEFAULT_BOX_ROTATION_KEY= 'boxRotation';
 
 export const emptyHeaderSx = {
     paddingBlockStart: '0.5rem',
@@ -63,6 +71,9 @@ export const emptyHeaderSx = {
  *                  - *State: Cone*:
  *                      - `targetPanel` slot - TargetPanel
  *                      - `sizeInput` slot - SizeInputFields
+ *                  - *State: Box*:
+ *                     - `targetPanel` slot - TargetPanel
+ *                     - `boxSearchInput` slot - BoxSearchInputFields
  *                  - *State: Polygon*:
  *                      - `polygonField` slot - PolygonField
  *                  - *State: Upload*:
@@ -81,6 +92,7 @@ export const emptyHeaderSx = {
  * @param p.nullAllowed
  * @param p.insetSpacial
  * @param p.usePosition whether to use Cone search type in spatialSearch
+ * @param p.useBox whether to use Box search type in spatialSearch
  * @param p.useUpload whether to use multi-object search type in spatialSearch
  * @param p.usePolygon whether to use Polygon search type in spatialSearch
  * @param p.slotProps props to control the slots mentioned above. See propTypes.slotProps for details.
@@ -97,6 +109,7 @@ export function EmbeddedPositionSearchPanel({
                                                 usePosition= true,
                                                 useUpload = false,
                                                 usePolygon= true,
+                                                useBox= false,
                                                 slotProps={},
                                                 doSearch,
                                                 formTitle,
@@ -105,7 +118,14 @@ export function EmbeddedPositionSearchPanel({
 
     const {targetKey=DEF_TARGET_PANEL_KEY}= slotProps.targetPanel ?? {};
     const {polygonKey=DEFAULT_POLYGON_KEY, }= slotProps.polygonField ?? {};
-    const {sizeKey= DEFAULT_SIZE_KEY, min= 1 / 3600, max= 1, enabled:sizeEnabled=true}= slotProps.sizeInput ?? {};
+    const {sizeKey= DEFAULT_SIZE_KEY, min=DEFAULT_MIN_SIZE_VALUE, max=DEFAULT_MAX_SIZE_VALUE, enabled:sizeEnabled=true}= slotProps.sizeInput ?? {};
+    const {
+        boxSizeXKey=DEFAULT_BOX_SIZE_X_KEY,
+        boxSizeYKey=DEFAULT_BOX_SIZE_Y_KEY,
+        boxRotationKey=DEFAULT_BOX_ROTATION_KEY,
+        min:boxMin=DEFAULT_MIN_SIZE_VALUE*2, // since box size is length of its side so it corresponds to cone diameter (= radius * 2)
+        max:boxMax=DEFAULT_MAX_SIZE_VALUE*2, // same as above
+    }= slotProps.boxFields ?? {};
 
     const {groupKey}= useContext(FieldGroupCtx);
     const {searchTypeKey=CONE_AREA_KEY}= slotProps.spatialSearch ?? {};
@@ -138,6 +158,7 @@ export function EmbeddedPositionSearchPanel({
 
     const searchTypes = [
         {key: CONE_CHOICE_KEY, use: usePosition, label: 'Cone'},
+        {key: BOX_CHOICE_KEY, use: useBox, label: 'Box'},
         {key: POLY_CHOICE_KEY, use: usePolygon, label: 'Polygon'},
         {key: UPLOAD_CHOICE_KEY, use: useUpload, label: 'Multi-object'},
     ];
@@ -186,6 +207,9 @@ export function EmbeddedPositionSearchPanel({
         overflow: 'auto',
     };
 
+    const minSize = doGetSearchTypeOp()===BOX_CHOICE_KEY ? boxMin : min;
+    const maxSize = doGetSearchTypeOp()===BOX_CHOICE_KEY ? boxMax : max;
+
     return (
         <Stack key='targetGroup' alignItems='center' height='100%' paddingBottom={insetSpacial ? 0 : 20}
            onMouseDown={() => {
@@ -198,11 +222,14 @@ export function EmbeddedPositionSearchPanel({
                     hipsUrl, centerPt:initCenterPt, hipsFOVInDeg, mocList,
                     coordinateSys: CoordinateSys.parse(csysStr) ?? CoordinateSys.EQ_J2000,
                     sRegion, plotId,
-                    minSize: min, maxSize: max, toolbarHelpId, showHelpLines, selectionHelpText,
+                    minSize, maxSize, toolbarHelpId, showHelpLines, selectionHelpText,
                     getWhichOverlay: doGetSearchTypeOp, setWhichOverlay: doToggle ? setSearchTypeOp : undefined,
                     targetKey,
                     sizeKey: sizeEnabled ? sizeKey : undefined, //to draw radius only when size input is enabled
                     polygonKey,
+                    boxSizeXKey,
+                    boxSizeYKey,
+                    boxRotationKey,
                     sx: {minHeight: 300, alignSelf: 'stretch', flexGrow:1, ...hipsTargetViewSx}
                 }}/>
             <Sheet
@@ -232,7 +259,10 @@ export function EmbeddedPositionSearchPanel({
                 <CollapsibleGroup variant={'plain'}>
                     <CollapsibleItem {...{
                         componentKey:'embedSearchPanel', isOpen:true, title:'Please select a search type',
-                        header: (isOpen) => (<Header {...{isOpen, doSearch, targetKey, sizeKey, polygonKey, searchTypeKey, searchTypeToggleOptions, slotProps}}/>),
+                        header: (isOpen) => (<Header {...{
+                            isOpen, doSearch, targetKey, sizeKey, polygonKey, searchTypeKey, searchTypeToggleOptions, slotProps,
+                            boxSizeXKey, boxSizeYKey, boxRotationKey
+                        }}/>),
                         slotProps: {
                             header: {
                                 sx: emptyHeaderSx,
@@ -281,6 +311,7 @@ EmbeddedPositionSearchPanel.propTypes= {
     nullAllowed: bool,
     insetSpacial: bool,
     usePosition: bool,
+    useBox: bool,
     usePolygon: bool,
     useUpload: bool,
     doSearch: func,
@@ -332,6 +363,9 @@ EmbeddedPositionSearchPanel.propTypes= {
             cancelSelectionText: string,
             sx: object,
         }),
+        boxFields : shape({
+            ...BoxSearchInputFields.propTypes,
+        }),
         uploadTableSelector: shape({
             component: elementType,
             ...UploadTableSelector.propTypes
@@ -349,11 +383,14 @@ EmbeddedPositionSearchPanel.propTypes= {
     }),
 };
 
-const Header = function({isOpen, slotProps={}, targetKey, sizeKey, polygonKey, searchTypeKey, searchTypeToggleOptions}) {
+const Header = function({
+    isOpen, slotProps={}, targetKey, sizeKey, polygonKey, searchTypeKey, searchTypeToggleOptions,
+    boxSizeXKey, boxSizeYKey, boxRotationKey
+}) {
     const {groupKey} = useContext(FieldGroupCtx);
     const reqObj = getFieldGroupResults(groupKey,true);
 
-    useFieldGroupRerender([targetKey,sizeKey,polygonKey,searchTypeKey, searchTypeToggleOptions]);
+    useFieldGroupRerender([targetKey,sizeKey,polygonKey,searchTypeKey, searchTypeToggleOptions, boxSizeXKey, boxSizeYKey, boxRotationKey]);
 
     return (
         isOpen ?
@@ -370,7 +407,8 @@ const Header = function({isOpen, slotProps={}, targetKey, sizeKey, polygonKey, s
                     cancelText=''>
                     <Stack {...{width:'100%', alignItems:'center'}}>
                         <Slot {...{component:SearchSummary, slotProps:slotProps.searchSummary, request:reqObj,
-                            targetKey, sizeKey, polygonKey, searchTypeKey, searchTypeToggleOptions}}/>
+                            targetKey, sizeKey, polygonKey, searchTypeKey, searchTypeToggleOptions,
+                            boxSizeXKey, boxSizeYKey, boxRotationKey}}/>
                     </Stack>
                 </FormPanel>
             </Stack>
@@ -378,9 +416,13 @@ const Header = function({isOpen, slotProps={}, targetKey, sizeKey, polygonKey, s
 };
 
 
-function SearchSummary({request, targetKey, sizeKey, polygonKey, searchTypeKey, searchTypeToggleOptions, getSearchType}) {
+function SearchSummary({
+    request, targetKey, sizeKey, polygonKey, searchTypeKey, searchTypeToggleOptions, getSearchType,
+    boxSizeXKey, boxSizeYKey, boxRotationKey
+}) {
     let {value: searchTypeValue, label: searchTypeLabel} = getSearchType?.(request) ?? {};
     searchTypeValue ??= request?.[searchTypeKey];
+    if (searchTypeToggleOptions.length === 1) searchTypeValue ??= searchTypeToggleOptions[0].value;
     if (!searchTypeValue) return false; //since searchTypeValue determines all the following summary info to be displayed
 
     searchTypeLabel ??= searchTypeToggleOptions.find(({value})=>value===searchTypeValue)?.label ?? searchTypeValue;
@@ -392,15 +434,25 @@ function SearchSummary({request, targetKey, sizeKey, polygonKey, searchTypeKey, 
         : formatWorldPtToStringSimple(target, getEqTypeFromMR(coordPref)); // for cone, point, etc.
 
     const radius = request?.[sizeKey]; // in degrees
+    const boxSizeX = request?.[boxSizeXKey];
+    const boxSizeY = request?.[boxSizeYKey];
+    const boxRotation = request?.[boxRotationKey];
     const fileName = request?.uploadInfo?.fileName;
     const rows = request?.uploadInfo?.totalRows;
 
     const summaryFragments = [];
-    if (radius && searchTypeValue === CONE_CHOICE_KEY) {
-        summaryFragments.push(`${toMaxFixed(radius, 6).toString()}° at `);
-    }
-    if (coords && searchTypeValue !== UPLOAD_CHOICE_KEY) {
+    if (searchTypeValue === CONE_CHOICE_KEY) {
+        if (radius) summaryFragments.push(`${toMaxFixed(radius, 6).toString()}° at `);
         summaryFragments.push(coords);
+    }
+    if (searchTypeValue === POLY_CHOICE_KEY && coords) {
+        summaryFragments.push(coords);
+    }
+    if (searchTypeValue === BOX_CHOICE_KEY && boxSizeX && boxSizeY) {
+        summaryFragments.push(`${toMaxFixed(boxSizeX, 6).toString()}° x ${toMaxFixed(boxSizeY, 6).toString()}° at ${coords}`);
+        if (boxRotation) {
+            summaryFragments.push(` rotated by ${toMaxFixed(Number(boxRotation), 3).toString()}° E of N`);
+        }
     }
     if (fileName && rows && searchTypeValue === UPLOAD_CHOICE_KEY) {
         summaryFragments.push(`${rows} rows in '${fileName}'`);
@@ -421,6 +473,9 @@ SearchSummary.propTypes = {
     targetKey: string,
     sizeKey: string,
     polygonKey: string,
+    boxSizeXKey: string,
+    boxSizeYKey: string,
+    boxRotationKey: string,
     searchTypeKey: string,
     searchTypeToggleOptions: arrayOf(shape({value: string, label: string})),
     getSearchType: func, // for customizing the logic of how searchType.value and searchType.label is determined
@@ -441,6 +496,7 @@ function SpatialSearch({rootSlotProps: slotProps, insetSpacial, uploadInfo, setU
             }} />}
             {children}
             {searchTypeOp === CONE_CHOICE_KEY && <ConeOp {...{slotProps,nullAllowed}}/> }
+            {searchTypeOp === BOX_CHOICE_KEY && <BoxOp {...{slotProps, nullAllowed}}/> }
             {searchTypeOp === POLY_CHOICE_KEY && <PolyOp {...{slotProps}}/> }
             {searchTypeOp === UPLOAD_CHOICE_KEY && <UploadOp {...{slotProps,uploadInfo,setUploadInfo}}/>}
         </Stack>
@@ -451,8 +507,8 @@ function SpatialSearch({rootSlotProps: slotProps, insetSpacial, uploadInfo, setU
 function ConeOp({slotProps,nullAllowed}) {
     const {
         sizeKey= DEFAULT_SIZE_KEY,
-        min= 1 / 3600,
-        max= 1,
+        min= DEFAULT_MIN_SIZE_VALUE,
+        max= DEFAULT_MAX_SIZE_VALUE,
         initValue= DEFAULT_INIT_SIZE_VALUE,
         enabled= true,
         sx={},
@@ -500,7 +556,7 @@ function PolyOp({slotProps}) {
         polygonExampleRow1= DEF_AREA_EXAMPLE,
         polygonExampleRow2,
         selectButtonText= DEFAULT_SELECTION_TEXT,
-        instructionsText= DEFAULT_INSTRUCTIONS_CIRCLE,
+        instructionsText= DEFAULT_INSTRUCTIONS_RECT,
     }= slotProps.polygonField ?? {};
 
 
@@ -514,6 +570,44 @@ function PolyOp({slotProps}) {
             }} />
             {Boolean(selectButtonText) &&
                 <SelectAreaForEmbedded {...{selectButtonText,instructionsText,shape:SelectedShape.rect}}/>}
+        </Stack>
+    );
+}
+
+function BoxOp({slotProps, nullAllowed}) {
+    const {
+        targetKey=DEF_TARGET_PANEL_KEY,
+        inputFieldLabel,
+        targetPanelExampleRow1,
+        targetPanelExampleRow2,
+    }= slotProps.targetPanel ?? {};
+
+    return (
+        <Stack>
+            <TargetPanel {...{
+                sx:{width:DEFAULT_TARGET_PANEL_WIDTH, ...slotProps.targetPanel?.sx},
+                key:targetKey,
+                inputFieldLabel,
+                fieldKey:targetKey,
+                nullAllowed,
+                targetPanelExampleRow1,
+                targetPanelExampleRow2,
+                slotProps: {
+                    feedback:{sx: {alignSelf:'center'} },
+                }
+            }}/>
+            <BoxSearchInputFields {...{
+                boxSizeXKey: DEFAULT_BOX_SIZE_X_KEY,
+                boxSizeYKey: DEFAULT_BOX_SIZE_Y_KEY,
+                boxRotationKey: DEFAULT_BOX_ROTATION_KEY,
+                min: DEFAULT_MIN_SIZE_VALUE * 2,
+                max: DEFAULT_MAX_SIZE_VALUE * 2,
+                initSizeXState: {value: (DEFAULT_INIT_SIZE_VALUE * 2)+''},
+                initSizeYState: {value: (DEFAULT_INIT_SIZE_VALUE * 2)+''},
+                selectButtonText: DEFAULT_SELECTION_TEXT,
+                instructionsText: DEFAULT_INSTRUCTIONS_RECT,
+                ...slotProps.boxFields
+            }} />
         </Stack>
     );
 }

--- a/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
+++ b/src/firefly/js/ui/dynamic/EmbeddedPositionSearchPanel.jsx
@@ -13,7 +13,7 @@ import {
 import {HiPSTargetView} from '../../visualize/ui/TargetHiPSPanel.jsx';
 import {showInfoPopup} from '../PopupUtil';
 import {RadioGroupInputField} from '../RadioGroupInputField.jsx';
-import {Slot, useFieldGroupRerender, useFieldGroupValue} from '../SimpleComponent.jsx';
+import {Slot, useFieldGroupRerender, useFieldGroupValue, useStoreConnector} from '../SimpleComponent.jsx';
 import {SizeInputFields} from '../SizeInputField.jsx';
 import {DEF_TARGET_PANEL_KEY, TargetPanel} from '../TargetPanel.jsx';
 import {CONE_AREA_KEY} from './DynamicDef.js';
@@ -30,8 +30,10 @@ import {getPreference} from 'firefly/core/AppDataCntlr';
 import {MR_EQJ2000_HMS, MR_FIELD_HIPS_MOUSE_READOUT1} from 'firefly/visualize/MouseReadoutCntlr';
 import {getEqTypeFromMR} from 'firefly/visualize/ui/MouseReadoutUIUtil';
 import {toMaxFixed} from 'firefly/util/MathUtil';
+import {Add, Remove} from '@mui/icons-material';
+import {getComponentState} from 'firefly/core/ComponentCntlr';
 
-
+const EMBEDDED_PANEL_KEY = 'embedSearchPanel';
 const DEFAULT_FOV_DEG= 30;
 const DEFAULT_HIPS= 'ivo://CDS/P/DSS2/color';
 const DEFAULT_PLOT_ID= 'defaultHiPSTargetSearch';
@@ -129,6 +131,9 @@ export function EmbeddedPositionSearchPanel({
 
     const {groupKey}= useContext(FieldGroupCtx);
     const {searchTypeKey=CONE_AREA_KEY}= slotProps.spatialSearch ?? {};
+
+    const initIsPanelOpen = true; // search panel is open initially
+    const isPanelOpen = useStoreConnector(()=>(getComponentState(EMBEDDED_PANEL_KEY)?.isOpen ?? initIsPanelOpen));
 
     const [getSearchTypeOp, setSearchTypeOp] = useFieldGroupValue(searchTypeKey);
     const [, setPolygon] = useFieldGroupValue(polygonKey);
@@ -258,7 +263,7 @@ export function EmbeddedPositionSearchPanel({
                 }}>
                 <CollapsibleGroup variant={'plain'}>
                     <CollapsibleItem {...{
-                        componentKey:'embedSearchPanel', isOpen:true, title:'Please select a search type',
+                        componentKey: EMBEDDED_PANEL_KEY, isOpen: initIsPanelOpen, title:'Please select a search type',
                         header: (isOpen) => (<Header {...{
                             isOpen, doSearch, targetKey, sizeKey, polygonKey, searchTypeKey, searchTypeToggleOptions, slotProps,
                             boxSizeXKey, boxSizeYKey, boxRotationKey
@@ -266,9 +271,10 @@ export function EmbeddedPositionSearchPanel({
                         slotProps: {
                             header: {
                                 sx: emptyHeaderSx,
+                                indicator: isPanelOpen ? <Remove/> : <Add/>,
                                 slotProps: {
                                     button: {
-                                        component:'div',
+                                        component:'div', // since we put a "Search" button inside it
                                     }
                                 }
                             },
@@ -399,7 +405,7 @@ const Header = function({
                 <FormPanel
                     onSuccess={slotProps?.formPanel.onSuccess}
                     direction='row'
-                    sx={{width:1, alignItems: 'center', justifyContent:'space-between'}}
+                    sx={{width:1, alignItems: 'center', justifyContent:'space-between', backgroundColor: 'transparent'}}
                     slotProps={{
                         searchBar: {p:0},
                     }}

--- a/src/firefly/js/util/MathUtil.js
+++ b/src/firefly/js/util/MathUtil.js
@@ -36,3 +36,5 @@ export function allDigits(s) {
     if (isNumber(s)) return Math.trunc(s)===s;
     return isString(s) && [...s].every( (c) => isDigit(c));
 }
+
+export const clampInRange = (num, min, max) => num <= max ? (num >= min ? num : min) : max;

--- a/src/firefly/js/visualize/CsysConverter.js
+++ b/src/firefly/js/visualize/CsysConverter.js
@@ -600,7 +600,7 @@ export class CysConverter {
     /**
      * @desc Return the sky coordinates given a image x (fsamp) and  y (fline)
      * @param {Point|undefined} pt  the point to convert
-     * @param  {CoordinateSys} [outputCoordSys] (optional) The coordinate system to return, default to coordinate system of image
+     * @param  {CoordinateSys} [outputCoordSys] (optional) The coordinate system to return, defaults to Equatorial
      * @returns {WorldPt|null} the translated coordinates
      */
     getWorldCoords(pt, outputCoordSys= undefined) {
@@ -637,7 +637,7 @@ export class CysConverter {
         let wpt = this.projection.getWorldCoords(ipt.x - .5 ,ipt.y - .5);
         const csys = wpt?.getCoordSys();
         if (csys?.isCelestial() && outputCoordSys!==csys) {
-            wpt= convertCelestial(wpt, outputCoordSys);
+            wpt= convertCelestial(wpt, outputCoordSys); // outputCoordSys=undefined will return wpt in Equatorial J2000
         }
         return wpt;
     }

--- a/src/firefly/js/visualize/PlotAttribute.js
+++ b/src/firefly/js/visualize/PlotAttribute.js
@@ -52,7 +52,7 @@ export const PlotAttribute= {
     /** the selection type, a string - 'rect' or 'circle' */
     SELECTION_TYPE: 'SELECTION_TYPE',
 
-    /** the component who created the selection eg ('SelectArea' or 'SearchRefinementTool') */
+    /** the component who created the selection eg ('SelectArea' or 'SearchSelectTool') */
     SELECTION_SOURCE: 'SELECTION_SOURCE',
 
 
@@ -70,6 +70,11 @@ export const PlotAttribute= {
      * boolean
      */
     USE_POLYGON: 'USE_POLYGON',
+
+    /**
+     * boolean
+     */
+    USE_BOX: 'USE_BOX',
 
     SELECT_ACTIVE_CHART_PT: 'selectActiveChartPt',
 
@@ -158,6 +163,11 @@ export const PlotAttribute= {
 
     /** the radius of the search */
     USER_SEARCH_RADIUS_DEG: 'USER_SEARCH_RADIUS_DEG',
+
+    /** the box used for search in format: sizeXInDeg,sizeYInDeg,rotAngleInDeg */
+    USER_SEARCH_BOX: 'USER_SEARCH_BOX',
+
+    USER_SEARCH_BOX_AXIS_WP: 'USER_SEARCH_BOX_AXIS_WP',
 
     /** an object warnings: {key: string, warning:string} */
     USER_WARNINGS: 'USER_WARNINGS',

--- a/src/firefly/js/visualize/SearchRefinementTool.jsx
+++ b/src/firefly/js/visualize/SearchRefinementTool.jsx
@@ -139,8 +139,8 @@ function SearchRefinementTool({searchActions, plotId, searchAreaInDeg, wp, polyg
     },[pv]);
 
     useEffect(() => { // if target or radius field change then hips plot to reflect it
-        updatePlotOverlayFromUserInput(plotId, whichOverlay, parseWorldPt(getWP()),
-            Number(hasRadius ? getSize() : .0002), convertStrToWpAry(getPoly()));
+        updatePlotOverlayFromUserInput({plotId, whichOverlay, wp: parseWorldPt(getWP()),
+            radius: Number(hasRadius ? getSize() : .0002), polygonAry: convertStrToWpAry(getPoly())});
     }, [getWP, getSize, getPoly, whichOverlay]);
 
     const cenWpt= parseWorldPt(getWP()??wp);

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -676,10 +676,10 @@ export function getBoundingBox(ptAry) {
 
 /**
  * Return a WorldPt that is offset by the relative ra and dec from the passed in position
- * @param {WorldPt} pos1
- * @param {number} offsetRa in arcseconds
- * @param {number} offsetDec in arcseconds
- * @return {WorldPt}
+ * @param {WorldPt} pos1 position to offset in Equatorial coordinate system
+ * @param {number} offsetRa eastward offset in arcseconds
+ * @param {number} offsetDec northward offset in arcseconds
+ * @return {WorldPt} resulting position in Equatorial coordinate system
  */
 export function calculatePosition(pos1, offsetRa, offsetDec ) {
     const ra = toRadians(pos1.getLon());
@@ -702,19 +702,22 @@ export function calculatePosition(pos1, offsetRa, offsetDec ) {
     const cosDn = Math.cos(dn);
     const sinDn = Math.sin(dn);
 
-
+    // Build a 3D unit vector (\hat{r}) for offsets (de, dn) in local tangent plane
     rhat[0] = cosDe * cosDn;
     rhat[1] = sinDe * cosDn;
     rhat[2] = sinDn;
 
+    // Apply Dec rotation to above vector
     shat[0] = cosDec * rhat[0] - sinDec * rhat[2];
     shat[1] = rhat[1];
     shat[2] = sinDec * rhat[0] + cosDec * rhat[2];
 
+    // Apply RA rotation to above vector
     uhat[0] = cosRa * shat[0] - sinRa * shat[1];
     uhat[1] = sinRa * shat[0] + cosRa * shat[1];
     uhat[2] = shat[2];
 
+    // Convert the final rotated vector back to RA and Dec in equatorial plane
     const uxy = Math.sqrt(uhat[0] * uhat[0] + uhat[1] * uhat[1]);
     if (uxy>0.0) {
         ra2 = Math.atan2(uhat[1], uhat[0]);
@@ -731,6 +734,47 @@ export function calculatePosition(pos1, offsetRa, offsetDec ) {
 
     return makeWorldPt(ra2, dec2);
 }
+
+/**
+ * Transform vector components from a local rotated frame to equatorial sky coordinate frame.
+ *
+ * @param {number} x angular distance (can be in arcsec, deg, etc.) along local X axis
+ * @param {number} y angular distance (can be in arcsec, deg, etc.) along local Y axis
+ * @param {number} angleDeg rotation angle of local Y axis east of north, in degrees. Default is 0 which means
+ * local Y axis points north and local X axis points east.
+ * @return {{east: number, north: number}} angular distances along equatorial East and North axes (in same units that were passed)
+ */
+export const transformToEastNorth = (x, y, angleDeg=0) => {
+    const thetaRad = convertAngle('deg', 'rad', angleDeg);
+    if (thetaRad === 0) {
+        return { east: x, north: y };
+    }
+
+    const cosTheta = Math.cos(thetaRad);
+    const sinTheta = Math.sin(thetaRad);
+    return {
+        east:  x * cosTheta + y * sinTheta,
+        north: -x * sinTheta + y * cosTheta,
+    };
+};
+
+/**
+ * Calculate a new position given a center position, offsets along local X and Y axes, and
+ * rotation angle of the local Y axis east of north.
+ *
+ * @param centerWp {WorldPt} center point to calculate offset from. (0, 0) for local axes.
+ * @param xOffset {number} angular distance in arcseconds along local X axis
+ * @param yOffset {number} angular distance in arcseconds along local Y axis
+ * @param rotAngle {number} rotation angle of local Y axis east of north, in degrees. Default is 0 which means
+ * local Y axis points north and local X axis points east.
+ * @returns {WorldPt}
+ */
+export const calculatePositionFromLocalOffsets = (centerWp, xOffset, yOffset, rotAngle=0) => {
+    const centerWpEqu = convertCelestial(centerWp);
+    const newWpOffset = transformToEastNorth(xOffset, yOffset, rotAngle);
+    const newWpEqu = calculatePosition(centerWpEqu, newWpOffset.east, newWpOffset.north);
+    return convertCelestial(newWpEqu, centerWp.getCoordSys());
+};
 
 export function isAngleUnit(unit) {
     return ['deg', 'degree', 'arcmin', 'arcsec', 'radian', 'rad'].includes(unit.toLowerCase());
@@ -1097,6 +1141,12 @@ export function getPointOnEllipse(cx, cy, rx, ry, angle) {
     return {x,y};
 }
 
+// Normalise rotation angle to be between -360 and 360 degrees. If the input is not a finite number then return 0.
+export function normalizeRotation(rotation=0) {
+    const value = Number(rotation);
+    if (!Number.isFinite(value)) return 0;
+    return value % 360;
+}
 
 export default {
     convert: convertCelestial,

--- a/src/firefly/js/visualize/draw/DrawLayer.js
+++ b/src/firefly/js/visualize/draw/DrawLayer.js
@@ -23,19 +23,18 @@ export const ColorChangeType= {DISABLE,DYNAMIC,STATIC};
  * @typedef {Object} DrawLayer
  *
  * @prop {String} drawLayerId unique for each layer
- * @prop {String} displayGroupId, any layer in this group Id will be controlled together in the UI.\
+ * @prop {String} displayGroupId any layer in this group Id will be controlled together in the UI.\
  *                           Default to the drawLayerId layers all have a type string that default to the id,
  *                           however if multiple of same are added, the type id should be set
- * @prop {String} drawingTypeId  allows for multiple layers of same type to be added (such as multiple markers)
- *                if they share the same type id
- *                a drawing layer factory def should always pass the same type Id
- *                eg. all catalog overlays will by the same type of have different layer ids
+ * @prop {String} drawLayerTypeId  allows for multiple layers of same type to be added (such as multiple markers)
+ * if they share the same type id. A drawing layer factory def should always pass the same type id,
+ * e.g. all catalog overlays will be of the same type but have different layer ids.
  * @prop {String} title title to show in the ui
  * @prop {String} shortTitle a smaller title for the legend
  * @prop {String[]} plotIdAry array of plotId that are layered
  * @prop {String[]} visiblePlotIdAry:  array of plotId that are visible, only ids in this array are visible
  * @prop {String[]} actionTypeAry  what actions that the reducer will allow through the drawing layer reducer
- * @prop {DrawingDef} drawingDef
+ * @prop {DrawingDef} drawingDef layer's definitions of color, symbol, size, text, etc. styling information
  *
  * @prop {Boolean} canHighlight default: false,  if the layer can highlight
  * @prop {Boolean} canSelect  default: false
@@ -62,14 +61,14 @@ export const ColorChangeType= {DISABLE,DYNAMIC,STATIC};
  *
  *
  * Key:   data
- * Value: null or [] or plotId:[]
+ * Value: null or [] or {plotId:[]}
  *              arrays are arrays of drawObj
  *              if data is an array the it applies to all the plots
  *              if data is an object the it applies to the only to the plotId with
  *              the fallback being the ALL_PLOTS key
  *
  * Key:   highlightData
- * Value: null or [] or plotId:[]
+ * Value: null or [] or {plotId:[]}
  *              arrays are arrays of drawObj
  *              if data is an object the it applies to the only to the plotId with
  *
@@ -133,7 +132,7 @@ function makeDrawLayer(drawLayerId,
          // it section: The types of IDs
          // drawLayerId: unique for each layer
          // drawingGroupLayerId:
-         // drawingTypeId: allows for multiple layers of same type to be added (such as multiple markers)
+         // drawLayerTypeId: allows for multiple layers of same type to be added (such as multiple markers)
          //                if they share the same type id then events mapping marked static will only be fired once
          //                a drawing layer factory def should always pass the same type Id
          //                eg. all catalog overlays will by the same type of have different layer ids
@@ -186,14 +185,14 @@ function makeDrawLayer(drawLayerId,
            //
            //
            // Key:   data
-           // Value: null or [] or plotId:[]
+           // Value: null or [] or {plotId:[]}
            //              arrays are arrays of drawObj
            //              if data is an array the it applies to all the plots
            //              if data is an object the it applies to the only to the plotId with
            //              the fallback being the ALL_PLOTS key
            //
            // Key:   highlightData
-           // Value: null or [] or plotId:[]
+           // Value: null or [] or {plotId:[]}
            //              arrays are arrays of drawObj
            //              if data is an object the it applies to the only to the plotId with
            //
@@ -213,7 +212,7 @@ function makeDrawLayer(drawLayerId,
 
            //
            //     mouse type as the key and the function to call when activated @see MouseState
-           //     if the value is an object the a it should define the properties: exclusive:boolean and func:function
+           //     if the value is an object then it should define the properties: exclusive:boolean and func:function
            //     the function usually dispatch type functions, but can be anything
            //     value can be an action string. in that case flux.process is call to dispatch that action.
            //     a mousestatepayload object is always passed.

--- a/src/firefly/js/visualize/draw/DrawLayerFactory.js
+++ b/src/firefly/js/visualize/draw/DrawLayerFactory.js
@@ -62,14 +62,11 @@
  * This function is just a convenience to create a draw factory definition object literal. You don't have
  * to use it.  You can create the object directly.
  * Every drawing layer needs a drawing
- * factory definition to manage it. All drawing layer modules must export an factoryDef object. The factoryDef should
- * the following properties.
+ * factory definition to manage it. All drawing layer modules must export a factoryDef object.
+ * The factoryDef must have `drawLayerTypeId` and `create` properties.
  *
- * drawLayerTypeId - string, required- type id of the drawLayer
- * create -function, function, required-  that will create a new draw layer of this type
- *
- * @param drawLayerTypeId
- * @param {DrawLayerDefinition~creator} create
+ * @param {string} drawLayerTypeId required; type id of the drawLayer
+ * @param {DrawLayerDefinition~creator} create required; function that will create a new draw layer of this type
  * @param {DrawLayerDefinition~getDrawData} [getDrawDataFunc]
  * @param {DrawLayerDefinition~getLayerChanges} [getLayerChanges] get the changes to incorporate into the drawing layer object
  * @param {object} onDetachAction

--- a/src/firefly/js/visualize/ui/CommonUIKeys.js
+++ b/src/firefly/js/visualize/ui/CommonUIKeys.js
@@ -1,5 +1,6 @@
 export const CONE_CHOICE_KEY = 'CONE';
 export const POLY_CHOICE_KEY = 'POLY';
+export const BOX_CHOICE_KEY = 'BOX';
 export const UPLOAD_CHOICE_KEY = 'UPLOAD';
 export const CONE_AREA_OPTIONS = [{label: 'Cone', value: CONE_CHOICE_KEY}, {label: 'Polygon', value: POLY_CHOICE_KEY}];
 

--- a/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
+++ b/src/firefly/js/visualize/ui/TargetHiPSPanel.jsx
@@ -43,7 +43,7 @@ import {
 import {makeWorldPt, parseWorldPt} from '../Point.js';
 import {createHiPSMocLayerFromPreloadedTable} from '../task/PlotHipsTask.js';
 import {WebPlotRequest} from '../WebPlotRequest.js';
-import {CONE_CHOICE_KEY, POLY_CHOICE_KEY} from './CommonUIKeys.js';
+import {BOX_CHOICE_KEY, CONE_CHOICE_KEY, POLY_CHOICE_KEY} from './CommonUIKeys.js';
 import {MultiImageViewer} from './MultiImageViewer.jsx';
 import {SmallLegend} from './SmallLegend';
 import {HelpLines, targetHipsDefaultMenuItemKey, TargetHipsPanelToolbar} from './TargetHipsPanelToolbar.jsx';
@@ -56,6 +56,10 @@ const DIALOG_ID= 'HiPSPanelPopup';
 const DEFAULT_HIPS= 'ivo://CDS/P/DSS2/color';
 const DEFAULT_FOV= 340;
 const RADIUS_DISABLED_KEY= 'none---Size';
+const POLYGON_DISABLED_KEY = 'non---Polygon';
+const BOX_SIZE_X_DISABLED_KEY= 'none---BoxSizeX';
+const BOX_SIZE_Y_DISABLED_KEY= 'none---BoxSizeY';
+const BOX_ROTATION_DISABLED_KEY= 'none---BoxRotation';
 
 const sharedPropTypes= {
     hipsUrl: string,
@@ -109,7 +113,9 @@ VisualTargetPanel.propTypes= {
 
 export const HiPSTargetView = ({sx, hipsDisplayKey='none',
                                    hipsUrl=DEFAULT_HIPS, hipsFOVInDeg= DEFAULT_FOV, centerPt=makeWorldPt(0,0, CoordinateSys.GALACTIC),
-                                   targetKey=DEF_TARGET_PANEL_KEY, sizeKey=RADIUS_DISABLED_KEY, polygonKey='non---Polygon',
+                                   targetKey=DEF_TARGET_PANEL_KEY, sizeKey=RADIUS_DISABLED_KEY, polygonKey=POLYGON_DISABLED_KEY,
+                                   boxSizeXKey=BOX_SIZE_X_DISABLED_KEY, boxSizeYKey=BOX_SIZE_Y_DISABLED_KEY,
+                                   boxRotationKey=BOX_ROTATION_DISABLED_KEY,
                                    getWhichOverlay=() => CONE_CHOICE_KEY, toolbarHelpId,
                                    showHelpLines=true, selectionHelpText= undefined,
                                    setWhichOverlay, sRegion, coordinateSys, mocList, minSize=1/3600, maxSize=100,
@@ -121,19 +127,37 @@ export const HiPSTargetView = ({sx, hipsDisplayKey='none',
     const [getTargetWp,setTargetWp]= useFieldGroupValue(targetKey, groupKey);
     const [getHiPSRadius, setHiPSRadius]= useFieldGroupValue(sizeKey, groupKey);
     const [getPolygon, setPolygon]= useFieldGroupValue(polygonKey, groupKey);
+    const [getBoxSizeX, setBoxSizeX]= useFieldGroupValue(boxSizeXKey, groupKey);
+    const [getBoxSizeY, setBoxSizeY]= useFieldGroupValue(boxSizeYKey, groupKey);
+    const [getBoxRotation, setBoxRotation]= useFieldGroupValue(boxRotationKey, groupKey);
     const [mocError, setMocError]= useState();
     const {current:lastWhichOverlay}= useRef({lastValue:undefined});
 
     const userEnterWorldPt= () =>  parseWorldPt(getTargetWp());
     const userEnterSearchRadius= () =>  Number(getHiPSRadius());
     const userEnterPolygon= () => convertStrToWpAry(getPolygon());
+    const userEnterBoxParams= () => {
+        const sizeX= Number(getBoxSizeX());
+        const sizeY= Number(getBoxSizeY());
+        const rotation= Number(getBoxRotation());
+        return {
+            sizeX: Number.isFinite(sizeX) ? sizeX : undefined,
+            sizeY: Number.isFinite(sizeY) ? sizeY : undefined,
+            rotation: Number.isFinite(rotation) ? rotation : undefined,
+        };
+    };
+    const setBoxParams= (boxParams) => {
+        setBoxSizeX(boxParams?.sizeX);
+        setBoxSizeY(boxParams?.sizeY);
+        setBoxRotation(boxParams?.rotation);
+    };
     const usingRadius= sizeKey!==RADIUS_DISABLED_KEY;
 
     useEffect(() => { // show HiPS plot
         if (!pv || hipsUrl!==pv.request.getHipsRootUrl()) {
             initHiPSPlot({plotId,hipsUrl, viewerId,centerPt,hipsFOVInDeg, coordinateSys,
                 userEnterWorldPt, userEnterSearchRadius,
-                getWhichOverlay, userEnterPolygon,
+                getWhichOverlay, userEnterPolygon, userEnterBoxParams,
             });
         }
         else {
@@ -141,8 +165,8 @@ export const HiPSTargetView = ({sx, hipsDisplayKey='none',
             if (coordinateSys && plot && coordinateSys!==plot.projection.coordSys) {
                 dispatchChangeHiPS({plotId,coordSys:coordinateSys});
             }
-            updatePlotOverlayFromUserInput(plotId, getWhichOverlay(), userEnterWorldPt(), userEnterSearchRadius(),
-                userEnterPolygon(), true);
+            updatePlotOverlayFromUserInput({plotId, whichOverlay: getWhichOverlay(), wp: userEnterWorldPt(), 
+                radius: userEnterSearchRadius(), polygonAry: userEnterPolygon(), boxParams: userEnterBoxParams(), forceCenterOn: true});
 
             if (getActivePlotView(visRoot())?.plotId !== plotId ) dispatchChangeActivePlotView(plotId);
         }
@@ -163,7 +187,7 @@ export const HiPSTargetView = ({sx, hipsDisplayKey='none',
                 lastWhichOverlay.lastValue= overLay;
             } : undefined;
         updateUIFromPlot({plotId,setWhichOverlay:setWhichOverlayWrapper, whichOverlay:getWhichOverlay(),setTargetWp,getTargetWp,
-            setHiPSRadius,getHiPSRadius,setPolygon,getPolygon,minSize,maxSize,
+            setHiPSRadius,getHiPSRadius,setPolygon,getPolygon,setBoxParams,getBoxParams:userEnterBoxParams, minSize,maxSize,
             canUpdateModalEndInfo:false
         });
     },[pv]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -171,16 +195,17 @@ export const HiPSTargetView = ({sx, hipsDisplayKey='none',
     useEffect(() => { // if target or radius field change then hips plot to reflect it
         const whichOverlay= getWhichOverlay();
         const canGenerate= whichOverlay!==lastWhichOverlay.lastValue;
-        if (canGenerate && whichOverlay===CONE_CHOICE_KEY && !userEnterWorldPt()) {
+        if (canGenerate && (whichOverlay===CONE_CHOICE_KEY || whichOverlay===BOX_CHOICE_KEY) && !userEnterWorldPt()) {
              const wp = primePlot(visRoot(), plotId)?.attributes[PlotAttribute.USER_SEARCH_WP];
              wp && setTargetWp(wp.toString());
          }
         const radius=  usingRadius ? userEnterSearchRadius() : undefined;
+        const boxParams= userEnterBoxParams();
 
-        updatePlotOverlayFromUserInput(plotId, whichOverlay, userEnterWorldPt(),
-            radius, userEnterPolygon(), false, canGenerate);
+        updatePlotOverlayFromUserInput({plotId, whichOverlay, wp: userEnterWorldPt(),
+            radius, polygonAry: userEnterPolygon(), boxParams, forceCenterOn: false, canGeneratePolygon: canGenerate});
         lastWhichOverlay.lastValue= whichOverlay;
-    }, [getTargetWp, getHiPSRadius, getPolygon, getWhichOverlay()]);
+    }, [getTargetWp, getHiPSRadius, getPolygon, getBoxSizeX, getBoxSizeY, getBoxRotation, getWhichOverlay()]);
 
     useEffect(() => {
         attachSRegion(sRegion,plotId);
@@ -210,6 +235,9 @@ HiPSTargetView.propTypes= {
     ...sharedPropTypes,
     sizeKey: string,
     targetKey: string,
+    boxSizeXKey: string,
+    boxSizeYKey: string,
+    boxRotationKey: string,
 };
 
 
@@ -369,10 +397,11 @@ function showHiPSPanelPopup({popupClosing, element, plotId= defPopupPlotId,
  * @param {Function} obj.userEnterSearchRadius
  * @param obj.getWhichOverlay
  * @param {Function} obj.userEnterPolygon
+ * @param {Function} obj.userEnterBoxParams
  * @return {Promise<void>}
  */
 async function initHiPSPlot({ hipsUrl, plotId, viewerId, centerPt, hipsFOVInDeg, coordinateSys,
-                                userEnterWorldPt, userEnterSearchRadius, getWhichOverlay, userEnterPolygon}) {
+                                userEnterWorldPt, userEnterSearchRadius, getWhichOverlay, userEnterPolygon, userEnterBoxParams}) {
     getDrawLayersByType(dlRoot(), HiPSMOC.TYPE_ID)
         .forEach( ({drawLayerId}) => dispatchDestroyDrawLayer(drawLayerId));// clean up any old moc layers
     const wpRequest= WebPlotRequest.makeHiPSRequest(hipsUrl, centerPt, hipsFOVInDeg);
@@ -403,7 +432,8 @@ async function initHiPSPlot({ hipsUrl, plotId, viewerId, centerPt, hipsFOVInDeg,
     initSearchSelectTool(plotId);
     if (userEnterWorldPt?.() || userEnterPolygon?.()?.length) {
         await onPlotComplete(plotId);
-        updatePlotOverlayFromUserInput(plotId,getWhichOverlay(), userEnterWorldPt?.(), userEnterSearchRadius?.(), userEnterPolygon?.(), true);
+        updatePlotOverlayFromUserInput({plotId,whichOverlay: getWhichOverlay(), wp: userEnterWorldPt?.(), 
+            radius: userEnterSearchRadius?.(), polygonAry: userEnterPolygon?.(), boxParams: userEnterBoxParams?.(), forceCenterOn: true});
     }
 }
 
@@ -509,6 +539,3 @@ function attachSRegion(sRegion, plotId) {
         {drawObj, color: 'red', title:'s_region outline', destroyWhenAllDetached: true});
     if (!isDrawLayerAttached(dl, plotId)) dispatchAttachLayerToPlot(dl.drawLayerId, plotId, false);
 }
-
-
-

--- a/src/firefly/js/visualize/ui/TargetHipsPanelToolbar.jsx
+++ b/src/firefly/js/visualize/ui/TargetHipsPanelToolbar.jsx
@@ -6,7 +6,7 @@ import HelpIcon from '../../ui/HelpIcon.jsx';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {visRoot} from '../ImagePlotCntlr.js';
 import {getActivePlotView} from '../PlotViewUtil.js';
-import {CONE_CHOICE_KEY} from './CommonUIKeys.js';
+import {BOX_CHOICE_KEY, CONE_CHOICE_KEY} from './CommonUIKeys.js';
 import {SelectAreaButton} from './SelectAreaUIComponents.jsx';
 import {VisMiniToolbar} from './VisMiniToolbar.jsx';
 
@@ -50,6 +50,10 @@ export const HelpLines= ({whichOverlay, selectionHelpText, usingRadius}) => {
                     (<>
                         <Typography level='body-xs' sx={nowrap}>Click to choose a search center, or use the Selection Tools
                          to choose a search center and radius.</Typography>
+                    </> ) : whichOverlay===BOX_CHOICE_KEY ?
+                    (<>
+                        <Typography level='body-xs' sx={nowrap}>Use the Selection Tools
+                            to choose a search box. Click to change the center.</Typography>
                     </> ) :
                     (<>
                         <Typography level='body-xs' sx={nowrap}>Use the Selection Tools

--- a/src/firefly/js/visualize/ui/VisualSearchUtils.js
+++ b/src/firefly/js/visualize/ui/VisualSearchUtils.js
@@ -16,18 +16,26 @@ import {PlotAttribute} from '../PlotAttribute.js';
 import {getDrawLayerByType, getPlotViewById, isDrawLayerAttached, primePlot} from '../PlotViewUtil.js';
 import {isValidPoint, makeDevicePt, makeImagePt, makeWorldPt, parseWorldPt, pointEquals} from '../Point.js';
 import {
-    calculatePosition, computeCentralPointAndRadius, computeDistance, convertCelestial, getPointOnEllipse
+    calculatePosition,
+    calculatePositionFromLocalOffsets,
+    computeCentralPointAndRadius,
+    computeDistance,
+    convertCelestial,
+    getPointOnEllipse,
+    getPositionAngle,
+    normalizeRotation,
 } from '../VisUtil.js';
 import {changeHiPSProjectionCenter, getDevPixScaleDeg, isImage} from '../WebPlot.js';
-import {CONE_CHOICE_KEY, POLY_CHOICE_KEY} from './CommonUIKeys.js';
+import {BOX_CHOICE_KEY, CONE_CHOICE_KEY, POLY_CHOICE_KEY} from './CommonUIKeys.js';
 import {
     clearModalEndInfo, closeToolbarModalLayers, getModalEndInfo, setModalEndInfo
 } from './ToolbarToolModalEnd.js';
 import {dispatchActiveTarget} from '../../core/AppDataCntlr.js';
+import {clampInRange} from 'firefly/util/MathUtil';
 
 
 export const SEARCH_REFINEMENT_DIALOG_ID = 'SEARCH_REFINEMENT_DIALOG';
-const SEARCH_REFINEMENT_SELECTION_SOURCE= 'SearchRefinementTool';
+const SEARCH_SELECT_TOOL_SOURCE = SearchSelectTool.TYPE_ID;
 const radians= [Math.PI/4, 2*Math.PI/4, 3*Math.PI/4, 4*Math.PI/4, 5*Math.PI/4, 6*Math.PI/4, 7*Math.PI/4, 8*Math.PI/4];
 
 function getInscribedCorners(cc,cen,rx,ry) {
@@ -74,42 +82,51 @@ export function getDetailsFromSelection(plot) {
     const dPt0= cc.getDeviceCoords(pt0);
     const dPt1= cc.getDeviceCoords(pt1);
     if (!dPt0 || !dPt1) return {};
-    const cen= makeDevicePt( (dPt0.x+dPt1.x)/2, (dPt0.y+dPt1.y)/2 );
-    const cenWpt= cc.getWorldCoords(cen);
-    const sideWPx= cc.getWorldCoords( makeDevicePt( dPt0.x,cen.y));
-    const sideWPy= cc.getWorldCoords( makeDevicePt( cen.x,dPt0.y));
+    const cenDevPt= makeDevicePt( (dPt0.x+dPt1.x)/2, (dPt0.y+dPt1.y)/2 );
+    const cenWpt= cc.getWorldCoords(cenDevPt); // in Equ
+    const sideWPx= cc.getWorldCoords( makeDevicePt( dPt0.x,cenDevPt.y)); // in Equ
+    const sideWPy= cc.getWorldCoords( makeDevicePt( cenDevPt.x,dPt0.y)); // in Equ
     if (!cenWpt || !sideWPx || !sideWPy) return {};
     const radiusInit= Math.min(computeDistance(sideWPx,cenWpt), computeDistance(sideWPy,cenWpt));
-    const radius= plot.attributes[PlotAttribute.SELECTION_SOURCE]===SEARCH_REFINEMENT_SELECTION_SOURCE &&
+    const radius= plot.attributes[PlotAttribute.SELECTION_SOURCE]===SEARCH_SELECT_TOOL_SOURCE &&
                   plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG] ?
                plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG] : Math.trunc(radiusInit*3600)/3600;
-    let corners;
-    const rx= cen.x-dPt0.x;
-    const ry= cen.y-dPt0.y;
+    let corners, rectSizeX, rectSizeY, rectRotAngle, rectXAxisWpt, rectYAxisWpt;
+    const rx= cenDevPt.x-dPt0.x;
+    const ry= cenDevPt.y-dPt0.y;
 
     const cone= plot.attributes[PlotAttribute.SELECTION_TYPE]===SelectedShape.circle.key;
 
-    if (cone) {
-        corners= getCircumscribedCorners(cc,cen,rx,ry);
+    if (cone) { // SelectedShape.circle
+        corners= getCircumscribedCorners(cc,cenDevPt,rx,ry);
     }
-    else {
-        const ptCorner01= cc.getWorldCoords(makeDevicePt(dPt0.x, dPt1.y));
-        const ptCorner10= cc.getWorldCoords(makeDevicePt(dPt1.x, dPt0.y));
-        corners= [pt0,ptCorner01,pt1,ptCorner10].filter( (pt) => pt);
+    else { // SelectedShape.rect
+        const ptX0Y1= cc.getWorldCoords(makeDevicePt(dPt0.x, dPt1.y)); // in Equ
+        const ptX1Y0= cc.getWorldCoords(makeDevicePt(dPt1.x, dPt0.y)); // in Equ
+        corners = [pt0,ptX0Y1,pt1,ptX1Y0].filter((pt) => pt); //poly UI params
+
+        rectXAxisWpt = cc.getWorldCoords(makeDevicePt(dPt0.x, cenDevPt.y)); // in Equ
+        rectYAxisWpt = cc.getWorldCoords(makeDevicePt(cenDevPt.x, dPt0.y)); // in Equ
+        rectSizeX = computeDistance(cenWpt, rectXAxisWpt) * 2;
+        rectSizeY = computeDistance(cenWpt, rectYAxisWpt) * 2;
+        rectRotAngle = getPositionAngle(
+            cenWpt.getLon(), cenWpt.getLat(),
+            rectYAxisWpt.getLon(), rectYAxisWpt.getLat() // since rotation angle is E of N (where Y axis = N at 0 deg)
+        );
     }
 
     let relativeDevCorners= corners
         .map( (pt) => {
             const dPt= cc.getDeviceCoords(pt);
             if (!dPt) return;
-            return makeDevicePt( cen.x-dPt.x, cen.y-dPt.y );
+            return makeDevicePt( cenDevPt.x-dPt.x, cenDevPt.y-dPt.y );
         })
         .filter( (pt) => pt);
 
     if (relativeDevCorners?.length!==corners.length) relativeDevCorners= undefined;
 
 
-    return {cenWpt, radius, corners, relativeDevCorners, cone};
+    return {cenWpt, radius, corners, rectSizeX, rectSizeY, rectRotAxisWpt: rectYAxisWpt, rectRotAngle, relativeDevCorners, cone};
 }
 
 export function makeRelativePolygonAry(plot, polygonAry) {
@@ -172,6 +189,7 @@ export function isWpArysEquals(wpAry1, wpAry2) {
 }
 
 export function initSearchSelectTool(plotId) {
+    // create a SearchSelect draw layer and attach it to the plot (if not already done)
     const dl = getDrawLayerByType(getDlAry(), SearchSelectTool.TYPE_ID);
     !dl && dispatchCreateDrawLayer(SearchSelectTool.TYPE_ID);
     !isDrawLayerAttached(dl, plotId) && dispatchAttachLayerToPlot(SearchSelectTool.TYPE_ID, plotId, false);
@@ -194,82 +212,144 @@ export function removeSearchSelectTool(plotId) {
     });
 }
 
+
+function handleConeUIFromPlot({plot, plotId, isSelectAreaDLOnPlot, cenWpt, radius,
+                                  setWpAndDispatch, doModalEnd, userEnterWorldPt, userEnterSearchRadius,
+                                  setHiPSRadius, getHiPSRadius, minSize, maxSize}) {
+    if (isSelectAreaDLOnPlot) {
+        if (!cenWpt) return;
+        const drawRadius = clampInRange(radius, minSize, maxSize);
+        if (pointEquals(userEnterWorldPt(), cenWpt) && drawRadius === userEnterSearchRadius()) return;
+        setWpAndDispatch(cenWpt);
+        setUISize(radius, minSize, maxSize, userEnterSearchRadius(), setHiPSRadius);
+        updatePlotOverlayFromUserInput({plotId, whichOverlay: CONE_CHOICE_KEY, wp: cenWpt, radius: drawRadius, polygonAry: undefined});
+        setTimeout(doModalEnd, 10);
+    } else {
+        const wp = plot.attributes[PlotAttribute.USER_SEARCH_WP];
+        if (!wp) return;
+        const utWPt = userEnterWorldPt();
+        if (Number(getHiPSRadius()) !== Number(plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG])) {
+            setUISize(plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG], minSize, maxSize, userEnterSearchRadius(), setHiPSRadius);
+        }
+        if (!utWPt || (isValidPoint(utWPt) && !pointEquals(wp, utWPt))) {
+            setWpAndDispatch(wp);
+            if (plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG]) doModalEnd();
+        }
+    }
+}
+
+function handleBoxUIFromPlot({plot, plotId, isSelectAreaDLOnPlot, cenWpt, rectSizeX, rectSizeY, rectRotAngle, rectRotAxisWpt,
+                                 setWpAndDispatch, doModalEnd, userEnterWorldPt, getBoxParams, setBoxParams, minSize, maxSize}) {
+    if (isSelectAreaDLOnPlot) {
+        if (!cenWpt) return;
+        const drawSizeX = clampInRange(rectSizeX, minSize, maxSize);
+        const drawSizeY = clampInRange(rectSizeY, minSize, maxSize);
+        const rotation = rectRotAngle;
+        if (pointEquals(userEnterWorldPt(), cenWpt) &&
+            drawSizeX === getBoxParams()?.sizeX &&
+            drawSizeY === getBoxParams()?.sizeY &&
+            rotation === getBoxParams()?.rotation) return;
+        setWpAndDispatch(cenWpt);
+        const drawBox = {sizeX: drawSizeX, sizeY: drawSizeY, rotation: normalizeRotation(rotation)};
+        setBoxParams(drawBox);
+        dispatchAttributeChange({plotId, changes: {
+            [PlotAttribute.USER_SEARCH_BOX]: drawBox,
+            [PlotAttribute.USER_SEARCH_BOX_AXIS_WP]: rectRotAxisWpt
+        }});
+        setTimeout(doModalEnd, 10);
+    } else {
+        const wp = plot.attributes[PlotAttribute.USER_SEARCH_WP];
+        if (!wp) return;
+        const utWPt = userEnterWorldPt();
+        const boxParams = plot.attributes[PlotAttribute.USER_SEARCH_BOX];
+        if (getBoxParams()?.sizeX !== boxParams?.sizeX ||
+            getBoxParams()?.sizeY !== boxParams?.sizeY ||
+            getBoxParams()?.rotation !== boxParams?.rotation) {
+            setBoxParams(boxParams);
+        }
+        if (!utWPt || (isValidPoint(utWPt) && !pointEquals(wp, utWPt))) {
+            setWpAndDispatch(wp);
+            if (boxParams?.sizeX && boxParams?.sizeY) doModalEnd();
+        }
+    }
+}
+
+function handlePolygonUIFromPlot({plot, plotId, isSelectAreaDLOnPlot, cenWpt, corners,
+                                     setTargetWp, getTargetWp, doModalEnd, userEnterPolygon, setPolygon}) {
+    let wpStr;
+    if (isSelectAreaDLOnPlot) {
+        if (isWpArysEquals(corners, userEnterPolygon())) return;
+        wpStr = cenWpt.toString();
+        const polyStr = convertWpAryToStr(corners, plot);
+        setPolygon(polyStr);
+        dispatchAttributeChange({plotId, changes: {[PlotAttribute.POLYGON_ARY]: convertStrToWpAry(polyStr)}});
+        setTimeout(doModalEnd, 10);
+    } else {
+        const polyWpAry = plot.attributes[PlotAttribute.POLYGON_ARY];
+        wpStr = plot.attributes[PlotAttribute.USER_SEARCH_WP];
+        if (polyWpAry?.length) {
+            if (isWpArysEquals(polyWpAry, userEnterPolygon())) return;
+            setPolygon(convertWpAryToStr(polyWpAry, plot));
+            doModalEnd();
+        }
+    }
+    if (wpStr && wpStr !== getTargetWp()) setTargetWp(wpStr);
+}
+
 export function updateUIFromPlot({plotId, setWhichOverlay, whichOverlay, setTargetWp, getTargetWp, canUpdateModalEndInfo=true,
-                                     setHiPSRadius, getHiPSRadius, setPolygon, getPolygon, minSize, maxSize }) {
+                                     setHiPSRadius, getHiPSRadius, setPolygon, getPolygon, getBoxParams, setBoxParams, minSize, maxSize }) {
 
     const userEnterWorldPt = () => parseWorldPt(getTargetWp());
     const userEnterSearchRadius = () => Number(getHiPSRadius());
     const userEnterPolygon = () => convertStrToWpAry(getPolygon());
 
-    if (whichOverlay !== CONE_CHOICE_KEY && whichOverlay !== POLY_CHOICE_KEY) return;
+    if (![CONE_CHOICE_KEY, POLY_CHOICE_KEY, BOX_CHOICE_KEY].includes(whichOverlay)) return;
     const plot = primePlot(visRoot(), plotId);
     if (!plot) return;
     let isCone = whichOverlay === CONE_CHOICE_KEY;
-    const {cenWpt, radius, corners} = plot.attributes[PlotAttribute.SELECTION] ? getDetailsFromSelection(plot) : {};
+    const isBox = whichOverlay === BOX_CHOICE_KEY;
+    const {cenWpt, radius, corners, rectSizeX, rectSizeY, rectRotAxisWpt, rectRotAngle} =
+        plot.attributes[PlotAttribute.SELECTION] ? getDetailsFromSelection(plot) : {};
+
     const plotSelType= plot.attributes[PlotAttribute.SELECTION_TYPE];
     if (setWhichOverlay && plotSelType) {
-        isCone= plotSelType!==SelectedShape.rect.key; // if future, if something not supported just default to cone
-        if (plot.attributes[PlotAttribute.SELECTION_SOURCE]!==SEARCH_REFINEMENT_SELECTION_SOURCE) {
-            setWhichOverlay(isCone ? CONE_CHOICE_KEY : POLY_CHOICE_KEY);
+        isCone= plotSelType!==SelectedShape.rect.key; // in future, if something not supported just default to cone
+        if (plot.attributes[PlotAttribute.SELECTION_SOURCE]!==SEARCH_SELECT_TOOL_SOURCE) {
+            setWhichOverlay(isCone ? CONE_CHOICE_KEY : (plot.attributes[PlotAttribute.USE_BOX]
+                ? BOX_CHOICE_KEY : POLY_CHOICE_KEY));
         }
     }
+    // SelectArea Drawing Layer is drawn on the plot
+    const isSelectAreaDLOnPlot = plot.attributes[PlotAttribute.SELECTION] && plot.attributes[PlotAttribute.SELECTION_SOURCE]===SelectArea.TYPE_ID;
 
+    const setWpAndDispatch = (wp) => {
+        setTargetWp(wp.toString());
+        dispatchActiveTarget(wp);
+    };
+    const doModalEnd = () => canUpdateModalEndInfo ? updateModalEndInfo(plot.plotId) : closeToolbarModalLayers();
+
+    const handlerCtx = {plot, plotId, isSelectAreaDLOnPlot, cenWpt, setTargetWp, setWpAndDispatch, doModalEnd, userEnterWorldPt};
     if (isCone) {
-        if (plot.attributes[PlotAttribute.SELECTION] && plot.attributes[PlotAttribute.SELECTION_SOURCE]===SelectArea.TYPE_ID) {
-            if (!cenWpt) return;
-            const drawRadius = radius <= maxSize ? (radius >= minSize ? radius : minSize) : maxSize;
-            if (pointEquals(userEnterWorldPt(), cenWpt) && drawRadius === userEnterSearchRadius()) return;
-            setTargetWp(cenWpt.toString());
-            dispatchActiveTarget(cenWpt);
-            setUISize(radius,minSize,maxSize,userEnterSearchRadius(),setHiPSRadius);
-            updatePlotOverlayFromUserInput(plotId, CONE_CHOICE_KEY, cenWpt, drawRadius, undefined);
-            setTimeout(() => {
-                canUpdateModalEndInfo ? updateModalEndInfo(plot.plotId) : closeToolbarModalLayers();
-            }, 10);
-        }
-        else {
-            const wp = plot.attributes[PlotAttribute.USER_SEARCH_WP];
-            if (!wp) return;
-            const utWPt = userEnterWorldPt();
-            if (Number(getHiPSRadius())!==Number(plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG])) {
-                setUISize(plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG],minSize,maxSize,userEnterSearchRadius(),setHiPSRadius);
-            }
-            if (!utWPt || (isValidPoint(utWPt) && !pointEquals(wp, utWPt))) {
-                setTargetWp(wp.toString());
-                dispatchActiveTarget(wp);
-                if (plot.attributes[PlotAttribute.USER_SEARCH_RADIUS_DEG]) {
-                    canUpdateModalEndInfo ? updateModalEndInfo(plot.plotId) : closeToolbarModalLayers();
-                }
-            }
-        }
-    }
-    else {
-        let wpStr;
-        if (plot.attributes[PlotAttribute.SELECTION] && plot.attributes[PlotAttribute.SELECTION_SOURCE]===SelectArea.TYPE_ID) {
-            if (isWpArysEquals(corners, userEnterPolygon())) return;
-            wpStr= cenWpt.toString();
-            const polyStr= convertWpAryToStr(corners, plot);
-            setPolygon(polyStr);
-            dispatchAttributeChange({ plotId, changes:{[PlotAttribute.POLYGON_ARY]: convertStrToWpAry(polyStr)}});
-            setTimeout(() => {
-                canUpdateModalEndInfo ? updateModalEndInfo(plot.plotId) : closeToolbarModalLayers();
-            }, 10);
-        } else {
-            const polyWpAry = plot.attributes[PlotAttribute.POLYGON_ARY];
-            wpStr = plot.attributes[PlotAttribute.USER_SEARCH_WP];
-            if (polyWpAry?.length) {
-                if (isWpArysEquals(polyWpAry, userEnterPolygon())) return;
-                setPolygon(convertWpAryToStr(polyWpAry, plot));
-                canUpdateModalEndInfo ? updateModalEndInfo(plot.plotId) : closeToolbarModalLayers();
-            }
-        }
-        if (wpStr && wpStr !== getTargetWp()) setTargetWp(wpStr);
+        handleConeUIFromPlot({
+            ...handlerCtx,
+            radius, userEnterSearchRadius, setHiPSRadius, getHiPSRadius, minSize, maxSize
+        });
+    } else if (isBox) {
+        handleBoxUIFromPlot({
+            ...handlerCtx,
+            rectSizeX, rectSizeY, rectRotAngle, rectRotAxisWpt, getBoxParams, setBoxParams, minSize, maxSize
+        });
+    } else {
+        handlePolygonUIFromPlot({
+            ...handlerCtx,
+            corners, getTargetWp, userEnterPolygon, setPolygon
+        });
     }
 }
 
 function setUISize(size, minSize, maxSize, uiCurrentValue, setter) {
     if (isUndefined(size) || isNaN(size)) return;
-    const sizeToSet = size <= maxSize ? (size >= minSize ? size : minSize) : maxSize;
+    const sizeToSet = clampInRange(size, minSize, maxSize);
     if (uiCurrentValue===sizeToSet) return;
     setter(sizeToSet+'');
 }
@@ -292,7 +372,7 @@ function convertConeToSelection(plot,wp,radius) {
         [PlotAttribute.SELECTION]: sel,
         [PlotAttribute.SELECTION_TYPE]: SelectedShape.circle.key,
         [PlotAttribute.IMAGE_BOUNDS_SELECTION]: imBoundSel,
-        [PlotAttribute.SELECTION_SOURCE]: SEARCH_REFINEMENT_SELECTION_SOURCE,
+        [PlotAttribute.SELECTION_SOURCE]: SEARCH_SELECT_TOOL_SOURCE,
     };
 }
 
@@ -318,53 +398,103 @@ function convertPolygonToSelection(plot,polygonAry) {
         [PlotAttribute.SELECTION]: sel,
         [PlotAttribute.SELECTION_TYPE]: SelectedShape.rect.key,
         [PlotAttribute.IMAGE_BOUNDS_SELECTION]: imBoundSel,
-        [PlotAttribute.SELECTION_SOURCE]: SEARCH_REFINEMENT_SELECTION_SOURCE,
+        [PlotAttribute.SELECTION_SOURCE]: SEARCH_SELECT_TOOL_SOURCE,
     };
     
 }
 
+function convertBoxToSelection(plot, wp, boxParams) {
+    if (!plot || !wp || !boxParams?.sizeX || !boxParams?.sizeY || !(boxParams?.rotation || boxParams?.rotation===0)) return {};
 
-function convertToSelection(plot, wp,radius,polygonAry,whichOverlay) {
-    if (!plot) return {};
-    return (whichOverlay===CONE_CHOICE_KEY) ?
-        convertConeToSelection(plot,wp,radius) :
-        convertPolygonToSelection(plot,polygonAry);
+    const halfSizeXArcsec = boxParams.sizeX / 2 * 3600;
+    const halfSizeYArcsec = boxParams.sizeY / 2 * 3600;
+    const rotAxisOffset = {x: 0, y: halfSizeYArcsec}; // since the rotation axis is along the Y axis of box
+    const boxCornerOffsets = [
+        {x: +halfSizeXArcsec, y: +halfSizeYArcsec}, // upperRight
+        {x: -halfSizeXArcsec, y: +halfSizeYArcsec}, // upperLeft
+        {x: -halfSizeXArcsec, y: -halfSizeYArcsec}, // lowerLeft
+        {x: +halfSizeXArcsec, y: -halfSizeYArcsec}, // lowerRight
+    ];
+
+    // wp is box center (0, 0) but Y and X axes of the box are not always aligned with North and East. So we can't do
+    // simple arithmetic to find the corners from above offsets and instead use the following function which takes
+    // (E of N) rotation of the local plane into account when applying offsets to find new positon.
+    const wpAry = boxCornerOffsets.map((offset) =>
+        calculatePositionFromLocalOffsets(wp, offset.x, offset.y, boxParams.rotation));
+    const rotAxisWp = calculatePositionFromLocalOffsets(wp, rotAxisOffset.x, rotAxisOffset.y, boxParams.rotation);
+
+    if (wpAry.some((pt) => !isValidPoint(pt))) return {};
+
+    const sel = {
+        pt0: wpAry[1], // upperLeft
+        pt1: wpAry[3], // lowerRight
+    };
+    const imBoundSel = getImageBoundsSelection(sel, CsysConverter.make(plot), SelectedShape.rect.key,
+        getPlotViewById(visRoot(), plot.plotId)?.rotation ?? 0);
+
+    return {
+        [PlotAttribute.POLYGON_ARY]: wpAry,
+        [PlotAttribute.USER_SEARCH_BOX_AXIS_WP]: rotAxisWp,
+        [PlotAttribute.SELECTION]: sel,
+        [PlotAttribute.SELECTION_TYPE]: SelectedShape.rect.key,
+        [PlotAttribute.IMAGE_BOUNDS_SELECTION]: imBoundSel,
+        [PlotAttribute.SELECTION_SOURCE]: SEARCH_SELECT_TOOL_SOURCE,
+    };
 }
 
-export function updatePlotOverlayFromUserInput(plotId, whichOverlay, wp, radius, polygonAry, forceCenterOn = false, canGeneratePolygon= false) {
+
+function convertToSelection(plot, wp, radius, polygonAry, whichOverlay, boxParams) {
+    if (!plot) return {};
+    if (whichOverlay === CONE_CHOICE_KEY) return convertConeToSelection(plot, wp, radius);
+    if (whichOverlay === BOX_CHOICE_KEY) return convertBoxToSelection(plot, wp, boxParams);
+    return convertPolygonToSelection(plot, polygonAry);
+}
+
+export function updatePlotOverlayFromUserInput({
+    plotId, whichOverlay, wp, radius, polygonAry, boxParams, forceCenterOn = false, canGeneratePolygon = false
+}) {
     const dl = getDrawLayerByType(getDlAry(), SearchSelectTool.TYPE_ID);
-    if (!dl) return;
+    if (!dl) return; // since the following changes are only made for SearchSelect drawing layer on plot
+
     const isCone = whichOverlay === CONE_CHOICE_KEY;
+    const isBox = whichOverlay === BOX_CHOICE_KEY;
+    const isPolygon = whichOverlay === POLY_CHOICE_KEY;
     const plot= primePlot(visRoot(),plotId);
 
+    // update SearchSelect drawing layer's attributes in the store
     dispatchChangeDrawingDef(dl.drawLayerId,{...dl.drawingDef,color:'yellow'},plotId);
     dispatchModifyCustomField(dl.drawLayerId,{isInteractive: true},plotId);
 
-    if (!isCone && wp && radius && canGeneratePolygon) {
+    if (isPolygon && wp && radius && canGeneratePolygon) {
+        // convert cone to a 8-pointed polygon that circumscribes it
         const cc= CsysConverter.make(plot);
-        const cen= cc.getDeviceCoords(wp);
+        const cen= cc.getDeviceCoords(wp); // center of cone
         const ptOnCone= cc.getDeviceCoords(calculatePosition( convertCelestial(wp),radius*3600,radius*3600));
-        const dist= Math.abs(cen.y-ptOnCone.y)*2;
-        polygonAry= getCircumscribedCorners(cc,cen,dist,dist);
+        const dist= Math.abs(cen.y-ptOnCone.y)*2; // diameter of cone
+        polygonAry= getCircumscribedCorners(cc,cen,dist,dist); // rx=ry for circle, so dist is used for both
     }
 
-    let changes= {
+    const changes= {
         [PlotAttribute.USER_SEARCH_WP]: wp,
         [PlotAttribute.USER_SEARCH_RADIUS_DEG]: isCone ? radius : undefined,
-        [PlotAttribute.POLYGON_ARY]: isCone ? undefined : polygonAry,
-        [PlotAttribute.RELATIVE_IMAGE_POLYGON_ARY]: isCone ? undefined : makeRelativePolygonAry(primePlot(visRoot(), plotId), polygonAry),
-        [PlotAttribute.USE_POLYGON]: !isCone,
+        [PlotAttribute.USER_SEARCH_BOX]: isBox && boxParams ? {...boxParams, rotation: normalizeRotation(boxParams?.rotation)} : undefined,
+        [PlotAttribute.POLYGON_ARY]: isPolygon ? polygonAry : undefined,
+        [PlotAttribute.RELATIVE_IMAGE_POLYGON_ARY]:
+            isPolygon ? makeRelativePolygonAry(primePlot(visRoot(), plotId), polygonAry) : undefined,
+        [PlotAttribute.USE_BOX]: isBox,
+        [PlotAttribute.USE_POLYGON]: isPolygon,
+        // add SearchSelectTool DL related plot attributes from the user input
+        ...(whichOverlay ? convertToSelection(plot, wp, radius, polygonAry, whichOverlay, boxParams) : {})
     };
-    if (whichOverlay) {
-        changes=  {...changes, ...convertToSelection(plot, wp,radius,polygonAry,whichOverlay)};
-    }
-
     dispatchAttributeChange({ plotId, changes });
+
+    // force redrawing the SearchSelect drawing layer now that plot attributes have been updated
     dispatchForceDrawLayerUpdate(dl.drawLayerId, plotId);
     if (!plot || isImage(plot)) return;
-    if (!isCone && !polygonAry) return;
+    if (isPolygon && !polygonAry) return;
+    if (isBox && !boxParams?.sizeX && !boxParams?.sizeY) return;
 
-    const centerProjPt = isCone ? wp : computeCentralPointAndRadius(polygonAry)?.centralPoint;
+    const centerProjPt = isPolygon ? computeCentralPointAndRadius(polygonAry)?.centralPoint : wp;
     const cc = CsysConverter.make(plot);
     if (!centerProjPt || !cc) return;
     if (cc.pointInView(centerProjPt) && !forceCenterOn) return;
@@ -408,7 +538,7 @@ export function markOutline(sa, plotId, {wp, radius, polyStr}) {
     if (polygonAry && sa.searchType === AREA) isCone = false;
     updateModalEndInfo(plotId);
 
-    updatePlotOverlayFromUserInput(plotId, isCone ? CONE_CHOICE_KEY : POLY_CHOICE_KEY, wp, radius, polygonAry);
+    updatePlotOverlayFromUserInput({plotId, whichOverlay: isCone ? CONE_CHOICE_KEY : POLY_CHOICE_KEY, wp, radius, polygonAry});
     dispatchModifyCustomField(dl.drawLayerId, {isInteractive: false}, plotId);
     dispatchForceDrawLayerUpdate(dl.drawLayerId, plotId);
 }


### PR DESCRIPTION
Fixes [FIREFLY-1942](https://jira.ipac.caltech.edu/browse/FIREFLY-1942)


* Updated the `EmbeddedPositionSearchPanel` to support a "Box" search type and added the `BoxSearchInputFields` component for user input of box size and rotation
* Modified the search selection drawing logic in `SearchSelectTool` to support boxes: added `drawSearchSelectionTransformBox` for rendering box shapes with rotation
* updated event dispatching and rendering functions to handle the new box type in `VisualSearchUtils` and `TargetHiPSPanel` to support bidirectional update between HiPS image + drawing layer and box UI inputs.

**Other Improvements**
* Enhanced the `QuantityInputField` to allow passing additional props for customizing the numeric input, supporting features like increment/decrement controls for rotation. 
* Added clarifying code comments
* ~Fixed a regression bug that was failing Spectral Image search tab to load in SPHEREx~ rebased from dev

Also see IFE PR: https://github.com/IPAC-SW/irsa-ife/pull/460

## Testing
- SPHEREx mosaic tool: https://firefly-1942-rotation-rect-select.irsakubedev.ipac.caltech.edu/applications/spherex/tool-mosaic
- DCE: https://firefly-1942-rotation-rect-select.irsakubedev.ipac.caltech.edu/irsaviewer/?__action=layout.showDropDown&view=IrsaDataCollections

Enable direction and grid layers on HiPS for testing. Zoom in the HiPS to FOV < 8 deg since there's upper limit on box size. Then:
1. Draw a rect selection area - it should convert to search select box (yellow box) and UI inputs should be populated
2. Change box UI inputs - it should redraw the box as per inputs. Use arrows on rotation field to quickly see effect of rotation

Do above testing for target at a 1) random location (`34, -56`), 2) near equator (`anything 0`), 3) at poles (`0 90`, `0 -90`). Also try changing projection (spherical/aitoff), and coordinate system (galactic/equatorial) of the HiPS.


### Regression Testing
Check if the following are working as before:
- DCE cone and polygon mode
- Search refinement tool on FITS images (cone and polygon)