### PR TITLE
Firefly 1966 add helm chart

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -116,4 +116,4 @@ jobs:
           # align chart appVersion with the image tag
           sed -i "s/^appVersion:.*/appVersion: \"${{ steps.resolve_tags.outputs.tag }}\"/" firefly/helm/Chart.yaml
           helm package firefly/helm/
-          helm push firefly-*.tgz oci://ghcr.io/caltech-ipac/firefly-chart
+          helm push firefly-*.tgz oci://ghcr.io/caltech-ipac/helm-charts

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -28,6 +28,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # initial checkout to make local actions available
+      - name: Checkout Firefly
+        uses: actions/checkout@v4
+        with:
+          path: firefly
+
       # -------------------------------------------------------------
       # Use local action to resolve git ref and image tag from inputs
       # -------------------------------------------------------------
@@ -86,10 +92,28 @@ jobs:
           context: .
           file: firefly/docker/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'release' || inputs.push_image == 'true' }}
+          push: ${{ github.event_name == 'release' || inputs.push_image }}
           # docker buildx does not allow uppercase letters in tags, so we convert to lowercase here
           tags: ghcr.io/caltech-ipac/firefly:${{ steps.resolve_tags.outputs.tag }}
           build-args: |
             env=ops
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # ------------------------------------------------------------
+      # Package and push Helm chart to GHCR
+      # ------------------------------------------------------------
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Publish Helm chart
+        if: github.event_name == 'release' || inputs.push_image
+        run: |
+          if [[ ! -f firefly/helm/Chart.yaml ]]; then
+            echo "No Helm chart found, skipping."
+            exit 0
+          fi
+          # align chart appVersion with the image tag
+          sed -i "s/^appVersion:.*/appVersion: \"${{ steps.resolve_tags.outputs.tag }}\"/" firefly/helm/Chart.yaml
+          helm package firefly/helm/
+          helm push firefly-*.tgz oci://ghcr.io/caltech-ipac/firefly-chart

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: firefly
+description: Firefly web application
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/helm/README.md
+++ b/helm/README.md
@@ -17,20 +17,17 @@ helm/
 
 **From GHCR:**
 
-List available versions:
-```bash
-gh api /orgs/Caltech-IPAC/packages/container/firefly-chart%2Ffirefly/versions \
-  --jq '.[].metadata.container.tags'
-```
+Available versions:  
+https://github.com/Caltech-IPAC/firefly/pkgs/container/helm-charts%2Ffirefly/versions
 
 Inspect a specific version:
 ```bash
-helm show chart oci://ghcr.io/caltech-ipac/firefly-chart/firefly --version <chart-version>
+helm show chart oci://ghcr.io/caltech-ipac/helm-charts/firefly --version <chart-version>
 ```
 
 Install:
 ```bash
-helm upgrade --install firefly oci://ghcr.io/caltech-ipac/firefly-chart/firefly \
+helm upgrade --install firefly oci://ghcr.io/caltech-ipac/helm-charts/firefly \
   -n my-namespace \
   --create-namespace \
   --version <chart-version> \
@@ -73,6 +70,7 @@ helm -n my-namespace uninstall firefly
 | `ingress.enabled` | `true` | Enable ingress |
 | `ingress.className` | `""` | Ingress class; omit to use cluster default. Supported values: `nginx`, `traefik`, `haproxy` |
 | `ingress.host` | `firefly.example.com` | **Required override.** Hostname depends on where the app is deployed and must be set explicitly via `-f env/<env>.yaml` or `--set ingress.host=<host>` |
+| `ingress.pathPrefix` | `""` | Optional prefix prepended to the ingress path: `/<pathPrefix>/firefly`. Also sets `PATH_PREFIX` env var on the container |
 | `ingress.annotations` | `{}` | Additional annotations; merged with auto-generated affinity annotations |
 | `ingress.tlsSecretName` | `""` | TLS secret name; when set, TLS is enabled |
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,128 @@
+# Firefly Helm Chart
+
+Helm chart for deploying [Firefly](https://github.com/Caltech-IPAC/firefly), a web application for astronomical data visualization.
+
+## Chart Structure
+
+```
+helm/
+├── Chart.yaml
+├── values.yaml         # defaults
+└── env/
+    ├── dev.yaml        # sample dev overrides
+    └── prod.yaml       # sample prod overrides
+```
+
+## Install
+
+**From GHCR:**
+
+List available versions:
+```bash
+gh api /orgs/Caltech-IPAC/packages/container/firefly-chart%2Ffirefly/versions \
+  --jq '.[].metadata.container.tags'
+```
+
+Inspect a specific version:
+```bash
+helm show chart oci://ghcr.io/caltech-ipac/firefly-chart/firefly --version <chart-version>
+```
+
+Install:
+```bash
+helm upgrade --install firefly oci://ghcr.io/caltech-ipac/firefly-chart/firefly \
+  -n my-namespace \
+  --create-namespace \
+  --version <chart-version> \
+  -f env/dev.yaml \
+  --set ingress.host=my.example.com
+```
+> Omit `--version` to use the latest published chart.
+
+**From local chart:**
+```bash
+helm update --install firefly ./helm \
+  -n my-namespace \
+  --create-namespace \
+  -f env/dev.yaml
+  --set ingress.host=my.example.com \
+```
+
+**Uninstall:**
+```bash
+helm -n my-namespace uninstall firefly
+```
+
+## Configuration
+
+### Image
+| Key | Default | Description |
+|-----|---------|-------------|
+| `image.repository` | `ghcr.io/caltech-ipac/firefly` | Image repository |
+| `image.tag` | appVersion in Chart.yaml | Image tag |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+
+### Scaling
+| Key | Default | Description |
+|-----|---------|-------------|
+| `replicaCount` | `1` | Number of replicas. When > 1, Redis is automatically deployed and session affinity annotations are added to the ingress based on `ingress.className` |
+
+### Ingress
+| Key | Default | Description |
+|-----|---------|-------------|
+| `ingress.enabled` | `true` | Enable ingress |
+| `ingress.className` | `""` | Ingress class; omit to use cluster default. Supported values: `nginx`, `traefik`, `haproxy` |
+| `ingress.host` | `firefly.example.com` | **Required override.** Hostname depends on where the app is deployed and must be set explicitly via `-f env/<env>.yaml` or `--set ingress.host=<host>` |
+| `ingress.annotations` | `{}` | Additional annotations; merged with auto-generated affinity annotations |
+| `ingress.tlsSecretName` | `""` | TLS secret name; when set, TLS is enabled |
+
+### Session Affinity
+Session affinity is required when `replicaCount > 1`. If `ingress.className` is set,
+the appropriate cookie-based affinity annotations are automatically injected. Supported
+values: `nginx`, `traefik`, `haproxy`. For other ingress controllers, set the annotations
+manually via `ingress.annotations`.
+
+### Persistence
+All volumes default to `emptyDir`. Each can be overridden with a new PVC or an existing one.
+The examples below are samples — actual values for `storageClass`, `size`, and `existingClaim`
+depend on your Kubernetes setup:
+
+```yaml
+persistence:
+  workDir:
+    pvc:
+      size: 10Gi
+      storageClass: standard
+      accessMode: ReadWriteOnce
+  logsDir:
+    existingClaim: my-logs-pvc
+  sharedWorkDir:
+    pvc:
+      size: 10Gi
+      storageClass: efs
+      accessMode: ReadWriteMany  # required for multi-replica
+```
+
+### Admin Password
+```yaml
+# plain text
+adminPassword:
+  value: mypassword
+
+# from a Kubernetes secret
+adminPassword:
+  secretName: my-secret
+  secretKey: password
+```
+
+### Redis
+Automatically deployed when `replicaCount > 1`. Consult `values.yaml` for configuration options including image, resources, and persistence.
+
+### Security Context
+Optional. Shared by both Firefly and Redis deployments. When not set, containers run as the default user defined in the image (e.g. `tomcat(91)` for Firefly).
+```yaml
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+```

--- a/helm/env/dev.yaml
+++ b/helm/env/dev.yaml
@@ -1,0 +1,7 @@
+replicaCount: 1
+
+resources:
+  requests:
+    memory: 1Gi
+  limits:
+    memory: 4Gi

--- a/helm/env/prod.yaml
+++ b/helm/env/prod.yaml
@@ -1,0 +1,7 @@
+replicaCount: 2
+
+resources:
+  requests:
+    memory: 4Gi
+  limits:
+    memory: 8Gi

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{- define "firefly.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "firefly.redisName" -}}
+{{- include "firefly.fullname" . }}-redis
+{{- end }}
+
+{{- define "firefly.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "firefly.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "firefly.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
               protocol: TCP
           env:
             {{- toYaml .Values.env | nindent 12 }}
+            {{- if .Values.ingress.pathPrefix }}
+            - name: PATH_PREFIX
+              value: {{ .Values.ingress.pathPrefix | quote }}
+            {{- end }}
             {{- if .Values.adminPassword.secretName }}
             - name: ADMIN_PASSWORD
               valueFrom:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "firefly.fullname" . }}
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "firefly.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "firefly.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "firefly.fullname" .) }}
+      {{- end }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          env:
+            {{- toYaml .Values.env | nindent 12 }}
+            {{- if .Values.adminPassword.secretName }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.adminPassword.secretName }}
+                  key: {{ .Values.adminPassword.secretKey }}
+            {{- else if .Values.adminPassword.value }}
+            - name: ADMIN_PASSWORD
+              value: {{ .Values.adminPassword.value | quote }}
+            {{- end }}
+            {{- if gt (int .Values.replicaCount) 1 }}
+            - name: PROPS_redis__host
+              value: {{ include "firefly.redisName" . }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: work-dir
+              mountPath: /firefly/workarea
+            - name: logs-dir
+              mountPath: /firefly/logs
+            - name: shared-work-dir
+              mountPath: /firefly/shared-workarea
+      volumes:
+        - name: work-dir
+          {{- if .Values.persistence.workDir.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.workDir.existingClaim }}
+          {{- else if .Values.persistence.workDir.pvc }}
+          persistentVolumeClaim:
+            claimName: {{ include "firefly.fullname" . }}-work
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: logs-dir
+          {{- if .Values.persistence.logsDir.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.logsDir.existingClaim }}
+          {{- else if .Values.persistence.logsDir.pvc }}
+          persistentVolumeClaim:
+            claimName: {{ include "firefly.fullname" . }}-logs
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: shared-work-dir
+          {{- if .Values.persistence.sharedWorkDir.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.sharedWorkDir.existingClaim }}
+          {{- else if .Values.persistence.sharedWorkDir.pvc }}
+          persistentVolumeClaim:
+            claimName: {{ include "firefly.fullname" . }}-shared-work
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -40,7 +40,7 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-          - path: /firefly
+          - path: {{ if .Values.ingress.pathPrefix }}/{{ trimPrefix "/" .Values.ingress.pathPrefix }}{{ end }}/firefly
             pathType: Prefix
             backend:
               service:

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.ingress.enabled }}
+{{- $affinityAnnotations := dict }}
+{{- if gt (int .Values.replicaCount) 1 }}
+  {{- if eq .Values.ingress.className "nginx" }}
+    {{- $affinityAnnotations = dict
+      "nginx.ingress.kubernetes.io/affinity" "cookie"
+      "nginx.ingress.kubernetes.io/affinity-mode" "persistent"
+      "nginx.ingress.kubernetes.io/session-cookie-change-on-failure" "true" }}
+  {{- else if eq .Values.ingress.className "traefik" }}
+    {{- $affinityAnnotations = dict
+      "traefik.ingress.kubernetes.io/service.sticky.cookie" "true" }}
+  {{- else if eq .Values.ingress.className "haproxy" }}
+    {{- $affinityAnnotations = dict
+      "haproxy.org/load-balance" "leastconn"
+      "haproxy.org/cookie-persistence" "SERVERID" }}
+  {{- end }}
+{{- end }}
+{{- $mergedAnnotations := merge .Values.ingress.annotations $affinityAnnotations }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "firefly.fullname" . }}
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+  {{- with $mergedAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tlsSecretName }}
+  tls:
+    - secretName: {{ .Values.ingress.tlsSecretName }}
+      hosts:
+        - {{ .Values.ingress.host }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /firefly
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "firefly.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.persistence.workDir.pvc (not .Values.persistence.workDir.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "firefly.fullname" . }}-work
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.workDir.pvc.accessMode | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.workDir.pvc.size }}
+  {{- if .Values.persistence.workDir.pvc.storageClass }}
+  storageClassName: {{ .Values.persistence.workDir.pvc.storageClass }}
+  {{- end }}
+---
+{{- end }}
+{{- if and .Values.persistence.logsDir.pvc (not .Values.persistence.logsDir.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "firefly.fullname" . }}-logs
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.logsDir.pvc.accessMode | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.logsDir.pvc.size }}
+  {{- if .Values.persistence.logsDir.pvc.storageClass }}
+  storageClassName: {{ .Values.persistence.logsDir.pvc.storageClass }}
+  {{- end }}
+{{- end }}
+{{- if and .Values.persistence.sharedWorkDir.pvc (not .Values.persistence.sharedWorkDir.existingClaim) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "firefly.fullname" . }}-shared-work
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.sharedWorkDir.pvc.accessMode | default "ReadWriteMany" }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.sharedWorkDir.pvc.size }}
+  {{- if .Values.persistence.sharedWorkDir.pvc.storageClass }}
+  storageClassName: {{ .Values.persistence.sharedWorkDir.pvc.storageClass }}
+  {{- end }}
+{{- end }}

--- a/helm/templates/redis.yaml
+++ b/helm/templates/redis.yaml
@@ -1,0 +1,78 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "firefly.redisName" . }}
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "firefly.redisName" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "firefly.redisName" . }}
+    spec:
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          ports:
+            - containerPort: {{ .Values.redis.port }}
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          command:
+            - redis-server
+          args:
+            - --maxmemory
+            - {{ .Values.redis.maxmemory | quote }}
+            - --save
+            - "600"
+            - "1"
+            - --appendonly
+            - "yes"
+            - --appendfilename
+            - {{ include "firefly.redisName" . }}.aof
+            - --dbfilename
+            - {{ include "firefly.redisName" . }}.rdb
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+              subPath: redis
+      volumes:
+        - name: redis-data
+          {{- if .Values.redis.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.redis.persistence.existingClaim }}
+          {{- else if .Values.persistence.sharedWorkDir.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.sharedWorkDir.existingClaim }}
+          {{- else if .Values.persistence.sharedWorkDir.pvc }}
+          persistentVolumeClaim:
+            claimName: {{ include "firefly.fullname" . }}-shared-work
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "firefly.redisName" . }}
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ include "firefly.redisName" . }}
+  ports:
+    - protocol: TCP
+      port: {{ .Values.redis.port }}
+      targetPort: {{ .Values.redis.port }}
+{{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "firefly.fullname" . }}
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- if eq .Values.service.sessionAffinity "ClientIP" }}
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: {{ .Values.service.sessionAffinityTimeout }}
+  {{- end }}
+  selector:
+    {{- include "firefly.selectorLabels" . | nindent 4 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ipac/firefly
+  repository: ghcr.io/caltech-ipac/firefly
   # tag: ""  # defaults to appVersion in Chart.yaml
   pullPolicy: IfNotPresent
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,6 +20,7 @@ ingress:
   # or extend them, or to set affinity manually when className is not set.
   annotations: {}
   host: my.example.com
+  pathPrefix: ""  # when set, prefixes the ingress path: /<pathPrefix>/firefly
   # tlsSecretName: my-tls  # when set, TLS is enabled
 
 livenessProbe:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,80 @@
+replicaCount: 1
+
+image:
+  repository: ipac/firefly
+  # tag: ""  # defaults to appVersion in Chart.yaml
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8080
+  sessionAffinity: ClientIP
+  sessionAffinityTimeout: 3600
+
+ingress:
+  enabled: true
+  # className: nginx  # omit to use the cluster's default ingress class
+  # When replicaCount > 1, cookie-based session affinity annotations are automatically
+  # added based on className (nginx, traefik, haproxy). Use annotations to override
+  # or extend them, or to set affinity manually when className is not set.
+  annotations: {}
+  host: my.example.com
+  # tlsSecretName: my-tls  # when set, TLS is enabled
+
+livenessProbe:
+  httpGet:
+    path: firefly/healthz
+    port: 8080
+  initialDelaySeconds: 120
+  periodSeconds: 60
+  timeoutSeconds: 10
+
+resources:
+  requests:
+    memory: 128Mi
+  limits:
+    memory: 512Mi
+
+env:
+  - name: CLEANUP_INTERVAL
+    value: "1h"
+
+# ADMIN_PASSWORD can be set as plain text or sourced from a secret.
+# Plain text:
+#   adminPassword:
+#     value: mypassword
+# From a secret:
+#   adminPassword:
+#     secretName: my-secret
+#     secretKey: password
+adminPassword: {}
+
+# Each persistence volume defaults to emptyDir.
+# Override per volume with either a new PVC or an existing one:
+#   pvc:
+#     size: 10Gi
+#     storageClass: standard
+#     accessMode: ReadWriteOnce  # use ReadWriteMany for sharedWorkDir
+#   existingClaim: my-existing-pvc
+persistence:
+  workDir: {}
+  logsDir: {}
+  sharedWorkDir: {}
+
+securityContext: {}
+
+redis:
+  image: redis:6.2
+  port: 6379
+  maxmemory: 256M
+  resources:
+    limits:
+      memory: 256Mi
+  persistence: {}
+    # existingClaim: my-redis-pvc
+    # If not set, falls back to sharedWorkDir PVC if configured, otherwise emptyDir.
+
+serviceAccount:
+  create: false
+  name: ""


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1966

## Summary
- Add Helm chart for deploying Firefly to Kubernetes
- Supports deployment, service, and ingress with session affinity
- Configurable persistence volumes (emptyDir, PVC, or existing PVC)
- Auto-deploys Redis and injects session affinity annotations when `replicaCount > 1`
- Publishes chart to GHCR (`ghcr.io/caltech-ipac/firefly-chart`) as part of the build/publish workflow
See [REAME](https://github.com/Caltech-IPAC/firefly/blob/FIREFLY-1966-add-helm-chart/helm/README.md) for details

**Notes**
The GHCR packages are currently private. You will need to authenticate to pull the image or chart. 
Login with:
helm registry login ghcr.io -u your-github-username
I will ask management to allow it to be public.