### PR TITLE
IRSA-7653: Fix precision handling for SizeInputField causing round-trip errors

### DIFF
--- a/src/firefly/js/ui/SizeInputField.jsx
+++ b/src/firefly/js/ui/SizeInputField.jsx
@@ -5,6 +5,7 @@
 
 import React, {useContext} from 'react';
 import PropTypes, {bool, object} from 'prop-types';
+import {memoize} from 'lodash';
 import toFloat from 'validator/es/lib/toFloat';
 import {convertAngle} from '../visualize/VisUtil.js';
 import {ConnectionCtx} from './ConnectionCtx.js';
@@ -12,8 +13,15 @@ import {toMaxFixed} from '../util/MathUtil.js';
 import {QuantityInputField} from 'firefly/ui/QuantityInputField';
 
 
-const DEC_DIGIT = 6;
+const MIN_ARCSEC = 0.001; // lowest size (in arcsec) we will ever represent
 const BASE_UNIT = 'deg';
+
+// Get the number of digits after decimal point needed to represent lowest arcsec value (`MIN_ARCSEC`) in the given unit.
+// Math.ceil(-log10(value)) gives digits needed to reach the first significant digit;
+// +3 retains 3 more digits beyond that (making 4 significant digits total).
+const getFracDigits = memoize((unit) =>
+    Math.ceil(Math.log10(convertAngle('arcsec', unit, MIN_ARCSEC, false)) * -1) + 3);
+
 export const ANGULAR_SIZE_UNITS = {
     [BASE_UNIT]: { name: 'degrees', symbol: '°' },
     'arcmin': { name: 'arcminutes', symbol: '\'' },
@@ -32,8 +40,8 @@ const convertSizeUnits = (valueStr, fromUnit=BASE_UNIT, toUnit=BASE_UNIT) => {
     if (valueStr===undefined || valueStr===null || valueStr==='') return '';
     const value = toFloat(valueStr+'');
     if (isNaN(value)) return valueStr; // preserve invalid input to let input validation will handle it
-    const newVal = convertAngle(fromUnit, toUnit, value.toString());
-    return toMaxFixed(newVal, DEC_DIGIT).toString();
+    const newVal = convertAngle(fromUnit, toUnit, value.toString(), false);
+    return toMaxFixed(newVal, getFracDigits(toUnit)).toString();
 };
 
 const formatSize = (valueInDeg, outputUnit) => `${convertSizeUnits(valueInDeg, BASE_UNIT, outputUnit)}${ANGULAR_SIZE_UNITS[outputUnit]?.symbol ?? ''}`;
@@ -54,6 +62,11 @@ export const SizeInputFields = (props) => {
     const connectContext= useContext(ConnectionCtx);
     const {value, displayValue, unit, ...restInitStateProps} = props?.initialState || {};
 
+    const {min: minProp, max: maxProp} = {...props, ...restInitStateProps};
+    const [min, max] = [minProp, maxProp].map(
+        (num) => toMaxFixed(num, getFracDigits(BASE_UNIT)) //so that bounds validation respect precision
+    );
+
     return (
         <QuantityInputField {...{
             label: `${sizeQuantityProps.quantityName}: `,
@@ -65,6 +78,7 @@ export const SizeInputFields = (props) => {
             // but other props might be nested in it, so destructure them out -- for backward compatibility
             initialState: {value, displayValue, unit},
             ...restInitStateProps,
+            min, max
         }} />);
 };
 

--- a/src/firefly/js/ui/WavelengthInputField.jsx
+++ b/src/firefly/js/ui/WavelengthInputField.jsx
@@ -6,6 +6,7 @@ import toFloat from 'validator/es/lib/toFloat';
 import {QuantityInputField} from 'firefly/ui/QuantityInputField';
 import {useFieldGroupValue} from 'firefly/ui/SimpleComponent';
 import {WAVELENGTH_UNITS} from 'firefly/visualize/VisUtil';
+import {toMaxFixed} from 'firefly/util/MathUtil';
 
 // following must be a key from the WAVELENGTH_UNITS object
 export const BASE_UNIT = 'um';
@@ -29,11 +30,8 @@ export const convertWvlUnits = (valueStr, fromUnit, toUnit) => {
     if (isNaN(value)) return valueStr;
     const newValue = convertWavelength(value, fromUnit, toUnit);
 
-    // to avoid floating-point rounding errors
-    let newValueStr = newValue.toFixed(getFracDigits(toUnit));
-    // remove leading 0s (if any)
-    newValueStr = parseFloat(newValueStr).toString();
-    return newValueStr;
+    // avoid floating-point inconsistencies by rounding to the max possible digits after decimal point for toUnit
+    return toMaxFixed(newValue, getFracDigits(toUnit)).toString();
 };
 
 const formatWvl = (baseValue, outputUnit) => `${convertWvlUnits(baseValue, BASE_UNIT, outputUnit)} ${WAVELENGTH_UNITS[outputUnit].symbol}`;

--- a/src/firefly/js/util/MathUtil.js
+++ b/src/firefly/js/util/MathUtil.js
@@ -20,8 +20,19 @@ export function getDecimalPlaces(range, numSigDigits) {
     return numDecPlaces;
 }
 
-/*
- * remove trailing zero from toFixed result
+
+/**
+ * Formats a number to at most `digits` decimal places by rounding.
+ * Unlike `toFixed`, the result is a number (not a string) and has no unnecessary trailing zeros.
+ *
+ * @param {number|string} floatNum - The number to format.
+ * @param {number} digits - Maximum number of decimal places to keep.
+ * @returns {number} The formatted number with at most `digits` decimal places.
+ *
+ * @example
+ * toMaxFixed(3.14159, 4) // 3.1416
+ * toMaxFixed(3.10000, 4) // 3.1
+ * toMaxFixed(3,       2) // 3
  */
 export function toMaxFixed(floatNum, digits) {
     return parseFloat(Number(floatNum).toFixed(digits));

--- a/src/firefly/js/visualize/VisUtil.js
+++ b/src/firefly/js/visualize/VisUtil.js
@@ -785,9 +785,12 @@ export function isAngleUnit(unit) {
  * @param {string} from 'degree' or 'deg', 'arcmin', 'arcsec', 'radian' case insensitive
  * @param {string} to 'degree' or 'deg', 'arcmin', 'arcsec', 'radian' case insensitive
  * @param {*} angle  number or string
+ * @param {boolean} limitPrecision limit the number of digits after decimal point for arcmin and arcsec units
+ * by truncation. Set it to false if you want full precision or want to handle precision in the caller function
+ * in another way (like rounding instead of truncation). Default is true.
  * @returns {number}
  */
-export function convertAngle(from, to, angle) {
+export function convertAngle(from, to, angle, limitPrecision=true) {
     const angleUnit = [['deg', 'degree'], 'arcmin', 'arcsec', ['radian', 'rad']];
     const rIdx = angleUnit.length-1;
     let fromIdx, toIdx;
@@ -808,11 +811,13 @@ export function convertAngle(from, to, angle) {
             toIdx = 0;
         }
         const v=  numAngle * Math.pow(60.0, (toIdx - fromIdx));
+        if (!limitPrecision) return v;
+
         switch (to) {
             case 'arcsec':
-                return Math.trunc(1000*v)/1000;
+                return Math.trunc(1000*v)/1000; // limit to 3 decimal places by truncating extra digits
             case 'arcmin':
-                return Math.trunc(100000*v)/100000;
+                return Math.trunc(100000*v)/100000; // limit to 5 decimal places by truncating extra digits
             case 'degree':
                 return v;
         }


### PR DESCRIPTION
See IFE PR: https://github.com/IPAC-SW/irsa-ife/pull/461

- Unlike WavelengthInputField, SizeInputField wasn't calculating precision (number of digits after decimal) based on each unit. Fixed it.
- Also added precision based rounding to min and max bounds to prevent errors in bound validation due to floating point comparison (esp when arcsec is converted to base unit degree and then compared)

