### PR TITLE
Firefly-1974: support Rubin v2 mask header format

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/RelatedData.java
@@ -9,7 +9,9 @@ import edu.caltech.ipac.firefly.visualize.RequestType;
 import edu.caltech.ipac.firefly.visualize.WebPlotRequest;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -32,7 +34,7 @@ public class RelatedData implements Serializable, HasSizeOf {
     private final String desc;
     /** related dataKey should be a unique string for a fits file */
     private Map<String,String> searchParams= new HashMap<>();
-    private Map<String,String> availableMask= new HashMap<>();
+    private List<MaskEntry> availableMask= new ArrayList<>();
     private int primaryHduIdx =0;
     private boolean parallelCubePlane = false;
     private String hduName= null;
@@ -59,7 +61,7 @@ public class RelatedData implements Serializable, HasSizeOf {
      * @param dataKey - should be a unique string for a fits file
      * @return RelatedData
      */
-    public static RelatedData makeMaskRelatedData(int primaryHduIdx, String fileName, Map<String,String> availableMask, boolean parallelCubePlane, int extensionNumber, String dataKey) {
+    public static RelatedData makeMaskRelatedData(int primaryHduIdx, String fileName, List<MaskEntry> availableMask, boolean parallelCubePlane, int extensionNumber, String dataKey) {
         Map<String,String> searchParams= new HashMap<>();
         searchParams.put(WebPlotRequest.FILE, fileName);
         searchParams.put(WebPlotRequest.PLOT_AS_MASK, "true");
@@ -75,7 +77,7 @@ public class RelatedData implements Serializable, HasSizeOf {
      * @param dataKey - should be a unique string for a fits file
      * @return RelatedData
      */
-    public static RelatedData makeMaskRelatedData(int primaryHduIdx, Map<String,String> searchParams, Map<String,String> availableMask, boolean parallelCubePlane, String dataKey) {
+    public static RelatedData makeMaskRelatedData(int primaryHduIdx, Map<String,String> searchParams, List<MaskEntry> availableMask, boolean parallelCubePlane, String dataKey) {
         RelatedData d= new RelatedData(IMAGE_MASK, dataKey, "Mask");
         d.availableMask= availableMask;
         d.searchParams= searchParams;
@@ -145,18 +147,21 @@ public class RelatedData implements Serializable, HasSizeOf {
         if (size==0) {
             size= dataType.length()+ dataKey.length()+ desc.length() + 8;
             if (hduName!=null) size+= hduName.length();
-            size+= Stream.of(searchParams, availableMask)
+            size+= Stream.of(searchParams)
                     .map( m -> m.entrySet().stream()
                             .map( e -> (long)(e.getKey().length()+e.getValue().length()))
                             .reduce(0L, Long::sum))
                     .reduce(0L, Long::sum);
+            size+= availableMask.stream()
+                    .map( m -> m.name.length() + m.desc().length() + 4)
+                    .reduce(0, Integer::sum);
         }
         return size;
     }
 
     public String getDataType() { return dataType;}
     public String getDataKey() { return dataKey;}
-    public Map<String,String> getAvailableMask() { return availableMask;}
+    public List<MaskEntry> getAvailableMask() { return availableMask;}
     public String getDesc() { return desc;}
     public Map<String,String> getSearchParams() { return searchParams;}
     public String getHduName() { return hduName;}
@@ -165,5 +170,7 @@ public class RelatedData implements Serializable, HasSizeOf {
     public int getHduIdx() { return hduIdx;}
     public int getPrimaryHduIdx() { return primaryHduIdx;}
     public boolean isParallelCubePlane() { return parallelCubePlane;}
+
+    public record MaskEntry(String name, int bit, String desc) {}
 }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisJsonSerializer.java
@@ -288,7 +288,15 @@ public class VisJsonSerializer {
         JSONObject retObj= new JSONObject();
         putStr(retObj,"dataType", rData.getDataType());
         if (!rData.getAvailableMask().isEmpty()) {
-            putJsonObj(retObj, "availableMask", new JSONObject(rData.getAvailableMask()));
+            JSONArray array= new JSONArray();
+            for(var me : rData.getAvailableMask()) {
+                JSONObject meJ= new JSONObject();
+                putStr(meJ, "name", me.name());
+                putNum(meJ, "bit", me.bit());
+                putStr(meJ, "desc", me.desc());
+                array.add(meJ);
+            }
+            retObj.put("availableMask", array);
         }
         putJsonObj(retObj, "searchParams", new JSONObject(rData.getSearchParams()));
         putStr(retObj, "desc", rData.getDesc());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/MaskEval.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/fitseval/MaskEval.java
@@ -16,9 +16,9 @@ import nom.tam.util.Cursor;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+
+import static edu.caltech.ipac.firefly.core.Util.Try;
 
 /**
  * @author Trey Roby
@@ -68,20 +68,61 @@ class MaskEval implements FitsEvaluation.Eval {
         }
     }
 
-    private static Map<String, String> getMaskHeaders(Header header) {
-        Map<String, String> maskHeaders = new HashMap<>(23);
-        HeaderCard hc;
+    private static List<RelatedData.MaskEntry> getMaskHeaders(Header header) {
+        Cursor<String, HeaderCard> extraIter = header.iterator();
+
+        boolean foundV1Style= false;
+        while (extraIter.hasNext() && !foundV1Style) {
+            var key = extraIter.next().getKey();
+            foundV1Style= (key.startsWith("MP") || key.startsWith("HIERARCH.MP")) ;
+        }
+        return foundV1Style ? getMaskHeadersV1(header) : getMaskHeadersV2(header);
+    }
+    
+    private static List<RelatedData.MaskEntry> getMaskHeadersV1(Header header) {
+        var maskEntries= new ArrayList<RelatedData.MaskEntry>();
         Cursor<String, HeaderCard> extraIter = header.iterator();
         while (extraIter.hasNext()) {
-            hc = extraIter.next();
+            var hc = extraIter.next();
             if (hc.getKey().startsWith("MP") || hc.getKey().startsWith("HIERARCH.MP")) {
-                maskHeaders.put(hc.getKey(), hc.getValue());
+                var v= Try.it(() -> Integer.parseInt(hc.getValue())).getOrElse(-1);
+                if (v>-1) maskEntries.add(new RelatedData.MaskEntry(hc.getKey(), v, ""));
             }
         }
-        return maskHeaders;
+        return maskEntries;
     }
 
-     public boolean isMask(FitsRead maskFr, FitsRead baseFr) {
+    private static List<RelatedData.MaskEntry> getMaskHeadersV2(Header header) {
+        var maskEntries= new ArrayList<RelatedData.MaskEntry>();
+        Cursor<String, HeaderCard> extraIter = header.iterator();
+        while (extraIter.hasNext()) {
+            var cnt= getMaskNameCnt(extraIter.next().getKey());
+            if (cnt!=null)  {
+                RelatedData.MaskEntry me= makeMaskEntry(header,cnt);
+                if (me!=null) maskEntries.add(me);
+            }
+        }
+        return maskEntries;
+    }
+
+    public static String getMaskNameCnt(String name) {
+        if (name==null) return null;
+        if (!name.startsWith("MSKN")) return null;
+        var valPartStr=  name.substring("MSKN".length());
+        var v= Try.it(() -> Integer.parseInt(valPartStr)).getOrElse(-1);
+        return v>-1 ? valPartStr : null;
+    }
+
+    public static RelatedData.MaskEntry makeMaskEntry(Header header, String cntStr) {
+        var name= header.getStringValue("MSKN"+cntStr);
+        int v= header.getIntValue("MSKM"+cntStr,-1);
+        var desc= header.getStringValue("MSKD"+cntStr,"");
+        if (v==-1 || name==null) return null;
+        return new RelatedData.MaskEntry(name,Integer.numberOfTrailingZeros(v),desc);
+    }
+
+
+    public boolean isMask(FitsRead maskFr, FitsRead baseFr) {
         boolean isCube= baseFr.isCube();
         int cubePlaneNumber=  baseFr.getPlaneNumber();
         if (!isCube && maskFr.isCube() && maskFr.getPlaneNumber()>0) return false;

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -46,6 +46,9 @@ public class FitsReadUtil {
     public static final String SPOT_OFF = "SPOT_OFF";
     public static final String SPOT_BP = "SPOT_BP"; // original bitpix
     public static final String SPOT_PL = "SPOT_PL"; // cube plane number, only used with cubes, deprecated
+    public static final String EXTNAME= "EXTNAME";
+    public static final String EXTTYPE= "EXTTYPE";
+    private static final String RESTORE_COMMENT= "restored after uncompression by Firefly";
 
     public static ImageData getImageData(BasicHDU<?> refHdu, float[] float1d) {
         Header h = refHdu.getHeader();
@@ -96,6 +99,31 @@ public class FitsReadUtil {
 
     public static UncompressFitsInfo createdUncompressVersionOfFile(BasicHDU<?>[] HDUs, File originalFile)
             throws IOException {
+        Fits fits= new Fits();
+        for (BasicHDU<?> hdu : HDUs) {
+            if (hdu instanceof CompressedImageHDU cHDU) {
+                Header header = hdu.getHeader();
+                String extName=  getExtName(header);
+                String extType=  getExtType(header,null);
+                ImageHDU iHDU= cHDU.asImageHDU();
+                var h= iHDU.getHeader();
+                if (getExtName(h)==null && extName!=null) h.addValue(EXTNAME,extName, RESTORE_COMMENT);
+                if (getExtType(h,null)==null && extType!=null) h.addValue(EXTTYPE,extType, RESTORE_COMMENT);
+                fits.addHDU(iHDU);
+            }
+            else {
+                fits.addHDU(hdu);
+            }
+        }
+        File retFile= getUncompressedFileName(originalFile,HDUs);
+        fits.write(retFile);
+        closeFits(fits);
+        Fits retReadFits= new Fits(retFile);
+        BasicHDU<?>[] inHDUs= retReadFits.read();
+        return new UncompressFitsInfo(retFile,inHDUs, retReadFits);
+    }
+
+    private static File getUncompressedFileName(File originalFile, BasicHDU<?>[] HDUs) {
         String fBase= FileUtil.getBase(originalFile);
         String dir= originalFile.getParent();
         var compressType= FileUtil.isGZipFile(originalFile)
@@ -104,16 +132,7 @@ public class FitsReadUtil {
                 ? "---bz2"
                 : "";
         var hduType=  FitsReadUtil.hasCompressedImageHDUS(HDUs) ? "---hdu" : "";
-        File retFile= new File(dir+"/"+ fBase+compressType+hduType+"-uncompressed"+".fits");
-        Fits fits= new Fits();
-        for (BasicHDU<?> hdu : HDUs) {
-            fits.addHDU( hdu instanceof CompressedImageHDU ?  ((CompressedImageHDU) hdu).asImageHDU() : hdu );
-        }
-        fits.write(retFile);
-        closeFits(fits);
-        Fits retReadFits= new Fits(retFile);
-        BasicHDU<?>[] inHDUs= retReadFits.read();
-        return new UncompressFitsInfo(retFile,inHDUs, retReadFits);
+        return new File(dir+"/"+ fBase+compressType+hduType+"-uncompressed"+".fits");
     }
 
     public static BasicHDU<?>[] getCubeExpandedImageHDUArray(BasicHDU<?>[] HDUs, boolean onlyFireCubeHdu, List<Long> headersSizesList, List<Long> headersOffsetsList) {
@@ -400,8 +419,8 @@ public class FitsReadUtil {
     }
 
     public static String getBUnit(Header h) { return h.getStringValue("BUNIT", ""); }
-    public static String getExtName(Header h) { return h.getStringValue("EXTNAME"); }
-    public static String getExtType(Header h, String defVal) { return h.getStringValue("EXTTYPE",defVal); }
+    public static String getExtName(Header h) { return h.getStringValue(EXTNAME); }
+    public static String getExtType(Header h, String defVal) { return h.getStringValue(EXTTYPE,defVal); }
     public static String getUtype(Header h) { return h.getStringValue("UTYPE"); }
     public static String getExtNameOrType(Header h) { return getExtName(h)!=null ? getExtName(h) : getExtType(h,null);}
     public static String getExtTypeOrName(Header h) { return getExtType(h,null)!=null ? getExtType(h,null) : getExtName(h);}

--- a/src/firefly/js/visualize/ImagePlotCntlr.js
+++ b/src/firefly/js/visualize/ImagePlotCntlr.js
@@ -802,6 +802,7 @@ export function dispatchChangeHiPS({ plotId, hipsUrlRoot, coordSys, centerProjPt
  * @param {string} p.fileKey file on the server
  * @param {string} p.color - color is optional, if not specified, one is chosen
  * @param {string} p.title
+ * @param {string} p.description - a more detailed description of the layer
  * @param {string} p.lazyLoad
  * @param {string} p.uiCanAugmentTitle
  * @param {string} [p.relatedDataId] pass a related data id if one exist
@@ -813,11 +814,11 @@ export function dispatchChangeHiPS({ plotId, hipsUrlRoot, coordSys, centerProjPt
  */
 export function dispatchPlotMask({plotId,imageOverlayId, maskValue, fileKey,
                                   hduNumber, maskNumber=-1, color, title,
-                                  uiCanAugmentTitle,
+                                  uiCanAugmentTitle, description,
                                   relatedDataId, lazyLoad, dispatcher= flux.process}) {
 
     dispatcher( { type: PLOT_MASK, payload: { plotId,imageOverlayId, fileKey, maskValue,
-                                              uiCanAugmentTitle, hduNumber, maskNumber,
+                                              uiCanAugmentTitle, hduNumber, maskNumber, description,
                                               color, title, relatedDataId, lazyLoad } });
 }
 

--- a/src/firefly/js/visualize/RelatedDataUtil.js
+++ b/src/firefly/js/visualize/RelatedDataUtil.js
@@ -2,7 +2,7 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {isEmpty, difference,get, flatten, values, uniq} from 'lodash';
+import {isEmpty, get, flatten, values, uniq} from 'lodash';
 import { primePlot, getPlotViewIdListInOverlayGroup, getPlotViewById, operateOnOthersInOverlayColorGroup} from './PlotViewUtil.js';
 import {WPConst} from './WebPlotRequest.js';
 import {RDConst} from './WebPlot.js';
@@ -70,19 +70,18 @@ function unactivatedDataTypeMatches(r,idx, pv) {
     if (dataType===RDConst.IMAGE_MASK) {
         const opvAry= pv.overlayPlotViews.filter((opv) => opv.relatedDataId===r.relatedDataId);
         if (!opvAry.length) return true;
-        const maskNumberAry= values(r.availableMask);
 
         const maskDataWidth= opvAry.find( (opv) => opv?.plot?.dataWidth)?.plot?.dataWidth;
         const maskDataHeight= opvAry.find( (opv) => opv?.plot?.dataHeight)?.plot?.dataHeight;
 
         if (maskDataHeight && maskDataHeight) {
-            if (maskNumberAry.length!==opvAry.length ||
+            if (r.availableMask.length!==opvAry.length ||
                 maskDataWidth !== primePlot(pv)?.dataWidth ||
                 maskDataHeight !== primePlot(pv)?.dataHeight) {
                 return true;
             }
         }
-        else if (maskNumberAry.length!==opvAry.length) {
+        else if (r.availableMask.length!==opvAry.length) {
             return true;
         }
     }
@@ -165,49 +164,44 @@ function enableRelatedDataLayerMask(pv, relatedData) {
     const fileKey= relatedData.searchParams[WPConst.FILE];
 
 
-    const availMaskValues= values(relatedData.availableMask).map( (v) => Number(v));
-
-    availMaskValues
-        .sort( (v1,v2) => v1-v2)
-        .forEach(  (v) =>
-            {
-                addMaskLayer(pv, v, hduNumber, fileKey, relatedData);
-            }
-        );
-
-
+    relatedData.availableMask
+        .sort( (me1,me2) => me1.bit-me2.bit)
+        .forEach(  (me) => addMaskLayer(pv, me, hduNumber, fileKey, relatedData) );
 }
 
 const maskIdRoot= 'AUTO_LOADED_MASK';
 let maskCnt= 0;
 
-function addMaskLayer(pv, maskNumber, hduNumber, fileKey, relatedData) {
+function addMaskLayer(pv, maskEntry, hduNumber, fileKey, relatedData) {
 
     const {relatedDataId}= relatedData;
 
-    const title= makeMaskTitle(maskNumber, relatedData.availableMask);
+    const title= makeMaskTitle(maskEntry);
 
-    dispatchPlotMask({plotId:pv.plotId,
-        imageOverlayId:`${pv.plotId}-${maskIdRoot}_#${maskNumber}_${maskCnt}`,
-        fileKey, maskNumber, maskValue:Math.pow(2,Number(maskNumber)),
-        uiCanAugmentTitle:false, hduNumber, title,
-        relatedDataId, lazyLoad:true});
+    dispatchPlotMask({
+        plotId:pv.plotId,
+        imageOverlayId:`${pv.plotId}-${maskIdRoot}_#${maskEntry.bit}_${maskCnt}`,
+        fileKey,
+        maskNumber:maskEntry.bit,
+        maskValue:Math.pow(2,Number(maskEntry.bit)),
+        uiCanAugmentTitle:false,
+        hduNumber,
+        title,
+        description:maskEntry.desc,
+        relatedDataId,
+        lazyLoad:true
+    });
     maskCnt++;
 }
 
-function makeMaskTitle(maskNumber, availableMask) {
-    const titleRoot= 'bit # '+maskNumber;
-    let maskDesc= Object.keys(availableMask)
-        .filter( (k) => k.includes('MP'))
-        .find( (k) => parseInt(availableMask[k])===maskNumber);
-    if (maskDesc) {
-        if (maskDesc.startsWith('HIERARCH')) maskDesc= maskDesc.substring(9);
-        if (maskDesc.startsWith('MP_')) maskDesc= maskDesc.substring(3);
-        return `${titleRoot} - ${maskDesc}`;
-    }
-    else {
-        return titleRoot;
-    }
+function makeMaskTitle(maskEntry) {
+    const {name='',bit=-1,desc=''}= maskEntry;
+    let maskName;
+    const titleRoot= 'bit # '+bit;
+    if (maskEntry.desc.startsWith('HIERARCH')) maskName= name.substring(9);
+    else if (maskEntry.desc.startsWith('MP_')) maskName= name.substring(3);
+    else maskName= name;
+    return `${titleRoot} - ${maskName}`;
 }
 
 function enableRelatedDataLayerImageOverlay(pv, relatedData) { // eslint-disable-line no-unused-vars

--- a/src/firefly/js/visualize/WebPlot.js
+++ b/src/firefly/js/visualize/WebPlot.js
@@ -114,8 +114,15 @@ export const RDConst= {
  * @prop {string} dataType - one of 'IMAGE_OVERLAY', 'IMAGE_MASK', 'TABLE'
  * @prop {string} desc - user description of the data
  * @prop {Object.<string, string>} searchParams - map of search parameters to get the related data
- * @prop {Object.<string, string>} availableMask - only used for masks- key is the bit number, value is the description
+ * @prop {Array.<MaskEntry>} availableMask - only used for masks- key is the bit number, value is the description
  *
+ */
+
+/**
+ * @typedef {Object} MaskEntry
+ * @prop {String} name
+ * @prop {Number} bit
+ * @prop {String} desc
  */
 
 

--- a/src/firefly/js/visualize/reducer/HandlePlotCreation.js
+++ b/src/firefly/js/visualize/reducer/HandlePlotCreation.js
@@ -250,7 +250,7 @@ function updateForWcsMatching(visRoot, pv, mpwWcsPrimId) {
 
 
 function newOverlayPrep(state, action) {
-    const {plotId, imageOverlayId, hduNumber, maskValue, maskNumber,
+    const {plotId, imageOverlayId, hduNumber, maskValue, maskNumber, description,
            color, title, drawingDef, relatedDataId,lazyLoadPayload, fileKey}= action.payload;
 
     const pv= getPlotViewById(state, plotId);
@@ -264,6 +264,7 @@ function newOverlayPrep(state, action) {
         opv= makeOverlayPlotView(imageOverlayId, plotId, title, hduNumber,
                                            maskNumber, maskValue, color, drawingDef, relatedDataId,
                                            fileKey);
+        opv.description= description;
         if (lazyLoadPayload) {
             opv.lazyLoadPayload= lazyLoadPayload;
             opv.visible= false;

--- a/src/firefly/js/visualize/task/ImageOverlayTask.js
+++ b/src/firefly/js/visualize/task/ImageOverlayTask.js
@@ -47,24 +47,14 @@ export function plotImageMaskActionCreator(rawAction) {
     return (dispatcher,getStore) => {
         var vr= getStore()[IMAGE_PLOT_KEY];
 
-        const {plotId, imageOverlayId, maskValue, hduNumber, title, fileKey,
+        const {plotId, imageOverlayId, maskValue, hduNumber, title, fileKey,description,
                uiCanAugmentTitle= true, maskNumber, relatedDataId, lazyLoad}= rawAction.payload;
         let {color}= rawAction.payload;
         if (!color) color= colorList[maskNumber % colorList.length];
 
-
-
         const payload= {
-            fileKey,
-            plotId,
-            maskValue,
-            maskNumber,
-            hduNumber,
-            color,
-            title,
-            imageOverlayId,
-            uiCanAugmentTitle,
-            relatedDataId,
+            fileKey, plotId, maskValue, maskNumber, hduNumber, color, title,
+            imageOverlayId, uiCanAugmentTitle, relatedDataId, description,
             requestKey: makeUniqueRequestKey('overlay')
         };
 

--- a/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
@@ -154,7 +154,7 @@ function makeImageLayerItemAry(pv, maxTitleChars, hasLast, mouseOverMaskValue) {
     const retAry= pv.overlayPlotViews.map( (opv,idx) => (
         <DrawLayerItemView key={'MaskControl-'+idx}
                            maxTitleChars={maxTitleChars}
-                           helpLine={''}
+                           helpLine={opv.description ?? ''}
                            lastItem={hasLast ? idx===last : false}
                            canUserDelete={true}
                            canUserChangeColor={true}

--- a/src/firefly/test/edu/caltech/ipac/util/serialization/SerializerTest.java
+++ b/src/firefly/test/edu/caltech/ipac/util/serialization/SerializerTest.java
@@ -187,7 +187,10 @@ public class SerializerTest {
         fi.setSuffix("txt");
         fi.setHasAccess(true);
 
-        RelatedData rd = RelatedData.makeMaskRelatedData(111, "file.fits", Map.of("header", "value"), false, 2, "mask-data-key");
+        RelatedData rd = RelatedData.makeMaskRelatedData(111, "file.fits",
+                List.of(new RelatedData.MaskEntry("header",0,"the header"),
+                        new RelatedData.MaskEntry("value",1,"the value")),
+                false, 2, "mask-data-key");
         fi.addRelatedData(rd);
 
         HttpServiceInput si = new HttpServiceInput("http://example.com");


### PR DESCRIPTION
#### [Firefly-1974](https://jira.ipac.caltech.edu/browse/FIREFLY-1974): support rubin v2 mask header format

Support mask in the FITS header form
```
MSKN0001= 'BAD     '
MSKM0001=        1
MSKD0001= 'Bad pixel in the instrument, including bad amplifiers.'
MSKN0002= 'COSMIC_RAY'
MSKM0002=        2 
MSKD0002= 'A cosmic ray affected this pixel.'                             
etc
```

#### Testing
- https://fireflydev.ipac.caltech.edu/firefly-1974-mask/firefly
- using the upload panel try both old and new FITS 
  - http://web.ipac.caltech.edu/staff/roby/mask/NEW_MASK_future_visit_image.fits
  - http://web.ipac.caltech.edu/staff/roby/mask/calexp_HSC_i_HSC-I_1228_0_38_HSC_runs_RC2_w_2021_14_DM-29519_sfm.fits

#### How to show mask
 - upload the image from the url and then choose only the first HDU, the choose load image
 - go to the drawing layers and click enable to show the mask layers
 - enable some or all of the layers
 - The new mask format allows for a description of the mask that will show up in the layer