### PR TITLE
FIREFLY-1964: Alert Viewer UI Updates and add URL API support

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/AlertAnalyzer.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/dpanalyze/AlertAnalyzer.java
@@ -24,6 +24,8 @@ public class AlertAnalyzer implements DataProductAnalyzer {
     private static final int REQUIRED_TABLE_COUNT = 2;
     private static final int REQUIRED_IMAGE_COUNT = 3;
     private static final String TABLE_FROM_1D_PREFIX = "1D image, load as table, ";
+    private static final List<String> ORDERED_TABLE_EXT_NAMES = List.of("ALERT", "DIASOURCE");
+    private static final List<String> ORDERED_IMAGE_EXT_NAMES = List.of("SCIENCE", "TEMPLATE", "DIFFIM");
 
     @Override
     public FileAnalysisReport analyzeFits(FileAnalysisReport inputReport,
@@ -67,19 +69,20 @@ public class AlertAnalyzer implements DataProductAnalyzer {
 
         final List<Part> picked = new ArrayList<>(REQUIRED_TABLE_COUNT + REQUIRED_IMAGE_COUNT);
 
-        //table 1: main table/chart
-        Part mainTable = tableCandidates.get(0);
-        mainTable.setChartTableDefOption(showChart);
-        picked.add(mainTable);
+        List<Part> pickedTables = pickTableParts(tableCandidates, headerAry);
 
-        //table 2: details table
-        Part detailsTable = tableCandidates.get(1);
+        //table 1: details table
+        Part detailsTable = pickedTables.get(0);
         detailsTable.setChartTableDefOption(showTable);
         picked.add(detailsTable);
 
+        //table 2: main table/chart
+        Part mainTable = pickedTables.get(1);
+        mainTable.setChartTableDefOption(showChart);
+        picked.add(mainTable);
+
         //3 images
-        for (int i = 0; i < REQUIRED_IMAGE_COUNT; i++) {
-            Part img = imageCandidates.get(i);
+        for (Part img : pickImageParts(imageCandidates, headerAry)) {
             img.setChartTableDefOption(showImage);
             picked.add(img);
         }
@@ -161,6 +164,52 @@ public class AlertAnalyzer implements DataProductAnalyzer {
         return p;
     }
 
+    private static List<Part> pickTableParts(List<Part> tableCandidates, Header[] headerAry) {
+        List<Part> orderedParts = ORDERED_TABLE_EXT_NAMES.stream()
+                .map((extName) -> findPartByExtName(tableCandidates, headerAry, extName))
+                .toList();
+
+        if (orderedParts.stream().allMatch((part) -> part != null)) {
+            return orderedParts;
+        }
+
+        return new ArrayList<>(tableCandidates.subList(0, REQUIRED_TABLE_COUNT));
+    }
+
+    private static List<Part> pickImageParts(List<Part> imageCandidates, Header[] headerAry) {
+        List<Part> orderedParts = ORDERED_IMAGE_EXT_NAMES.stream()
+                .map((extName) -> findPartByExtName(imageCandidates, headerAry, extName))
+                .toList();
+
+        if (orderedParts.stream().allMatch((part) -> part != null)) {
+            return orderedParts;
+        }
+
+        return new ArrayList<>(imageCandidates.subList(0, REQUIRED_IMAGE_COUNT));
+    }
+
+    private static Part findPartByExtName(List<Part> parts, Header[] headerAry, String targetExtName) {
+        for (Part part : parts) {
+            if (targetExtName.equals(getExtName(part, headerAry))) {
+                return part;
+            }
+        }
+        return null;
+    }
+
+    private static String getExtName(Part part, Header[] headerAry) {
+        if (part == null || headerAry == null || headerAry.length == 0) return "";
+
+        int hduIdx = getHduIndex(part);
+        if (hduIdx < 0 || hduIdx >= headerAry.length) return "";
+
+        Header h = headerAry[hduIdx];
+        if (h == null) return "";
+
+        String extName = h.getStringValue("EXTNAME");
+        return extName == null ? "" : extName.trim().toUpperCase();
+    }
+
     private static FileAnalysisReport makeErrorReport(FileAnalysisReport inputReport,
                                                       String analyzerId,
                                                       String msg) {
@@ -173,6 +222,4 @@ public class AlertAnalyzer implements DataProductAnalyzer {
         return out;
     }
 }
-
-
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/alert/AlertViewerSearchProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/alert/AlertViewerSearchProcessor.java
@@ -14,11 +14,13 @@ import edu.caltech.ipac.firefly.server.query.ParamDoc;
 import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
 import edu.caltech.ipac.firefly.server.util.LockingRetrieve;
 import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.StringUtils;
-import edu.caltech.ipac.util.download.UriRef;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
@@ -26,7 +28,7 @@ import static edu.caltech.ipac.firefly.core.FileAnalysisReport.ReportType.Detail
 import static edu.caltech.ipac.firefly.core.FileAnalysisReport.Type.ErrorResponse;
 
 @SearchProcessorImpl(id = "AlertViewerSearchProcessor", params = {
-        @ParamDoc(name = "source", desc = "A FITS URL or an Alert ID.")
+        @ParamDoc(name = "source", desc = "An alert ID.")
 })
 public class AlertViewerSearchProcessor extends JsonStringProcessor {
 
@@ -35,6 +37,10 @@ public class AlertViewerSearchProcessor extends JsonStringProcessor {
     public static final String ID = "AlertViewerSearchProcessor";
     public static final String SOURCE = "source";
     private static final String ANALYZER_ID = "alert";
+    private static final String ALERT_ID = "ID";
+    public static final String RESPONSEFORMAT = "RESPONSEFORMAT";
+    private static final String FITS_RESPONSE_FORMAT = "fits";
+    private static final String ALERT_SERVICE_BASE_URL_PROP = "alert.viewer.fits.service.url";
 
     @Override
     public boolean doCache() {
@@ -46,32 +52,37 @@ public class AlertViewerSearchProcessor extends JsonStringProcessor {
         final String source = req.getParam(SOURCE) == null ? null : req.getParam(SOURCE).trim();
 
         if (StringUtils.isEmpty(source)) {
-            return makeError(source, "A FITS URL is required.");
+            return makeError(source, "An alert ID is required.");
         }
 
-        if (!UriRef.isValid(source)) {
-            return makeError(source, "Alert ID lookup is not supported yet. Please enter a full FITS URL.");
+        if (source.contains("://")) {
+            return makeError(source, "Please enter an alert ID, URLs are not supported.");
         }
 
         try {
-            /*todo: future AlertID logic (if source is just an alert ID) and if the service returns FITS directly:
-               //makeAlertServiceUrl would construct a URL to an alert service that returns the FITS file for a given alert ID
-               URL serviceUrl = new URL(makeAlertServiceUrl(alertId));
-               File tmpFits = File.createTempFile("alert-", ".fits");
-               FileInfo fileInfo = URLDownload.getDataToFile(serviceUrl, tmpFits);
-              */
-            FileInfo fileInfo = LockingRetrieve.downloadWithCacheMsg(source);
+            final String serviceUrl = makeAlertServiceUrl(source);
+            FileInfo fileInfo = LockingRetrieve.downloadWithCacheMsg(serviceUrl);
             if (fileInfo == null) {
-                return makeError(source, "Unable to retrieve the FITS file.");
+                return makeError(source, "Unable to retrieve the FITS file for alert ID: " + source);
             }
             final int responseCode = fileInfo.getResponseCode();
             if (responseCode > 305 || responseCode < 200) {
-                final String responseMsg = StringUtils.isEmpty(fileInfo.getResponseCodeMsg())
+                String responseMsg = StringUtils.isEmpty(fileInfo.getResponseCodeMsg())
                         ? "Unknown error"
                         : fileInfo.getResponseCodeMsg();
-                return makeError(source,
-                        "Unable to retrieve the FITS file: " + responseCode + " " + responseMsg);
+
+                String message = switch (responseCode) {
+                    case 400 -> "400 Bad Request: unknown query parameter, or malformed alert ID";
+                    case 401 -> "401 Unauthorized: missing or invalid token";
+                    case 404 -> "404 Not Found: no alert exists for the given ID";
+                    case 415 -> "415 Unsupported Media Type: unrecognised RESPONSEFORMAT value";
+                    case 500 -> "500 Internal Server Error: alert service internal error.";
+                    default -> "Unable to retrieve the FITS file: " + responseCode + " " + responseMsg;
+                };
+
+                return makeError(source, message);
             }
+
 
             FileAnalysisReport report = FileAnalysis.analyze(fileInfo, Details, ANALYZER_ID, Collections.emptyMap());
             return makeSuccess(source, fileInfo, report);
@@ -159,6 +170,18 @@ public class AlertViewerSearchProcessor extends JsonStringProcessor {
 
     private static String makeError(String source, String message) {
         return baseResponse(source, false, message).toJSONString();
+    }
+
+    private static String makeAlertServiceUrl(String alertId) throws DataAccessException {
+        final String baseUrl = AppProperties.getProperty(ALERT_SERVICE_BASE_URL_PROP,
+                "https://data-int.lsst.cloud/api/alerts");
+        if (StringUtils.isEmpty(baseUrl)) {
+            throw new DataAccessException("Missing required property: " + ALERT_SERVICE_BASE_URL_PROP);
+        }
+        final String joiner = baseUrl.contains("?") ? "&" : "?";
+        return String.format("%s%s%s=%s&%s=%s",
+                baseUrl, joiner, ALERT_ID, URLEncoder.encode(alertId, StandardCharsets.UTF_8),
+                RESPONSEFORMAT, FITS_RESPONSE_FORMAT);
     }
 
     private static JSONObject baseResponse(String source, boolean success, String message) {

--- a/src/firefly/js/api/webApiCommands/AlertViewerCommands.js
+++ b/src/firefly/js/api/webApiCommands/AlertViewerCommands.js
@@ -1,0 +1,41 @@
+import {makeExamples} from '../WebApi.js';
+import {dispatchShowDropDown} from '../../core/LayoutCntlr.js';
+
+const alertViewerOverview = {
+    overview: [
+        'Open Alert Viewer and load an alert by alert id.'
+    ],
+    parameters: {
+        id: {desc: 'Alert id to load into Alert Viewer', isRequired: true},
+    },
+};
+
+const alertViewerExamples = [
+    {
+        desc: 'Open Alert Viewer and load an alert by id',
+        params: {
+            id: '170059278837088375'
+        }
+    },
+];
+
+function validateAlertViewer() {
+    return {valid: true};
+}
+
+function showAlertViewer(cmd, params) {
+    const {id} = params;
+    dispatchShowDropDown({view: 'AlertUpload', initArgs: {urlApi: {id}}});
+}
+
+export function getAlertViewerCommands() {
+    return [
+        {
+            cmd: 'alert',
+            validate: validateAlertViewer,
+            execute: showAlertViewer,
+            ...alertViewerOverview,
+            examples: makeExamples('alert', alertViewerExamples),
+        },
+    ];
+}

--- a/src/firefly/js/apps/alertviewer/AlertIDDialog.jsx
+++ b/src/firefly/js/apps/alertviewer/AlertIDDialog.jsx
@@ -57,7 +57,7 @@ function AlertIdPanel({currId, onChange}) {
                 <ValidationField
                     groupKey={GROUP_KEY}
                     fieldKey={ID_KEY}
-                    label='Enter Alert URL or ID'
+                    label='Enter Alert ID'
                     initialState={{value:''}}
                     onKeyPress={(ev, v) => {
                         if (ev.key === 'Enter') handleSuccess(v, onChange, true);

--- a/src/firefly/js/apps/alertviewer/AlertIDs.js
+++ b/src/firefly/js/apps/alertviewer/AlertIDs.js
@@ -1,6 +1,7 @@
 const MAX_ROW = Math.pow(2, 31) - 1;
 
 export const ALERT = {
+    STATE_ID: 'ALERT_VIEWER_STATE',
     TABLE_GROUP_MAIN: 'main',
     TABLE_GROUP_DETAILS: 'details',
 

--- a/src/firefly/js/apps/alertviewer/AlertResultView.jsx
+++ b/src/firefly/js/apps/alertviewer/AlertResultView.jsx
@@ -19,6 +19,7 @@ import {dispatchChartAdd, getChartData} from 'firefly/charts/ChartsCntlr.js';
 import {MultiViewStandardToolbar} from 'firefly/visualize/ui/MultiViewStandardToolbar';
 import {getDefaultChartProps} from 'firefly/charts/ChartUtil';
 import DockLayoutPanel from 'firefly/ui/panel/DockLayoutPanel.jsx';
+import {getComponentState} from 'firefly/core/ComponentCntlr';
 
 const ALERT_STANDARD_LAYOUT = {
     east: {index: 0, defaultSize: '50%'},
@@ -84,23 +85,29 @@ export function AlertResultView() {
     };
 
     const {hasMainTable, hasDetailTable, hasImages} = useStoreConnector(getAlertData);
+    const {id, source, fileName} = useStoreConnector(() => getComponentState(ALERT.STATE_ID));
+    const fallbackTitle = fileName || source || 'Alert Viewer';
+    const alertTitleDisplay = id ? (
+        <Stack direction='row' spacing={1}>
+            <Typography level='title-md'>
+                Alert ID:
+            </Typography>
+            <Typography level='body-md'>
+                {id}
+            </Typography>
+        </Stack>
+    ) : (
+        <Typography level='title-md'>
+            {fallbackTitle}
+        </Typography>
+    );
 
     const standardPanels = [
-        hasMainTable ? (
-            <MultiProductChoice
-                dataProductsState={null}
-                dpId='alert'
-                chartViewerId={ALERT.CHART_VIEWER_1}
-                tableGroupViewerId={ALERT.TABLE_GROUP_MAIN}
-                whatToShow={whatToShow}
-                onChange={handleShowChange}
-                mayToggle={true}
-            />
-        ) : (
-            <EmptySlot label='Table' />
-        ),
         hasDetailTable ? (
             <Stack sx={{width: 1, height: 1, pt: '28px'}}>
+                <Stack direction='row' alignItems='center' sx={{height: '28px', mt: '-28px', px: 1}}>
+                    {alertTitleDisplay}
+                </Stack>
                 <PropertySheetAsTable
                     tbl_id={ALERT.TABLE_2_ID}
                     tbl_group={ALERT.TABLE_GROUP_DETAILS}
@@ -113,8 +120,23 @@ export function AlertResultView() {
             </Stack>
         ) : (
             <Stack sx={{width: 1, height: 1, pt: '28px'}}>
+                <Stack direction='row' alignItems='center' sx={{height: '28px', mt: '-28px', px: 1}}>
+                    {alertTitleDisplay}
+                </Stack>
                 <EmptySlot label='Details Table' />
             </Stack>
+        ),
+        hasMainTable ? (
+            <MultiProductChoice
+                dpId='alert'
+                chartViewerId={ALERT.CHART_VIEWER_1}
+                tableGroupViewerId={ALERT.TABLE_GROUP_MAIN}
+                whatToShow={whatToShow}
+                onChange={handleShowChange}
+                mayToggle={true}
+            />
+        ) : (
+            <EmptySlot label='Table' />
         ),
         hasImages ? (
             <Stack sx={{width: 1, height: 1}}>
@@ -132,7 +154,7 @@ export function AlertResultView() {
     ];
 
     return (
-        <Sheet sx={{width: 1, height: 1, display: 'flex'}}>
+        <Sheet sx={{width: 1, height: 1, display: 'flex', minHeight: 0}}>
             <DockLayoutPanel config={ALERT_STANDARD_LAYOUT}>
                 {standardPanels}
             </DockLayoutPanel>

--- a/src/firefly/js/apps/alertviewer/AlertUploadPanel.jsx
+++ b/src/firefly/js/apps/alertviewer/AlertUploadPanel.jsx
@@ -1,4 +1,5 @@
-import React, {useState} from 'react';
+import React, {useContext, useEffect, useState} from 'react';
+import PropTypes from 'prop-types';
 import {showInfoPopup} from 'firefly/ui/PopupUtil';
 import {Button, IconButton, Input, Stack, Typography} from '@mui/joy';
 import {LoadingMessage} from 'firefly/visualize/ui/FileUploadViewPanel';
@@ -9,7 +10,6 @@ import WebPlotRequest from 'firefly/visualize/WebPlotRequest';
 import RangeValues from 'firefly/visualize/RangeValues';
 import {dispatchDeletePlotView, dispatchPlotImage} from 'firefly/visualize/ImagePlotCntlr';
 import {dispatchComponentStateChange} from 'firefly/core/ComponentCntlr';
-import {ROUTER} from 'firefly/templates/router/RouteHelper';
 import {addToRecentAlertIDs, showAlertIdDialog} from 'firefly/apps/alertviewer/AlertIDDialog';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import {removeTablesFromGroup} from 'firefly/tables/TableUtil';
@@ -17,41 +17,52 @@ import {getJsonData} from 'firefly/rpc/SearchServicesJson';
 import {ServerRequest} from 'firefly/data/ServerRequest';
 import {dispatchChartRemove} from 'firefly/charts/ChartsCntlr';
 import {dispatchHideDropDown} from 'firefly/core/LayoutCntlr';
+import {TitleOptions} from 'firefly/visualize/WebPlotRequest';
+import {InitArgsCtx} from 'firefly/templates/common/InitArgsCtx';
+import {dispatchFormSubmit} from 'firefly/core/AppDataCntlr';
 
 const ALERT_LOAD_REQUEST = 'AlertViewerSearchProcessor';
+const IMAGE_TITLES = ['Science', 'Template', 'Difference'];
 
-export const UploadPanel = () => {
-    const instruction = 'Enter an Alert URL or ID to load in the Alert Viewer:';
+export const UploadPanel = ({}) => {
+    const instruction = 'Enter an Alert ID to load in the Alert Viewer:';
     const [isLoading, setIsLoading] = useState(false);
-    const [source, setSource] = useState('');
+    const [alertId, setAlertId] = useState('');
+    const {initArgs} = useContext(InitArgsCtx);
 
-    const doLoad = async () => {
-        const trimmedSource = source.trim();
-        if (!trimmedSource) {
-            showInfoPopup('Please enter a FITS URL.', 'Load Error');
+    const doLoad = async (loadId = alertId) => {
+        const trimmedId = loadId.trim();
+        if (!trimmedId) {
+            showInfoPopup('Please enter an alert ID.', 'Load Error');
             return;
         }
 
         setIsLoading(true);
         try {
             const request = new ServerRequest(ALERT_LOAD_REQUEST);
-            request.setParam('source', trimmedSource);
+            request.setParam('source', trimmedId);
 
             const result = await getJsonData(request);
             if (!result?.success) {
                 showInfoPopup(result?.message || 'Unable to load alert data.', 'Load Error');
                 return;
             }
-
-            addToRecentAlertIDs(trimmedSource);
+            addToRecentAlertIDs(trimmedId);
             clearAlertProducts(); //todo: keep this?
-            loadFromEntries(result);
+            loadFromEntries(result, trimmedId);
         } catch (error) {
             showInfoPopup(`Error loading file: ${error.message}`, 'Load Error');
         } finally {
             setIsLoading(false);
         }
     };
+
+    useEffect(() => {
+        const urlApiId = initArgs?.urlApi?.id?.trim?.();
+        if (!urlApiId) return;
+        setAlertId(urlApiId);
+        void doLoad(urlApiId);
+    }, [initArgs]);
 
     return (
         <Stack width={1} alignItems='center'>
@@ -60,19 +71,19 @@ export const UploadPanel = () => {
                     <Stack direction='row' spacing={1}>
                         <Input
                             sx={{width: '50rem'}}
-                            value={source}
-                            placeholder='Enter a FITS URL or Alert ID'
-                            onChange={(ev) => setSource(ev.target.value)}
+                            value={alertId}
+                            placeholder='Enter an Alert ID'
+                            onChange={(ev) => setAlertId(ev.target.value)}
                             onKeyDown={(ev) => ev.key === 'Enter' && doLoad()}
                         />
-                        <Button onClick={doLoad} loading={isLoading}>Load</Button>
+                        <Button onClick={() => doLoad()} loading={isLoading}>Load</Button>
                         <IconButton
                             size='sm'
                             variant='outlined'
                             title='Recent Alert IDs'
                             onClick={() => {
-                                showAlertIdDialog(source, (newId) => {
-                                    if (newId) setSource(newId);
+                                showAlertIdDialog(alertId, (newId) => {
+                                    if (newId) setAlertId(newId);
                                 });
                             }}
                         >
@@ -85,7 +96,9 @@ export const UploadPanel = () => {
     );
 };
 
-UploadPanel.propTypes = {};
+UploadPanel.propTypes = {
+    initArgs: PropTypes.object,
+};
 
 function clearAlertProducts() {
     removeTablesFromGroup(ALERT.TABLE_GROUP_MAIN);
@@ -97,11 +110,11 @@ function clearAlertProducts() {
     );
 }
 
-function loadFromEntries(result) {
+function loadFromEntries(result, alertId) {
     try {
         const entries = result?.entries ?? [];
-        const mainTablePart = entries[0];
-        const detailsTablePart = entries[1];
+        const mainTablePart = entries[1];
+        const detailsTablePart = entries[0];
         const imageParts = entries.slice(2, 5);
 
         if (entries.length < 5) {
@@ -121,7 +134,7 @@ function loadFromEntries(result) {
         const getExtNum = (part, fallbackIdx) => part?.extNum ?? fallbackIdx;
         const getFileLocation = (part) => part?.fileKey ?? result?.fileKey;
         const getFileName = (part) => part?.fileName ?? result?.fileName ?? result?.source ?? 'Uploaded FITS';
-        const pickedTableParts = [mainTablePart, detailsTablePart];
+        const pickedTableParts = [detailsTablePart, mainTablePart];
 
         for (let i = 0; i < 2; i++) {
             const part = pickedTableParts[i];
@@ -129,6 +142,7 @@ function loadFromEntries(result) {
             const desc = part?.desc;
             const fileLocation = getFileLocation(part);
             const uploadedFileName = getFileName(part);
+            const isDetailsTable = i === 0;
 
             if (!fileLocation) {
                 showInfoPopup(`Alert viewer table entry ${i + 1} is missing a file key.`, 'Load Error');
@@ -140,7 +154,7 @@ function loadFromEntries(result) {
                 fileLocation,
                 null,
                 {
-                    tbl_id: i === 0 ? ALERT.TABLE_1_ID : ALERT.TABLE_2_ID,
+                    tbl_id: isDetailsTable ? ALERT.TABLE_2_ID : ALERT.TABLE_1_ID,
                     pageSize: ALERT.TABLE_PAGESIZE,
                     META_INFO: {}
                 }
@@ -149,7 +163,7 @@ function loadFromEntries(result) {
 
             dispatchTableSearch(
                 tblReq,
-                {removable: true, tbl_group: i === 0 ? ALERT.TABLE_GROUP_MAIN : ALERT.TABLE_GROUP_DETAILS}
+                {removable: true, tbl_group: isDetailsTable ? ALERT.TABLE_GROUP_DETAILS : ALERT.TABLE_GROUP_MAIN}
             );
         }
 
@@ -158,9 +172,7 @@ function loadFromEntries(result) {
         for (let i = 0; i < 3; i++) {
             const part = imageParts[i];
             const extNum = getExtNum(part, i);
-            const desc = part?.desc;
             const fileLocation = getFileLocation(part);
-            const uploadedFileName = getFileName(part);
             const plotId = plotIds[i];
 
             if (!fileLocation) {
@@ -172,11 +184,17 @@ function loadFromEntries(result) {
             wpRequest.setInitialRangeValues(RangeValues.make2To10SigmaLinear());
             wpRequest.setPlotGroupId(ALERT.IMG_VIEWER);
             wpRequest.setMultiImageExts(`${extNum}`);
-            wpRequest.setTitle(desc || `${uploadedFileName} [ext ${extNum}]`);
+            wpRequest.setTitle(IMAGE_TITLES[i] ?? `Image ${i + 1}`);
+            wpRequest.setTitleOptions(TitleOptions.NONE);
 
             dispatchPlotImage({plotId, wpRequest, viewerId: ALERT.IMG_VIEWER, setNewPlotAsActive: i === 0});
         }
-        dispatchComponentStateChange(ROUTER, {RESULTS: '/results'});
+        dispatchComponentStateChange(ALERT.STATE_ID, {
+            id: alertId,
+            source: result?.source,
+            fileName: result?.fileName,
+        });
+        dispatchFormSubmit({submitTo: '/results'});
         dispatchHideDropDown();
     } catch (error) {
         console.error('Error loading file:', error);

--- a/src/firefly/js/apps/alertviewer/alertviewer.js
+++ b/src/firefly/js/apps/alertviewer/alertviewer.js
@@ -4,6 +4,7 @@ import {createRouter} from 'firefly/templates/router/RoutedApp.jsx';
 import {FormWatcher} from 'firefly/templates/router/RouteHelper';
 import {UploadPanel} from 'firefly/apps/alertviewer/AlertUploadPanel';
 import {AlertResultView} from 'firefly/apps/alertviewer/AlertResultView';
+import {getAlertViewerCommands} from 'firefly/api/webApiCommands/AlertViewerCommands';
 
 function getBasename() {
     const p = window.location.pathname || '';
@@ -45,7 +46,7 @@ export const alertviewer = {
         {label:'Alert', action: 'AlertUpload', primary: true, path:'/upload'},
         {label:'Help', action:'app_data.helpLoad', type:'COMMAND'},
     ],
-    webApiCommands: {},
+    webApiCommands: getAlertViewerCommands(),
 };
 
 


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1964
- UI changes according to ticket
- Added support for URL API
- Call Rubin Service (set it up via `AppProperties` so Rubin can configure it, relying on default fallback to work for firefly testing)  
  - URL uploads no longer supported, only Alert IDs (I can add back  URL support as well - if we'd want that. In that case, server side code will bypass checking `AppProperties` for base URL and just rely on user entered URL to retrieve a FITs file)

**Testing**: 
**Firefly's AlertViewer**: https://fireflydev.ipac.caltech.edu/firefly-1964-alert-viewer/firefly
  - Test out these Alert IDs: 
    - `170059278837088375`, `170112073844916273`
    - They will fail on the above test build with `Unable to retrieve the FITS file: 401 Unauthorized`
    - But you can checkout my branch and test the UI changes locally 