### PR TITLE
FIREFLY-1331: Add Version validation for compatibility check between python client and firefly server

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/data/ServerParams.java
@@ -127,6 +127,7 @@ public class ServerParams {
     public static final String STAT = "CmdStat";
     public static final String GET_USER_INFO = "CmdGetUserInfo";
     public static final String GET_ALERTS = "CmdAlerts";
+    public static final String GET_VERSION = "CmdVersion";
 
     public static final String JSON_DATA = "JsonData";
     public static final String RESOLVE_NAME= "CmdResolveName";

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/AppServerCommands.java
@@ -10,6 +10,9 @@ import edu.caltech.ipac.firefly.data.ServerEvent;
 import edu.caltech.ipac.firefly.data.ServerParams;
 import edu.caltech.ipac.firefly.data.userdata.UserInfo;
 import edu.caltech.ipac.firefly.messaging.JsonHelper;
+import edu.caltech.ipac.firefly.server.util.VersionUtil;
+import edu.caltech.ipac.util.KeyVal;
+import edu.caltech.ipac.util.serialization.Serializer;
 import edu.caltech.ipac.firefly.server.events.FluxAction;
 import edu.caltech.ipac.firefly.server.events.ServerEventManager;
 import edu.caltech.ipac.firefly.server.security.SsoAdapter;
@@ -24,6 +27,7 @@ import org.json.simple.parser.ParseException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -149,6 +153,23 @@ public class AppServerCommands {
     }
 
 
+
+    public static class GetVersion extends ServCommand {
+        public String doCommand(SrvParam params) throws Exception {
+            boolean raw = params.getOptionalBoolean("raw", false);
+            Object versionData;
+            if (raw) {
+                versionData = VersionUtil.getAppVersion();
+            } else {
+                Map<String, String> versionMap = new LinkedHashMap<>();
+                for (KeyVal<String, String> kv : VersionUtil.getVersionInfo()) {
+                    versionMap.put(kv.getKey(), kv.getValue());
+                }
+                versionData = versionMap;
+            }
+            return Serializer.getJsonMapper().writeValueAsString(versionData);
+        }
+    }
 
     public static class GetAlerts extends ServCommand {
         public String doCommand(SrvParam params) throws Exception {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/ServerCommandAccess.java
@@ -104,6 +104,7 @@ public class ServerCommandAccess {
         _cmdMap.put(ServerParams.LOGOUT,                 new AppServerCommands.Logout());
         _cmdMap.put(ServerParams.GET_USER_INFO,          new AppServerCommands.GetUserInfo());
         _cmdMap.put(ServerParams.GET_ALERTS,             new AppServerCommands.GetAlerts());
+        _cmdMap.put(ServerParams.GET_VERSION,            new AppServerCommands.GetVersion());
         _cmdMap.put(ServerParams.TEXT_FILE,              new AppServerCommands.TextFile());
 
     }


### PR DESCRIPTION
Fixes [FIREFLY-1331](https://jira.ipac.caltech.edu/browse/FIREFLY-1331)

Exposed the version info as `cmd=CmdVersion` at the commands servelet endpoint (`CmdSrv/sync`). 

Firefly client is not using the `raw=true` param but it maybe helpful in future if validation logic becomes complicated.

See Firefly client PR: https://github.com/Caltech-IPAC/firefly_client/pull/79

## Testing 
1. http://aac8ce8bef8604e7ca9d38b934ab83c5-4855331a01d9fb87.elb.us-east-1.amazonaws.com/firefly-1331/firefly (yes I managed to deploy the PR build on AWS using helm!)

   - Open the version dialog and check if it matches the JSON returned by `/CmdSrv/sync?cmd=CmdVersion` [query params](http://aac8ce8bef8604e7ca9d38b934ab83c5-4855331a01d9fb87.elb.us-east-1.amazonaws.com/firefly-1331/firefly/CmdSrv/sync?cmd=CmdVersion)

   - Check that `/CmdSrv/sync?cmd=CmdVersion?raw=true` [query params](http://aac8ce8bef8604e7ca9d38b934ab83c5-4855331a01d9fb87.elb.us-east-1.amazonaws.com/firefly-1331/firefly/CmdSrv/sync?cmd=CmdVersion&raw=true) returns primitive version object which can also be useful in some cases

2. https://firefly-1331-version-validation.irsakubedev.ipac.caltech.edu/irsaviewer/CmdSrv/sync?cmd=CmdVersion