### PR TITLE
Improve AlertViewer UI/UX 

### DIFF
--- a/src/firefly/js/apps/alertviewer/AlertUploadPanel.jsx
+++ b/src/firefly/js/apps/alertviewer/AlertUploadPanel.jsx
@@ -37,6 +37,7 @@ export const UploadPanel = ({}) => {
             return;
         }
 
+        addToRecentAlertIDs(trimmedId);
         setIsLoading(true);
         try {
             const request = new ServerRequest(ALERT_LOAD_REQUEST);
@@ -47,7 +48,6 @@ export const UploadPanel = ({}) => {
                 showInfoPopup(result?.message || 'Unable to load alert data.', 'Load Error');
                 return;
             }
-            addToRecentAlertIDs(trimmedId);
             clearAlertProducts(); //todo: keep this?
             loadFromEntries(result, trimmedId);
         } catch (error) {

--- a/src/firefly/js/apps/alertviewer/alertviewer.js
+++ b/src/firefly/js/apps/alertviewer/alertviewer.js
@@ -1,10 +1,15 @@
 import React from 'react';
+import QueryStats from '@mui/icons-material/QueryStats';
+import {Sheet, Stack, Typography} from '@mui/joy';
 
 import {createRouter} from 'firefly/templates/router/RoutedApp.jsx';
 import {FormWatcher} from 'firefly/templates/router/RouteHelper';
+import {LandingPage} from 'firefly/templates/fireflyviewer/LandingPage.jsx';
 import {UploadPanel} from 'firefly/apps/alertviewer/AlertUploadPanel';
 import {AlertResultView} from 'firefly/apps/alertviewer/AlertResultView';
 import {getAlertViewerCommands} from 'firefly/api/webApiCommands/AlertViewerCommands';
+import {dispatchShowDropDown} from 'firefly/core/LayoutCntlr';
+import {dispatchOnAppReady} from 'firefly/core/AppDataCntlr';
 
 function getBasename() {
     const p = window.location.pathname || '';
@@ -27,19 +32,54 @@ const routes = [
     },
 ];
 
+function AlertViewerBottomSection() {
+    return (
+        <Sheet variant='soft' sx={{pt: 8, pb: 4, px: 2}}>
+            <Stack spacing={10} alignItems='center'>
+                <Stack spacing={3}>
+                    <Stack spacing={2} alignItems='center'>
+                        <QueryStats sx={{ width: '6rem', height: '6rem' }} />
+                        <Stack spacing={1} alignItems='center'>
+                            <Typography level='h2' fontWeight='md'>Getting Started</Typography>
+                        </Stack>
+                    </Stack>
+                    <Stack direction='row' spacing={6}>
+                        <Stack spacing={.5} alignItems='center'>
+                            <Typography level='title-lg' color='primary'>Navigate to the Alert tab</Typography>
+                            <Typography level='body-md'>Search for results via Alert IDs</Typography>
+                        </Stack>
+                    </Stack>
+                </Stack>
+                <Stack spacing={2} alignItems='center'>
+                    <Typography level='body-lg'>Visualizations of the results will appear in this tab</Typography>
+                </Stack>
+            </Stack>
+        </Sheet>
+    );
+}
+
+function AlertViewerLanding() {
+    return (
+        <LandingPage slotProps={{
+            topSection: {title: 'Welcome to AlertViewer'},
+            bottomSection: {
+                component: AlertViewerBottomSection
+            }
+        }}/>
+    );
+}
+
 
 export const alertviewer = {
     init,
     props: {
         appTitle: 'Alert Viewer',
+        backgroundMonitor: false,
         getRouter: createRouter(basename, routes),
         appIcon: 'n/a',
         slotProps: {
             drawer: { drawerWidth:'24rem'},
-            landing: {
-                desc: 'Some information about the alert viewer here. This is the landing page. This text will be changed to something more useful in the future.',
-                bgImage: null,
-            }
+            landing: {component: AlertViewerLanding},
         }
     },
     menu: [
@@ -50,4 +90,11 @@ export const alertviewer = {
 };
 
 
-function init() {}
+function init() {
+    const {pathname, search} = window.location;
+    const params = new URLSearchParams(search);
+    const hasUrlApi = params.has('api');
+    if (!hasUrlApi && (pathname === basename || pathname === `${basename}/`)) {
+        dispatchOnAppReady(() => dispatchShowDropDown({view: 'AlertUpload'}));
+    }
+}

--- a/src/firefly/js/templates/router/RoutedApp.jsx
+++ b/src/firefly/js/templates/router/RoutedApp.jsx
@@ -62,7 +62,8 @@ export  default function RoutedApp({slotProps, menu, mainPanel, children, dropdo
 
     useEffect(() => {
         startTTFeatureWatchers(getAllStartIds());
-        dispatchSetMenu({menuItems: menu});
+        const {backgroundMonitor = true} = props;
+        dispatchSetMenu({menuItems: menu, showBgMonitor: backgroundMonitor});
         dispatchOnAppReady(() => {
             dispatchNotifyRemoteAppReady();
         });


### PR DESCRIPTION
**SUIT PR**: https://github.com/lsst/suit/pull/84
- Remove Job Monitor tab for alert viewer 
- Default tab when you hit `/alertviewer` is now the `Alert` tab (`/alertviewer/upload`) instead of the `Results` tab.
- Simplified `Results` (landing page) text for `AlertViewer` 
  - required a small custom component to modify the bottom section of the `LandingPage`, I could have probably done this through `slotProps`, but it was proving to be trickier (was affecting Euclid/Spherex) and `LandingPage` is used in several places so I thought it was best to create a simple custom component instead in this case 
  - And the changes in RoutedApp are to support being able to call `LandingPage` as well (to have more control over customizing it)

**Testing**: 
- **Firefly's AlertViewer**: [https://fireflydev.ipac.caltech.edu/alert-viewer-changes/firefly/alertviewer](https://fireflydev.ipac.caltech.edu/alert-viewer-changes/firefly/alertviewer)
- **SUIT's AlertViewer**: https://enable-alert-viewer.irsakubedev.ipac.caltech.edu/suit/alertviewer
  - Ensure you're routed to Alert tab directly. Inspect the Results tab (landing page) text. 
  - Checkout this branch locally if you want to test submitting Alert IDs (sample IDs: `170112073844916273`, `170059278837088375`)
  - URL API should still work (if trying on the test builds above, you should get a missing/invalid token error, locally it should take you to the results tab with results loaded). 