### PR TITLE
IRSA-7673: Update job image results and table container for SPHEREx Mosaic Tool

### DIFF
--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -18,7 +18,7 @@ import {logger} from '../../util/Logger';
 import * as TblUtil from 'firefly/tables/TableUtil';
 import {copyRequestOptions, getRequestFromJob, getTblId, makeFileRequest} from 'firefly/tables/TableRequestUtil';
 import {dispatchTableRemove, dispatchTableSearch, dispatchTableUpdate} from 'firefly/tables/TablesCntlr';
-import WebPlotRequest from 'firefly/visualize/WebPlotRequest';
+import WebPlotRequest, {TitleOptions} from 'firefly/visualize/WebPlotRequest';
 import {getAViewFromMultiView, getMultiViewRoot, IMAGE} from 'firefly/visualize/MultiViewCntlr';
 import {dispatchPlotImage} from 'firefly/visualize/ImagePlotCntlr';
 import {dispatchFormSubmit} from 'firefly/core/AppDataCntlr';
@@ -368,10 +368,17 @@ export function loadMixedResult({jobInfo, href}) {
     loadImageResult({jobInfo, href});      // placeholder for mixed content loader to be implemented later
 }
 
-export function loadImageResult({jobInfo, href}) {
+export function loadImageResult({jobInfo, request, href}) {
     const wpRequest = WebPlotRequest.makeURIPlotRequest(href);
     const {viewerId=''} = getAViewFromMultiView(getMultiViewRoot(), IMAGE) || {};
     wpRequest.setPlotGroupId(viewerId);
+
+    const requestTitle = request?.META_INFO?.title;
+    if (requestTitle) {
+        wpRequest.setTitleOptions(TitleOptions.NONE);
+        wpRequest.setTitle(requestTitle);
+    }
+
     const plotId = `${href.replace('.', '_')}-${jobInfo.jobId}`;
     dispatchPlotImage({plotId, wpRequest, viewerId});
     handleLayoutChanges(jobInfo);

--- a/src/firefly/js/tables/ui/TablesContainer.jsx
+++ b/src/firefly/js/tables/ui/TablesContainer.jsx
@@ -23,7 +23,8 @@ import {getTableUiById, getTableUiByTblId, getTblIdsByGroup} from '../TableUtil.
 const logger = Logger('Tables').tag('TablesContainer');
 
 export function TablesContainer(props) {
-    const {mode='both', closeable=true, tableOptions, style, expandedMode:xMode=false} = props;
+    const {mode='both', closeable=true, tableOptions, style, expandedMode:xMode=false,
+        forceSingleTableAsTab=false} = props;
     const expandedMode = useStoreConnector(() => xMode || getExpandedMode() === LO_VIEW.tables);
     const tbl_group = expandedMode && mode !== 'standard' ? TblUtil.getTblExpandedInfo().tbl_group : props.tbl_group;
 
@@ -38,9 +39,11 @@ export function TablesContainer(props) {
     logger.debug('render... tbl_group: ' + tbl_group);
 
     if (expandedMode) {
-        return <ExpandedView {...{active, tables, tableOptions, expandedMode, closeable, tbl_group}} />;
+        return <ExpandedView {...{active, tables, tableOptions, expandedMode, closeable, tbl_group, forceSingleTableAsTab}} />;
     } else {
-        return isEmpty(tables) ? <div/> : <StandardView {...{active, tables, tableOptions, expandedMode, tbl_group, style}} />;
+        return isEmpty(tables)
+            ? <div/>
+            : <StandardView {...{active, tables, tableOptions, expandedMode, tbl_group, forceSingleTableAsTab, style}} />;
     }
 }
 
@@ -50,6 +53,7 @@ TablesContainer.propTypes = {
     tbl_group: PropTypes.string,
     style: PropTypes.object,
     tableOptions: PropTypes.object,
+    forceSingleTableAsTab: PropTypes.bool,
     mode: PropTypes.oneOf(['expanded', 'standard', 'both'])
 };
 
@@ -76,13 +80,13 @@ function ExpandedView(props) {
 
 
 function StandardView(props) {
-    const {tables, tableOptions, expandedMode, active, tbl_group, style={}} = props;
+    const {tables, tableOptions, expandedMode, active, tbl_group, forceSingleTableAsTab, style={}} = props;
 
     const onTabSelect = (tbl_id) => {
         tbl_id && dispatchActiveTableChanged(tbl_id, tbl_group);
     };
     const keys = Object.keys(tables);
-    if (keys.length === 1) {
+    if (keys.length === 1 && !forceSingleTableAsTab) {
         return <SingleTable table={get(tables, [keys[0]])} expandedMode={expandedMode} tableOptions={tableOptions}/>;
     } else {
         const uid = hashCode(keys.join());


### PR DESCRIPTION
See ife PR for tickets and testing: https://github.com/IPAC-SW/irsa-ife/pull/462

1. `TableContainer` defaults to `SingleTable` when single table which is different from `TabPanel` in 2 ways: 
     1. when table load is completed with error it doesn't render table title with a close icon button so user gets stuck with failed table view and can't clear it
     2. the table toolbar is narrower in height than tab panel which makes layout jumpy vertically when more tables are added
   
     I exposed a prop to force using TabPanel even for single table case to overcome above two issues.

2. `loadImageResult` uses image title from result href's filename instead of using it from job request's title which is implicit in `loadTableResult`. This becomes stark when you have multiple image results plotted and you are trying to identify which image came from which job. Fixed it.