### PR TITLE
FIREFLY-1997: Alertviewer use URL API approach for results

### DIFF
--- a/src/firefly/js/apps/alertviewer/AlertUploadPanel.jsx
+++ b/src/firefly/js/apps/alertviewer/AlertUploadPanel.jsx
@@ -3,41 +3,37 @@ import PropTypes from 'prop-types';
 import {showInfoPopup} from 'firefly/ui/PopupUtil';
 import {Button, IconButton, Input, Stack, Typography} from '@mui/joy';
 import {LoadingMessage} from 'firefly/visualize/ui/FileUploadViewPanel';
+import {addToRecentAlertIDs, showAlertIdDialog} from 'firefly/apps/alertviewer/AlertIDDialog';
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
+import {InitArgsCtx} from 'firefly/templates/common/InitArgsCtx';
+import {getRootURL} from 'firefly/util/WebUtil';
+import {getJsonData} from 'firefly/rpc/SearchServicesJson';
+import {ServerRequest} from 'firefly/data/ServerRequest';
 import {makeFileRequest} from 'firefly/tables/TableRequestUtil';
 import {ALERT} from './AlertIDs.js';
 import {dispatchTableSearch} from 'firefly/tables/TablesCntlr';
-import WebPlotRequest from 'firefly/visualize/WebPlotRequest';
+import WebPlotRequest, {TitleOptions} from 'firefly/visualize/WebPlotRequest';
 import RangeValues from 'firefly/visualize/RangeValues';
 import {dispatchDeletePlotView, dispatchPlotImage} from 'firefly/visualize/ImagePlotCntlr';
 import {dispatchComponentStateChange} from 'firefly/core/ComponentCntlr';
-import {addToRecentAlertIDs, showAlertIdDialog} from 'firefly/apps/alertviewer/AlertIDDialog';
-import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import {removeTablesFromGroup} from 'firefly/tables/TableUtil';
-import {getJsonData} from 'firefly/rpc/SearchServicesJson';
-import {ServerRequest} from 'firefly/data/ServerRequest';
 import {dispatchChartRemove} from 'firefly/charts/ChartsCntlr';
 import {dispatchHideDropDown} from 'firefly/core/LayoutCntlr';
-import {TitleOptions} from 'firefly/visualize/WebPlotRequest';
-import {InitArgsCtx} from 'firefly/templates/common/InitArgsCtx';
 import {dispatchFormSubmit} from 'firefly/core/AppDataCntlr';
 
 const ALERT_LOAD_REQUEST = 'AlertViewerSearchProcessor';
 const IMAGE_TITLES = ['Science', 'Template', 'Difference'];
 
-export const UploadPanel = ({}) => {
+export const AlertIdPanel = ({loadInPlace=false}) => {
     const instruction = 'Enter an Alert ID to load in the Alert Viewer:';
     const [isLoading, setIsLoading] = useState(false);
     const [alertId, setAlertId] = useState('');
     const {initArgs} = useContext(InitArgsCtx);
 
-    const doLoad = async (loadId = alertId) => {
+    const doLoadInPlace = async (loadId) => {
         const trimmedId = loadId.trim();
-        if (!trimmedId) {
-            showInfoPopup('Please enter an alert ID.', 'Load Error');
-            return;
-        }
+        if (!trimmedId) return;
 
-        addToRecentAlertIDs(trimmedId);
         setIsLoading(true);
         try {
             const request = new ServerRequest(ALERT_LOAD_REQUEST);
@@ -48,7 +44,7 @@ export const UploadPanel = ({}) => {
                 showInfoPopup(result?.message || 'Unable to load alert data.', 'Load Error');
                 return;
             }
-            clearAlertProducts(); //todo: keep this?
+            clearAlertProducts();
             loadFromEntries(result, trimmedId);
         } catch (error) {
             showInfoPopup(`Error loading file: ${error.message}`, 'Load Error');
@@ -57,11 +53,37 @@ export const UploadPanel = ({}) => {
         }
     };
 
+    const doLoad = async (loadId = alertId) => {
+        const trimmedId = loadId.trim();
+        if (!trimmedId) {
+            showInfoPopup('Please enter an alert ID.', 'Load Error');
+            return;
+        }
+
+        addToRecentAlertIDs(trimmedId);
+        try {
+            if (loadInPlace) {
+                await doLoadInPlace(trimmedId);
+            } else {
+                setIsLoading(true);
+                const url = new URL('alertviewer', getRootURL());
+                url.searchParams.set('api', 'alert');
+                url.searchParams.set('id', trimmedId);
+                window.open(url.href, '_blank');
+            }
+        } catch (error) {
+            const errMsg = loadInPlace ? `Error loading file: ${error.message}` : `Error opening alert viewer: ${error.message}`;
+            showInfoPopup(errMsg, 'Load Error');
+        } finally {
+            if (!loadInPlace) setIsLoading(false);
+        }
+    };
+
     useEffect(() => {
         const urlApiId = initArgs?.urlApi?.id?.trim?.();
         if (!urlApiId) return;
         setAlertId(urlApiId);
-        void doLoad(urlApiId);
+        void doLoadInPlace(urlApiId);
     }, [initArgs]);
 
     return (
@@ -96,8 +118,8 @@ export const UploadPanel = ({}) => {
     );
 };
 
-UploadPanel.propTypes = {
-    initArgs: PropTypes.object,
+AlertIdPanel.propTypes = {
+    loadInPlace: PropTypes.bool,
 };
 
 function clearAlertProducts() {

--- a/src/firefly/js/apps/alertviewer/alertviewer.js
+++ b/src/firefly/js/apps/alertviewer/alertviewer.js
@@ -5,7 +5,7 @@ import {Sheet, Stack, Typography} from '@mui/joy';
 import {createRouter} from 'firefly/templates/router/RoutedApp.jsx';
 import {FormWatcher} from 'firefly/templates/router/RouteHelper';
 import {LandingPage} from 'firefly/templates/fireflyviewer/LandingPage.jsx';
-import {UploadPanel} from 'firefly/apps/alertviewer/AlertUploadPanel';
+import {AlertIdPanel} from 'firefly/apps/alertviewer/AlertUploadPanel';
 import {AlertResultView} from 'firefly/apps/alertviewer/AlertResultView';
 import {getAlertViewerCommands} from 'firefly/api/webApiCommands/AlertViewerCommands';
 import {dispatchShowDropDown} from 'firefly/core/LayoutCntlr';
@@ -24,7 +24,7 @@ const basename = getBasename(); //'/firefly/alertviewer';
 const routes = [
     {
         path: '/upload',
-        element: <FormWatcher submitTo='/results'><UploadPanel/></FormWatcher>
+        element: <FormWatcher submitTo='/results'><AlertIdPanel loadInPlace={false}/></FormWatcher>
     },
     {
         path: '/results',


### PR DESCRIPTION
**Ticket**: [FIREFLY-1997](https://jira.ipac.caltech.edu/browse/FIREFLY-1997)
- Use URL API approach for all alertviewer searches and open them in a new tab 

**Testing**: 
- **Firefly**: https://fireflydev.ipac.caltech.edu/firefly-1997-alerts-url-api/firefly/alertviewer
  - you should still see the URL API be created and a new tab above, but it'll fail due to token authentication
  - to test results working, checkout my branch and run firefly locally 