### PR TITLE
IRSA-7687: Make BgMaskPanel's layout responsive and improve the error state

### DIFF
--- a/src/firefly/js/core/LayoutCntlr.js
+++ b/src/firefly/js/core/LayoutCntlr.js
@@ -350,7 +350,7 @@ export function getLayoutRoot() {
 export function getLayouInfo() {
     const state= flux.getState() ?? {};
     const layout = state[LAYOUT_PATH] ?? {initLoadCompleted:false};
-    const hasImages = getPlotViewAry(visRoot()).some( (pv) => pv.plotViewCtx.useForSearchResults);
+    const hasImages = getPlotViewAry(visRoot())?.some( (pv) => pv.plotViewCtx.useForSearchResults);
     const hasTables = !isEmpty(state[TABLE_SPACE_PATH]?.results?.main?.tables);
     /*
       to make plot area disappear if it's not possible to create a plot use

--- a/src/firefly/js/core/background/BgMaskPanel.jsx
+++ b/src/firefly/js/core/background/BgMaskPanel.jsx
@@ -1,6 +1,6 @@
 import React, {useEffect} from 'react';
 import {bool, string, func, object, element} from 'prop-types';
-import {Button, Skeleton, Stack, Typography} from '@mui/joy';
+import {Box, Button, Sheet, Skeleton, Stack, Typography} from '@mui/joy';
 
 import {dispatchComponentStateChange, getComponentState} from '../ComponentCntlr.js';
 import {useStoreConnector, Slot} from '../../ui/SimpleComponent.jsx';
@@ -12,6 +12,7 @@ import {showJobMonitor} from './JobMonitor';
 import {dispatchJobRemove} from './BackgroundCntlr';
 
 const logger = Logger('BgMaskPanel');
+const maskPanelBreakpoint = '25rem';
 
 /**
  * This component uses ComponentCntlr state persistence.  It is keyed by the given props's componentKey.
@@ -23,7 +24,7 @@ const logger = Logger('BgMaskPanel');
  */
 
 
-export const BgMaskPanel = React.memo(({componentKey, onMaskComplete, mask, showError= true, ...props}) => {
+export const BgMaskPanel = React.memo(({componentKey, onMaskComplete, mask, showError= true, renderError, ...props}) => {
 
     const inProgress = useStoreConnector(() => getComponentState(componentKey)?.inProgress || false);
     const jobInfo    = useStoreConnector(() => {
@@ -49,42 +50,75 @@ export const BgMaskPanel = React.memo(({componentKey, onMaskComplete, mask, show
         doHide();
     };
 
-    const msg = jobInfo?.errorSummary?.message;
+    const showInfo = () => showJobInfo(jobInfo?.meta?.jobId);
+    const infoButton = <InfoButton enabled={!!jobInfo} onClick={showInfo}/>;
+
     logger.debug(inProgress ? 'show' : 'hide');
     if (inProgress) {
+        // we override default zIndex=9 of Skeleton since it sometimes interferes with other components,
+        // the absolute position of mask and its siblings already handles z-indexing cleanly
+        const progressMask = <Skeleton sx={{zIndex: 'auto'}}/>;
+
         return (
-            <MaskP jobInfo={jobInfo} mask={mask} {...props}>
-                <Stack direction='row' spacing={1}>
-                    <Button variant='solid' disabled={!jobInfo} color='primary' onClick={doHide}>Send to background</Button>
-                    <Button variant='solid' disabled={!jobInfo} color='primary' onClick={doShowMonitor}>Job Monitor</Button>
-                    <Button variant='soft' disabled={!jobInfo} onClick={doCancel}>Cancel</Button>
+            <MaskP mask={mask === undefined ? progressMask : mask} {...props}>
+                <Stack spacing={2} sx={{whiteSpace: 'nowrap', m: 'auto', width: 'fit-content', alignItems: 'stretch'}}>
+                    <Stack direction='row' alignItems='center' justifyContent='center' spacing={1}>
+                        <JobProgress jobInfo={jobInfo} sx={{
+                            [`@container (width <= ${maskPanelBreakpoint})`]: {
+                                // hide the title of JobProgress when the panel is too narrow
+                                '& .MuiTypography-title-sm': { maxWidth: 0, overflow: 'hidden', mr: -1 },
+                            }
+                        }}/>
+                        {infoButton}
+                    </Stack>
+                    <Stack sx={{
+                        gap: 1,
+                        flexDirection: 'column',
+                        [`@container (width > ${maskPanelBreakpoint})`]: {
+                            // arrange buttons in a row only when the panel is wide enough
+                            flexDirection: 'row', alignItems: 'center'
+                        }
+                    }}>
+                        <Button variant='solid' size='sm' disabled={!jobInfo} color='primary' onClick={doHide}>Send to background</Button>
+                        <Button variant='solid' size='sm' disabled={!jobInfo} color='primary' onClick={doShowMonitor}>Job Monitor</Button>
+                        <Button variant='soft' size='sm' disabled={!jobInfo} onClick={doCancel}>Cancel</Button>
+                    </Stack>
                 </Stack>
             </MaskP>
         );
     } else if (errorInJob && showError) {
+        const errorMask = <Sheet sx={{width: 1, height: 1, bgcolor: 'warning.softBg'}}/>;
+        const errorMsg = jobInfo?.errorSummary?.message;
+        const defaultErrorContent = (
+            <Stack direction='row' alignItems='center' justifyContent='center' spacing={1}>
+                <Typography level='title-md' color='warning' noWrap={true}>{errorMsg || 'Error'}</Typography>
+                {infoButton}
+            </Stack>
+        );
         return (
-            <MaskP msg={msg} jobInfo={jobInfo} mask={mask} {...props}/>
+            <MaskP mask={mask === undefined ? errorMask : mask} {...props}>
+                {renderError?.(errorMsg, infoButton) ?? defaultErrorContent}
+            </MaskP>
         );
     } else return null;
 });
 
-function MaskP({msg, jobInfo, children, mask=<Skeleton/>, ...props}) {
-    const showInfo = () => {
-        showJobInfo(jobInfo?.meta?.jobId);
-    };
-
+function MaskP({mask, children, ...props}) {
+    if (!mask) return <Box sx={{containerType: 'inline-size'}}>{children}</Box>;
     return (
-        <Slot component={Stack} position='absolute' sx={{inset:0}} slotProps={props}>
+        <Slot component={Stack}
+              sx={{
+                  position: 'absolute', inset: 0,
+                  containerType:'inline-size' // this allows its children to use @container queries for responding to size breakpoints
+              }}
+              slotProps={props}>
             {mask}
-            <Stack whiteSpace='nowrap' position='absolute' zIndex={10} top='50%' left='50%' spacing={2} sx={{transform: 'translate(-50%, -50%)'}}>
-                <Stack direction='row' alignItems='center' justifyContent='center' spacing={1}>
-                    {<JobProgress jobInfo={jobInfo}/> ||
-                     <Typography level='title-md' color='warning' fontStyle='italic' noWrap={true}>{msg}</Typography>
-                    }
-                    <InfoButton enabled={!!jobInfo} onClick={showInfo}/>
-                </Stack>
+            <Box sx={{
+                       position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', // to center the content
+                       maxWidth: '100%', maxHeight: '100%', overflow: 'hidden', // to prevent content overflowing
+                   }}>
                 {children}
-            </Stack>
+            </Box>
         </Slot>
     );
 }
@@ -94,5 +128,6 @@ BgMaskPanel.propTypes = {
     style: object,                    // used for overriding default styling
     onMaskComplete: func,
     showError: bool,
-    mask: element
+    mask: element,
+    renderError: func,                // (errorMsg, infoButton) => ReactNode; replaces default error display
 };

--- a/src/firefly/js/visualize/PlotViewUtil.js
+++ b/src/firefly/js/visualize/PlotViewUtil.js
@@ -188,7 +188,7 @@ export const isActivePlotView= (visRoot,plotId) => visRoot.activePlotId===plotId
  * @param {VisRoot} visRoot - root of the visualization object in store
  * @return {PlotView} the active plot view
  */
-export const getActivePlotView= (visRoot) => visRoot?.plotViewAry.find( (pv) => pv.plotId===visRoot.activePlotId);
+export const getActivePlotView= (visRoot) => visRoot?.plotViewAry?.find( (pv) => pv.plotId===visRoot.activePlotId);
 
 /**
  *

--- a/src/firefly/js/visualize/iv/ImageViewer.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewer.jsx
@@ -7,8 +7,8 @@ import {bool, func, string} from 'prop-types';
 import React, {memo, useState, useEffect, useRef, useDeferredValue, use, Suspense} from 'react';
 import {omit} from 'lodash';
 import shallowequal from 'shallowequal';
-import {getPlotViewById,getAllDrawLayersForPlot} from '../PlotViewUtil.js';
-import {ImageViewerView} from './ImageViewerDecorate.jsx';
+import {getPlotViewById, getAllDrawLayersForPlot, getPlotViewProxyById} from '../PlotViewUtil.js';
+import {ImageViewerView, getImageViewerDecorateSx} from './ImageViewerDecorate.jsx';
 import {visRoot, ExpandType} from '../ImagePlotCntlr.js';
 import {extensionRoot} from '../../core/ExternalAccessCntlr.js';
 import {MouseState, addImageMouseListener, lastMouseCtx} from '../VisMouseSync.js';
@@ -114,24 +114,31 @@ ImageViewer.propTypes= {
 };
 
 
-export function ImageViewerPlaceHolder({fromWorkingTask:task=false, ...rest}){
-    return task ? <WorkingTaskPlaceHolder {...rest}/> : <MessagePlaceHolder {...rest}/>;
+export function ImageViewerPlaceHolder({fromWorkingTask:task=false, plotId, ...rest}){
+    const {pv, vr} = useStoreConnector(() => {
+        const vr= visRoot();
+        return {vr, pv: getPlotViewById(vr, plotId) ?? getPlotViewProxyById(vr, plotId)};
+    });
+    const decorateSx = getImageViewerDecorateSx(plotId, pv, vr);
+    return task
+        ? <WorkingTaskPlaceHolder {...rest} plotId={plotId} sx={decorateSx}/>
+        : <MessagePlaceHolder {...rest} plotId={plotId} sx={decorateSx}/>;
 }
 
 ImageViewerPlaceHolder.propTypes= {
     plotId : string.isRequired,
     fromWorkingTask: bool,
     message : string,
+    maskShowing: bool,
 };
 
-function MessagePlaceHolder({plotId,message,children}){
+function MessagePlaceHolder({plotId,message,maskShowing=true,sx,children}){
     if (!plotId) return <div/>;
     return (
-        <Box sx={{ position:'absolute', left:0, right:0, top:0, bottom:0}}>
+        <Box sx={sx}>
             <ImageViewStatusPanel {...{
-                maskShowing:true, messageShowing:Boolean(message || children),useMessageAlpha:true,
+                maskShowing, messageShowing:Boolean(message || children),useMessageAlpha:true,
                 slotProps :{ message: { text: message} },
-                sx: {left:2, right:2},
             }}>
                 {children}
             </ImageViewStatusPanel>
@@ -140,20 +147,19 @@ function MessagePlaceHolder({plotId,message,children}){
 }
 
 
-function WorkingTaskPlaceHolder({plotId,children,message:defMessage}){
+function WorkingTaskPlaceHolder({plotId,children,message:defMessage,sx}){
     const {promise,message=defMessage}= useStoreConnector( () => getWorkingTask(plotId)  ) ?? {};
     const Empty= ({promise}) => void (promise && use(promise));
     const workingPanel= (
         <ImageViewStatusPanel {...{
             maskShowing:true, messageShowing:Boolean(message || children),useMessageAlpha:true,
             slotProps :{ message: { text: message} },
-            sx: {left:2, right:2},
         }}>
             {children}
         </ImageViewStatusPanel>
     );
     return (
-        <Box sx={{ position:'absolute', left:0, right:0, top:0, bottom:0}}>
+        <Box sx={sx}>
             <Suspense fallback={workingPanel}>
                 <Empty promise={promise}/>
             </Suspense>

--- a/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerDecorate.jsx
@@ -185,13 +185,29 @@ function hasManyPlots(pv,visRoot) {
 
 function getBorderColor(manyPlots, theme, pv,visRoot) {
     if (!pv?.plotId) return 'rgba(0,0,0,.4)';
-    if (!pv.plotViewCtx.highlightFeedback) return 'rgba(0,0,0,.1)';
+    if (!pv?.plotViewCtx?.highlightFeedback) return 'rgba(0,0,0,.1)';
     if (isActivePlotView(visRoot,pv.plotId) || pv.subHighlight) {
         return manyPlots ? `rgba(${theme.vars.palette.warning.mainChannel} / 1)` : 'rgba(0,0,0,.02)';
     }
     const group= getPlotGroupById(visRoot,pv.plotGroupId);
     if (group?.overlayColorLock) return 'rgba(0, 0, 0, .1)';
     else return 'rgba(0,0,0,.2)';
+}
+
+export function getImageViewerDecorateSx(plotId, pv, vr) {
+    const manyPlots= hasManyPlots(pv, vr);
+    const expandedToSingle= vr.expandedMode===ExpandType.SINGLE;
+    return (theme) => ({
+        width: !manyPlots ? 1 : 'calc(100% - 4px)',
+        bottom: 0,
+        top: 0,
+        overflow: 'hidden',
+        position: 'absolute',
+        borderStyle: !manyPlots ? undefined : (pv?.subHighlight && !isActivePlotView(vr, plotId)) ? 'dashed' : 'solid',
+        borderWidth: (expandedToSingle || !manyPlots) ? '0 0 0 0' : '1px',
+        borderRadius: manyPlots ? '5px' : undefined,
+        borderColor: getBorderColor(manyPlots, theme, pv, vr),
+    });
 }
 
 
@@ -268,7 +284,6 @@ const ImageViewerDecorate= memo((props) => {
 
     const showDelete= pv.plotViewCtx.userCanDeletePlots;
     const ctxToolbar= contextToolbar(pv,drawLayersAry,extensionList,width, makeToolbar);
-    const expandedToSingle= (visRoot.expandedMode===ExpandType.SINGLE);
     const plot= primePlot(pv);
     const iWidth= Math.trunc(width);
     const iHeight=Math.trunc(height);
@@ -276,22 +291,7 @@ const ImageViewerDecorate= memo((props) => {
     const brief= briefAnno.includes(pv.plotViewCtx.annotationOps);
 
     const outerStyle= { width: '100%', height: '100%', overflow:'hidden', position:'relative'};
-
-    const innerStyle= (theme) => {
-        const manyPlots= hasManyPlots(pv,visRoot);
-        const active= isActivePlotView(visRoot,pv.plotId);
-        return {
-            width: !manyPlots  ? 1 : 'calc(100% - 4px)',
-            bottom: 0,
-            top: 0,
-            overflow: 'hidden',
-            position: 'absolute',
-            borderStyle: !manyPlots ? undefined : (pv.subHighlight && !active) ? 'dashed' : 'solid' ,
-            borderWidth: (expandedToSingle || !manyPlots) ? '0 0 0 0' : '1px',
-            borderRadius: manyPlots ? '5px' : undefined,
-            borderColor: getBorderColor(manyPlots, theme, pv,visRoot),
-        };
-    };
+    const innerStyle= getImageViewerDecorateSx(pv.plotId, pv, visRoot);
 
     const makeActive= () => pv?.plotId && dispatchChangeActivePlotView(pv.plotId,MOUSE_CLICK_REASON);
     const showZoom= mousePlotId===pv?.plotId;

--- a/src/firefly/js/visualize/iv/ImageViewerStatus.jsx
+++ b/src/firefly/js/visualize/iv/ImageViewerStatus.jsx
@@ -99,7 +99,7 @@ export function ImageViewStatusPanel(props) {
                         </Box>
                     </Stack>
                 </Card>
-            }>
+            }
         </Box>
     );
 }


### PR DESCRIPTION
See ife PR: https://github.com/IPAC-SW/irsa-ife/pull/464

- Refactored `BgMaskPanel`:
   - made button layout responsive via CSS container queries so it adapts to the panel's own width esp when panel becomes small in image grid
   - made it accept a `renderError(errorMsg, infoButton)` render prop for custom error UIs, with the existing default behavior unchanged for all other callers

- I noticed two run-time issues when loading SP results because of accessing prop on undefined, fixed them by using `?.`


Do some regression testing with long running table search and resize the table width to test responsive layout.