### PR TITLE
Firefly-1999: mask should be read as long

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/DirectStretchUtils.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/DirectStretchUtils.java
@@ -49,7 +49,7 @@ public class DirectStretchUtils {
     public static StretchDataInfo getStretchDataMask(PlotState state, ActiveFitsReadGroup frGroup, int tileSize, long maskBits)
             throws Exception {
         FitsRead fr= frGroup.getFitsRead(state.firstBand());
-        float [] flip1d= fr.getRawFloatAryFlipped(false);
+        long [] flip1d= fr.getRawLongAryFlipped(false);
         StretchVars sv= getStretchVars(fr,tileSize, CompressType.FULL);
         List<ImageMask> maskList=  new ArrayList<>();
 
@@ -323,14 +323,14 @@ public class DirectStretchUtils {
     private static class StretchMaskTile {
         byte[] result;
 
-        Void stretch(StretchTileDef stdef, List<ImageMask> maskList, final float [] float1d, final int naxis1) {
+        Void stretch(StretchTileDef stdef, List<ImageMask> maskList, final long [] long1d, final int naxis1) {
             byte [] byteAry= new byte[stdef.width * stdef.height];
             int[] pixelhist = new int[256];
             int lastPixel = stdef.x + stdef.width -1;
             int lastLine = stdef.y + stdef.height -1;
             ImageMask[] iMasks= maskList.toArray(new ImageMask[0]);
             ImageStretch.stretchPixelsForMask(stdef.x, lastPixel, stdef.y, lastLine, naxis1,
-                    (byte) 255, float1d, byteAry, pixelhist, iMasks);
+                    long1d, byteAry, pixelhist, iMasks);
             this.result = byteAry;
             return null;
         }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/VisServerOps.java
@@ -359,7 +359,7 @@ public class VisServerOps {
                 FitsRead[] fr= FitsCacher.loadFits(cropFits, cropFile).getFitReadAry();
 
 
-                if (saveCropFits) FitsReadUtil.writeFitsFile(cropFile,fr,cropFits);
+                if (saveCropFits) FitsReadUtil.writeFitsFileForCropOnly(cropFile,fr,cropFits);
 
 
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageData.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageData.java
@@ -191,11 +191,12 @@ public class ImageData implements Serializable {
     private void constructImage(FitsRead[] fitsReadAry)  {
         DataBufferByte db= (DataBufferByte) getRaster().getDataBuffer();
         if (imageType ==ImageType.TYPE_8_BIT) {
-            if (imageMasks!=null && imageMasks.length!=0){
-                bufferedImage = new BufferedImage(getColorModel(), getRaster(), false, null);
-                fitsReadAry[0].doStretchMask( db.getData(0), x, lastPixel, y, lastLine, imageMasks);
-            }
-            else {
+            // make is not used in this mode anymore
+//            if (imageMasks!=null && imageMasks.length!=0){
+//                bufferedImage = new BufferedImage(getColorModel(), getRaster(), false, null);
+//                fitsReadAry[0].doStretchMask( db.getData(0), x, lastPixel, y, lastLine, imageMasks);
+//            }
+//            else {
                 bufferedImage = new BufferedImage(getColorModel(), getRaster(), false, null);
                 ImageHeader imHead= new ImageHeader(fitsReadAry[0].getHeader());
                 ImageStretch.stretchPixels8Bit(rangeValuesAry[Band.NO_BAND.getIdx()],
@@ -203,7 +204,7 @@ public class ImageData implements Serializable {
                                                imHead,  fitsReadAry[0].getHistogram(),
                                                x, lastPixel, y, lastLine );
 
-            }
+//            }
         }
         else if (imageType ==ImageType.TYPE_24_BIT) {
             float[][] float1dAry= new float[3][];

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageMask.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/ImageMask.java
@@ -113,7 +113,7 @@ public class ImageMask {
      * @param  mask value to check
      * @return <code>true</code> if any are set
      */
-    public final boolean isSet(final int mask) {
+    public final boolean isSet(final long mask) {
         return (check & mask) != 0;
     }
 

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsRead.java
@@ -40,6 +40,7 @@ public class FitsRead implements Serializable, HasSizeOf {
     private final int totalImageHdusInFile;
     private ImageHDU hdu;
     private float[] float1d;
+    private long[] long1d;
     private final Header header;
     private Histogram hist;
     private final File file;
@@ -117,8 +118,14 @@ public class FitsRead implements Serializable, HasSizeOf {
 
     public float[] getRawFloatAry() {
         if (float1d!=null) return float1d;
-        float1d= FitsReadUtil.dataArrayFromHDUAndPlane(this.file,this.hduNumber, planeNumber);
+        float1d= FitsReadUtil.dataArrayFromHDUAndPlaneAsFloat(this.file,this.hduNumber, planeNumber);
         return float1d;
+    }
+
+    public long[] getRawLongAry() {
+        if (long1d!=null) return long1d;
+        long1d= (long[])FitsReadUtil.dataArrayFromHDUAndPlane(this.file,this.hduNumber, planeNumber, Long.TYPE);
+        return long1d;
     }
 
     private String makeSyncKey() {
@@ -129,12 +136,41 @@ public class FitsRead implements Serializable, HasSizeOf {
     public float[] getRawFloatAryFlipped(boolean cacheOnSecondRequest) {
         float[] retAry;
         synchronized (syncKey) {
+            if (long1d!=null) {
+                float1d= null;
+                long1d= null;
+                dataFlipped= false;
+            }
             if (float1d==null && cacheOnSecondRequest && !requestedFlipped) {
-                retAry= FitsReadUtil.dataArrayFromHDUAndPlane(this.file,this.hduNumber, planeNumber);
+                retAry= FitsReadUtil.dataArrayFromHDUAndPlaneAsFloat(this.file,this.hduNumber, planeNumber);
                 flipInPlace(retAry,getNaxis1(),getNaxis2());
             }
             else {
                 retAry= getRawFloatAry();
+                if (!dataFlipped) {
+                    flipInPlace(retAry,getNaxis1(),getNaxis2());
+                    dataFlipped = true;
+                }
+            }
+            requestedFlipped= true;
+            return retAry;
+        }
+    }
+
+    public long[] getRawLongAryFlipped(boolean cacheOnSecondRequest) {
+        long[] retAry;
+        synchronized (syncKey) {
+            if (float1d!=null) {
+                float1d= null;
+                long1d= null;
+                dataFlipped= false;
+            }
+            if (long1d==null && cacheOnSecondRequest && !requestedFlipped) {
+                retAry= (long[])FitsReadUtil.dataArrayFromHDUAndPlane(this.file,this.hduNumber, planeNumber, Long.TYPE);
+                flipInPlace(retAry,getNaxis1(),getNaxis2());
+            }
+            else {
+                retAry= getRawLongAry();
                 if (!dataFlipped) {
                     flipInPlace(retAry,getNaxis1(),getNaxis2());
                     dataFlipped = true;
@@ -170,6 +206,20 @@ public class FitsRead implements Serializable, HasSizeOf {
         }
     }
 
+    private static void flipInPlace(long [] long1d, int naxis1, int naxis2) {
+        int idx=0;
+        long val;
+        for (int y= naxis2-1; y>=naxis2/2; y--) {
+            for (int x= 0; x<naxis1; x++) {
+                val= long1d[idx];
+                long1d[idx]= long1d[y*naxis1+x];
+                long1d[y*naxis1+x]= val;
+                idx++;
+                if (idx==(naxis1*naxis2)/2) return;
+            }
+        }
+    }
+
     private static float [] flipFloatArray(float [] float1d, int naxis1, int naxis2) {
         float [] flipped= new float[float1d.length];
         int idx=0;
@@ -197,6 +247,7 @@ public class FitsRead implements Serializable, HasSizeOf {
      * @param startLine start line
      * @param lastLine list line
      * @param lsstMasks mask array
+     * @deprecated
      */
     public synchronized void doStretchMask(
                                        byte[] pixelData,
@@ -206,10 +257,9 @@ public class FitsRead implements Serializable, HasSizeOf {
                                        int lastLine,
                                        ImageMask[] lsstMasks)  {
 
-        byte blank_pixel_value = (byte) 255;
         int[] pixelhist = new int[256];
         ImageStretch.stretchPixelsForMask(startPixel, lastPixel, startLine, lastLine, this.getNaxis1(),
-                        blank_pixel_value, getRawFloatAry(), pixelData, pixelhist, lsstMasks);
+                        getRawLongAry(), pixelData, pixelhist, lsstMasks);
     }
 
 
@@ -330,8 +380,10 @@ public class FitsRead implements Serializable, HasSizeOf {
      * physical_values = BZERO + BSCALE × array_value	(5.3)
      * <p>
      * This method return the physical data value at the pixels as an one dimensional array
+     *
+     * This function should not be used for any new development
      */
-    public float[] getDataFloat() {
+    public float[] getDataFloatForOlderUtils() {
         float[] floatAry= getRawFloatAryStandard();
         if (getBscale()==1.0 && getBzero()==0) return floatAry;
         float[] fData = new float[floatAry.length];

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/FitsReadUtil.java
@@ -317,12 +317,18 @@ public class FitsReadUtil {
 
     }
 
-    public static float[] dataArrayFromHDUAndPlane(File file, int hduNumber, int planeNumber) {
+    public static float[] dataArrayFromHDUAndPlaneAsFloat(File file, int hduNumber, int planeNumber) {
+        return (float [])dataArrayFromHDUAndPlane(file, hduNumber, planeNumber, Float.TYPE);
+    }
+
+
+
+    public static Object dataArrayFromHDUAndPlane(File file, int hduNumber, int planeNumber, Class<?> arrayType) {
         try (Fits fits = new Fits(file)) {
             BasicHDU<?> hdu= fits.read()[hduNumber];
             if (!(hdu instanceof ImageHDU)) return null;
             var h= hdu.getHeader();
-            return (float [])dataArrayFromFitsFile((ImageHDU)hdu, 0,0,getNaxis1(h),getNaxis2(h), planeNumber,Float.TYPE);
+            return dataArrayFromFitsFile((ImageHDU)hdu, 0,0,getNaxis1(h),getNaxis2(h), planeNumber,arrayType);
         }
         catch (Exception e) {
             Logger.getLogger("FitsRead").error(e,"Could not read FITS data");
@@ -392,11 +398,11 @@ public class FitsReadUtil {
         return new ImageHDU(newHeader,  null);
     }
 
-    public static void writeFitsFile(File outfile, FitsRead[] fitsReadAry, Fits refFits) throws IOException {
+    public static void writeFitsFileForCropOnly(File outfile, FitsRead[] fitsReadAry, Fits refFits) throws IOException {
         Fits outputFits = new Fits();
         for (FitsRead fr : fitsReadAry) {
             BasicHDU<?> refHdu = refFits.getHDU(0);
-            ImageHDU imageHDU = makeImageHDU(refHdu.getHeader(), FitsReadUtil.getImageData(refHdu, fr.getDataFloat()));
+            ImageHDU imageHDU = makeImageHDU(refHdu.getHeader(), FitsReadUtil.getImageData(refHdu, fr.getDataFloatForOlderUtils()));
             outputFits.addHDU(imageHDU);
         }
         outputFits.write(outfile);

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/Geom.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/Geom.java
@@ -166,7 +166,7 @@ public class Geom {
                 throw new FitsException("Image contains no projection info");
 
             try {
-                in_data = inFitsRead.getDataFloat();
+                in_data = inFitsRead.getDataFloatForOlderUtils();
                 //System.out.println("creating in_data  in_data.length = " + in_data.length);
             } catch (OutOfMemoryError e) {
                 GeomException ge = new GeomException(

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/ImageStretch.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/plotdata/ImageStretch.java
@@ -542,8 +542,7 @@ public class ImageStretch {
      * @param startLine (tile info) start line
      * @param lastLine (tile info) end line
      * @param naxis1 number of pixels in a line
-     * @param blank_pixel_value blank pixel value
-     * @param float1dArray array of raw values
+     * @param long1dArray array of raw values
      * @param pixeldata array to populate
      */
     public static void stretchPixelsForMask(int startPixel,
@@ -551,8 +550,7 @@ public class ImageStretch {
                                             int startLine,
                                             int lastLine,
                                             int naxis1,
-                                            byte blank_pixel_value,
-                                            float[] float1dArray,
+                                            long[] long1dArray,
                                             byte[] pixeldata,
                                             int[] pixelhist,
                                             ImageMask[] lsstMasks) {
@@ -567,36 +565,32 @@ public class ImageStretch {
 
             for (int index = start_index; index <= last_index; index++) {
 
-                if (Double.isNaN(float1dArray[index])) { //original pixel value is NaN, assign it to blank
-                    pixeldata[pixelCount] = blank_pixel_value;
-                } else {
-                    /*
-                     The IndexColorModel is designed in the way that each pixel[index] contains the color in
-                     lsstMasks[index].  In pixel index0, it stores the lsstMasks[0]'s color. Thus, assign
-                     pixelData[pixelCount]=index of the lsstMasks, this pixel is going to be plotted using the
-                     color stored there.  The color model is indexed.  For 8 bit image, it has 256 maximum colors.
-                     For detail, see the indexColorModel defined in ImageData.java.
-                     */
-                    int maskPixel= (int)float1dArray[index];
-                    if (combinedMask.isSet(maskPixel )) {
-                        for (int i = 0; i < lsstMasks.length; i++) {
-                            if (lsstMasks[i].isSet(maskPixel)) {
-                                pixeldata[pixelCount] = (byte) i;
-                                break;
-                            }
+                /*
+                 The IndexColorModel is designed in the way that each pixel[index] contains the color in
+                 lsstMasks[index].  In pixel index0, it stores the lsstMasks[0]'s color. Thus, assign
+                 pixelData[pixelCount]=index of the lsstMasks, this pixel is going to be plotted using the
+                 color stored there.  The color model is indexed.  For 8 bit image, it has 256 maximum colors.
+                 For detail, see the indexColorModel defined in ImageData.java.
+                 */
+                long maskPixel= long1dArray[index];
+                if (combinedMask.isSet(maskPixel )) {
+                    for (int i = 0; i < lsstMasks.length; i++) {
+                        if (lsstMasks[i].isSet(maskPixel)) {
+                            pixeldata[pixelCount] = (byte) i;
+                            break;
                         }
                     }
-                    else {
-
-                        /*
-                        The transparent color is stored at pixel[lsstMasks.length].  The pixelData[pixelCount]=(byte) lsstMasks.length,
-                        this pixel will be transparent.
-                         */
-                        pixeldata[pixelCount]= (byte) lsstMasks.length;
-                    }
-
-                    pixelhist[pixeldata[pixelCount] & 0xff]++;
                 }
+                else {
+
+                    /*
+                    The transparent color is stored at pixel[lsstMasks.length].  The pixelData[pixelCount]=(byte) lsstMasks.length,
+                    this pixel will be transparent.
+                     */
+                    pixeldata[pixelCount]= (byte) lsstMasks.length;
+                }
+
+                pixelhist[pixeldata[pixelCount] & 0xff]++;
                 pixelCount++;
 
             }

--- a/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerItemView.jsx
@@ -5,16 +5,16 @@
 import {isString} from 'lodash';
 import React from 'react';
 import {Box, ChipDelete, Divider, Stack, Switch, Tooltip, Typography} from '@mui/joy';
-import PropTypes from 'prop-types';
+import {object, any, bool, func, number, string} from 'prop-types';
 import {getTitleTag, makeColorChange, makeShape} from './DrawLayerUIComponents';
 import Layers from '@mui/icons-material/Layers';
 
 
 export function DrawLayerItemView({maxTitleChars, lastItem, deleteLayer,
-                            color, canUserChangeColor, canUserDelete, title, helpLine,
-                            isPointData, drawingDef, autoFormatTitle, canUserHide=true,
+                            color, canUserChangeColor=true, canUserDelete=false, title, helpLine='',
+                            isPointData=false, drawingDef, autoFormatTitle=true, canUserHide=true,
                             packWithNext=false,
-                            visible, changeVisible, modifyColor, modifyShape, UIComponent}) {
+                            visible, changeVisible, modifyColor, modifyShape, UIComponent=undefined}) {
 
     const sx= { width:1, height:1, pr:1.5, position: 'relative', overflow:'hidden', whiteSpace : 'nowrap'};
     const useDivide= lastItem || !packWithNext;
@@ -44,24 +44,24 @@ export function DrawLayerItemView({maxTitleChars, lastItem, deleteLayer,
 
 
 DrawLayerItemView.propTypes= {
-    maxTitleChars  : PropTypes.number.isRequired,
-    lastItem       : PropTypes.bool.isRequired,
-    visible        : PropTypes.bool.isRequired,
-    canUserChangeColor : PropTypes.any.isRequired,
-    color          : PropTypes.string.isRequired,
-    title          : PropTypes.any.isRequired,
-    helpLine       : PropTypes.string.isRequired,
-    canUserDelete  : PropTypes.bool.isRequired,
-    canUserHide    : PropTypes.bool,
-    isPointData    : PropTypes.bool.isRequired,
-    drawingDef     : PropTypes.object,
-    deleteLayer    : PropTypes.func,
-    changeVisible  : PropTypes.func,
-    modifyColor    : PropTypes.func,
-    modifyShape    : PropTypes.func,
-    UIComponent    : PropTypes.object,
-    autoFormatTitle: PropTypes.bool,
-    packWithNext: PropTypes.bool,
+    maxTitleChars  : number.isRequired,
+    lastItem       : bool.isRequired,
+    visible        : bool.isRequired,
+    canUserChangeColor : any,
+    color          : string.isRequired,
+    title          : any.isRequired,
+    helpLine       : string.isRequired,
+    canUserDelete  : bool,
+    canUserHide    : bool,
+    isPointData    : bool,
+    drawingDef     : object,
+    deleteLayer    : func,
+    changeVisible  : func,
+    modifyColor    : func,
+    modifyShape    : func,
+    UIComponent    : object,
+    autoFormatTitle: bool,
+    packWithNext: bool,
 };
 
 
@@ -105,7 +105,7 @@ export function DrawLayerLegendView({maxTitleChars, color, canUserChangeColor, t
 
 
 function makeColorChangeUIElement(color, canUserChangeColor, modifyColor, text) {
-    return canUserChangeColor ? makeColorChange(color,modifyColor, {width: 'calc(33%)'},text) : false;
+    return canUserChangeColor ? makeColorChange(color,modifyColor, text) : false;
 }
 
 function makePointDataShape(isPointData, drawingDef, modifyShape) {
@@ -113,17 +113,13 @@ function makePointDataShape(isPointData, drawingDef, modifyShape) {
 }
 
 function makeHelpLine(helpLine) {
-    if (helpLine) {
-        return (
-            <Typography {...{level:'body-sm',
-                paddingBottom:1,maxWidth:'30em',ml:2, whiteSpace: 'normal'}}>
-                {helpLine}
-            </Typography>
-        );
-    }
-    else {
-        return false;
-    }
+    if (!helpLine) return false;
+    return (
+        <Typography {...{level:'body-sm',
+            paddingBottom:1,maxWidth:'30em',ml:2, whiteSpace: 'normal'}}>
+            {helpLine}
+        </Typography>
+    );
 }
 
 function makeDelete(canUserDelete,deleteLayer) {
@@ -139,4 +135,3 @@ function makeDelete(canUserDelete,deleteLayer) {
     );
 
 }
-

--- a/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerPanelView.jsx
@@ -154,20 +154,15 @@ function makeImageLayerItemAry(pv, maxTitleChars, hasLast, mouseOverMaskValue) {
     const retAry= pv.overlayPlotViews.map( (opv,idx) => (
         <DrawLayerItemView key={'MaskControl-'+idx}
                            maxTitleChars={maxTitleChars}
-                           helpLine={opv.description ?? ''}
+                           helpLine={opv.description}
                            lastItem={hasLast ? idx===last : false}
-                           canUserDelete={true}
-                           canUserChangeColor={true}
-                           isPointData={false}
                            packWithNext= {idx!==last}
                            color={opv.colorAttributes.color}
-                           autoFormatTitle={true}
                            title= {makeOverlayTitle(opv, Boolean(mouseOverMaskValue & opv.maskValue), dataWidth, dataHeight) }
                            visible={opv.visible}
                            modifyColor={() => modifyMaskColor(opv)}
                            deleteLayer={() => deleteMaskLayer(opv)}
                            changeVisible={() => setMaskVisibleInGroup(opv, !opv.visible)}
-                           UIComponent={null}
     />));
     return retAry;
 }

--- a/src/firefly/js/visualize/ui/DrawLayerUIComponents.jsx
+++ b/src/firefly/js/visualize/ui/DrawLayerUIComponents.jsx
@@ -19,7 +19,7 @@ import {
 const symbolSize= 10;
 
 
-export function makeColorChange(color, modifyColor, sx= {}, text='Color') {
+export function makeColorChange(color, modifyColor, text='Color') {
     const feedBackStyle= { width:symbolSize, height:symbolSize, backgroundColor: color};
     if (!text) {
         return <Chip onClick={() => modifyColor()}> <div style={feedBackStyle} /> </Chip> ;
@@ -138,7 +138,7 @@ export function modifyDrawColor(inDl, plotId, tbl_id, postTitle, topComponent) {
     });
 }
 
-export function getTitleTag(title, maxTitleChars, autoFormatTitle, level, sx, maxMax=30) {
+export function getTitleTag(title, maxTitleChars, autoFormatTitle, level=undefined, sx=undefined, maxMax=30) {
     if (!autoFormatTitle) {
         return isFunction(title) ? title() : title;
     }

--- a/src/firefly/test/edu/caltech/ipac/firefly/util/FitsValidation.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/util/FitsValidation.java
@@ -45,7 +45,7 @@ public class FitsValidation extends ConfigTest{
         FitsRead[] fitsReads = FitsReadFactory.createFitsReadArray(calculatedFits);
         FitsRead[] expectedFitsRead = FitsReadFactory.createFitsReadArray(expectedFits);
        for (int i=0;  i<fitsReads.length; i++){
-            Assert.assertArrayEquals(fitsReads[i].getDataFloat(), expectedFitsRead[i].getDataFloat(), (float) delta);
+            Assert.assertArrayEquals(fitsReads[i].getDataFloatForOlderUtils(), expectedFitsRead[i].getDataFloatForOlderUtils(), (float) delta);
         }
 
     }

--- a/src/firefly/test/edu/caltech/ipac/visualize/plot/CropTestBase.java
+++ b/src/firefly/test/edu/caltech/ipac/visualize/plot/CropTestBase.java
@@ -61,7 +61,7 @@ public class CropTestBase {
         FitsRead[] fitsReads = FitsReadFactory.createFitsReadArray(calculatedFits);
         FitsRead[] expectedFitsRead = FitsReadFactory.createFitsReadArray(expectedFits);
         for (int i=0;  i<fitsReads.length; i++){
-            Assert.assertArrayEquals(fitsReads[i].getDataFloat(), expectedFitsRead[i].getDataFloat(), (float) delta);
+            Assert.assertArrayEquals(fitsReads[i].getDataFloatForOlderUtils(), expectedFitsRead[i].getDataFloatForOlderUtils(), (float) delta);
         }
 
     }

--- a/src/firefly/test/edu/caltech/ipac/visualize/plot/FlipXYTest.java
+++ b/src/firefly/test/edu/caltech/ipac/visualize/plot/FlipXYTest.java
@@ -227,7 +227,7 @@ public class FlipXYTest extends FitsValidation {
 
         validateSingleHDU(fitsRead.getHDU(), flipedTwiceFR.getHDU());
 
-        Assert.assertArrayEquals(fitsRead.getDataFloat(), flipedTwiceFR.getDataFloat(), (float) delta);
+        Assert.assertArrayEquals(fitsRead.getDataFloatForOlderUtils(), flipedTwiceFR.getDataFloatForOlderUtils(), (float) delta);
 
     }
 
@@ -251,7 +251,7 @@ public class FlipXYTest extends FitsValidation {
         FitsRead flipedTwiceFR = flipY_2.doFlip();
 
         validateSingleHDU(fitsRead.getHDU(), flipedTwiceFR.getHDU());
-        Assert.assertArrayEquals(fitsRead.getDataFloat(), flipedTwiceFR.getDataFloat(), (float) delta);
+        Assert.assertArrayEquals(fitsRead.getDataFloatForOlderUtils(), flipedTwiceFR.getDataFloatForOlderUtils(), (float) delta);
     }
 
     @Test
@@ -273,7 +273,7 @@ public class FlipXYTest extends FitsValidation {
             FitsRead  expectedFlipXY = FitsReadFactory.createFitsReadArray(inFits)[0];
 
             validateSingleHDU(expectedFlipXY.getHDU(),flipedXY.getHDU());
-            Assert.assertArrayEquals(expectedFlipXY.getDataFloat(),flipedXY.getDataFloat(), (float) delta);
+            Assert.assertArrayEquals(expectedFlipXY.getDataFloatForOlderUtils(),flipedXY.getDataFloatForOlderUtils(), (float) delta);
         } catch (Exception e) {
             e.printStackTrace();
             throw e;

--- a/src/firefly/test/edu/caltech/ipac/visualize/plot/HistogramTest.java
+++ b/src/firefly/test/edu/caltech/ipac/visualize/plot/HistogramTest.java
@@ -267,7 +267,7 @@ public class HistogramTest extends ConfigTest {
         String inFitsName = FileLoader.getDataPath(HistogramTest.class)+fileName;
         FitsRead fitsRead = FileLoader.loadFitsRead(HistogramTest.class, fileName);
         ImageHeader imageHeader = new ImageHeader(fitsRead.getHeader());
-        inData = fitsRead.getDataFloat();
+        inData = fitsRead.getDataFloatForOlderUtils();
 
         float[] float1d = new float[inData.length];
         //get the raw data
@@ -344,7 +344,7 @@ public class HistogramTest extends ConfigTest {
         String inFitsName = FileLoader.getDataPath(HistogramTest.class)+fileName;
         FitsRead fitsRead = FileLoader.loadFitsRead(HistogramTest.class, fileName);
         ImageHeader imageHeader = new ImageHeader(fitsRead.getHeader());
-        float[] inData = fitsRead.getDataFloat();
+        float[] inData = fitsRead.getDataFloatForOlderUtils();
 
         float[] float1d = new float[inData.length];
         //get the raw data

--- a/src/firefly/test/edu/caltech/ipac/visualize/plot/ImageDataTest.java
+++ b/src/firefly/test/edu/caltech/ipac/visualize/plot/ImageDataTest.java
@@ -176,10 +176,10 @@ public class ImageDataTest {
         compareImage(expectedImage,calculatedImage);
 
 
-        //Test the ImageData withmask
-        ImageData  imageDataWithMask = new ImageData(imageMasks, rangeValues, 0,0, 100, 100);
-        BufferedImage calculatedImageWithMask  = imageDataWithMask.getImage(frArray);
-        compareImage(expectedImageWithMask,calculatedImageWithMask);
+        //Test the ImageData withmask - make are no long used in this more
+//        ImageData  imageDataWithMask = new ImageData(imageMasks, rangeValues, 0,0, 100, 100);
+//        BufferedImage calculatedImageWithMask  = imageDataWithMask.getImage(frArray);
+//        compareImage(expectedImageWithMask,calculatedImageWithMask);
 
     }
 

--- a/src/firefly/test/edu/caltech/ipac/visualize/plot/ZscaleTest.java
+++ b/src/firefly/test/edu/caltech/ipac/visualize/plot/ZscaleTest.java
@@ -39,7 +39,7 @@ public class ZscaleTest {
 
         Fits fits = FileLoader.loadFits(ZscaleTest.class,filename );
         FitsRead[] fry = FitsReadFactory.createFitsReadArray(fits);
-        float1d = fry[0].getDataFloat();
+        float1d = fry[0].getDataFloatForOlderUtils();
         imageHeader = new ImageHeader(fry[0].getHeader());
 
     }


### PR DESCRIPTION
#### [Firefly-1999](https://jira.ipac.caltech.edu/browse/FIREFLY-1999): mask should be read as long

- data is being lost when an int (converted to a float) with a high range is read. Mask should be read as long

#### Testing

- there are two file in the ticket, test with `level2a_2026W12_2A_0212_2D3_spx_l2a-v2-2026-098.fits`
- zoom into the bottom left
- go to drawing layer and enable mask, the show the bit `#0`
- the missing streak (show in the ticket) should show up.