### PR TITLE
FIREFLY-2003: Add custom default columns for Alert Viewer

### DIFF
--- a/src/firefly/html/alertviewer.html
+++ b/src/firefly/html/alertviewer.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <link rel="icon" type="image/x-icon" href="images/fftools-logo-16x16.png">
+    <link rel="icon" type="image/x-icon" href="${pageContext.request.contextPath}/images/fftools-logo-16x16.png">
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <title>Alert Viewer</title>
 
@@ -15,7 +15,7 @@
             }
         };
     </script>
-    <script  type="text/javascript" src="firefly_loader.js"></script>
+    <script  type="text/javascript" src="${pageContext.request.contextPath}/firefly_loader.js"></script>
 </head>
 
 <body style="margin: 0">
@@ -28,5 +28,4 @@
 </body>
 
 </html>
-
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/alert/AlertViewerSearchProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/alert/AlertViewerSearchProcessor.java
@@ -7,6 +7,7 @@ import edu.caltech.ipac.firefly.core.FileAnalysis;
 import edu.caltech.ipac.firefly.core.FileAnalysisReport;
 import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.ServerRequest;
+import edu.caltech.ipac.firefly.data.table.MetaConst;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.query.JsonStringProcessor;
@@ -14,6 +15,9 @@ import edu.caltech.ipac.firefly.server.query.ParamDoc;
 import edu.caltech.ipac.firefly.server.query.SearchProcessorImpl;
 import edu.caltech.ipac.firefly.server.util.LockingRetrieve;
 import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.DataType;
+import edu.caltech.ipac.table.TableUtil;
 import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.StringUtils;
 import org.json.simple.JSONArray;
@@ -21,8 +25,10 @@ import org.json.simple.JSONObject;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import static edu.caltech.ipac.firefly.core.FileAnalysisReport.ReportType.Details;
 import static edu.caltech.ipac.firefly.core.FileAnalysisReport.Type.ErrorResponse;
@@ -41,6 +47,10 @@ public class AlertViewerSearchProcessor extends JsonStringProcessor {
     public static final String RESPONSEFORMAT = "RESPONSEFORMAT";
     private static final String FITS_RESPONSE_FORMAT = "fits";
     private static final String ALERT_SERVICE_BASE_URL_PROP = "alert.viewer.fits.service.url";
+    private static final int DIASOURCE_TBL_INDEX = 1; //the main table on the right is the DIASOURCE tbl
+    private static final String DEFAULT_CHART_X = "midpointMjdTai";
+    private static final String DEFAULT_CHART_Y = "psfFlux";
+    private static final String DEFAULT_CHART_Y_ERROR = "psfFluxErr";
 
     @Override
     public boolean doCache() {
@@ -136,7 +146,14 @@ public class AlertViewerSearchProcessor extends JsonStringProcessor {
             JSONArray entries = new JSONArray();
             for (int i = 0; i < Math.min(parts.size(), 5); i++) {
                 FileAnalysisReport.Part part = parts.get(i);
-                entries.add(makeEntry(part, i, fileKey, fileName));
+                JSONObject entry = makeEntry(part, i, fileKey, fileName);
+                if (i == DIASOURCE_TBL_INDEX) {
+                    JSONObject chartMeta = buildDiaSourceTableChartMeta(fileInfo, part);
+                    if (chartMeta != null) {
+                        entry.put("chartMeta", chartMeta);
+                    }
+                }
+                entries.add(entry);
             }
 
             out.put("entries", entries);
@@ -152,20 +169,72 @@ public class AlertViewerSearchProcessor extends JsonStringProcessor {
         return out.toJSONString();
     }
 
-    private static JSONObject makeEntry(FileAnalysisReport.Part part, int fallbackIdx, String fileKey, String fileName) {
+    private static JSONObject makeEntry(FileAnalysisReport.Part part, int entryIndex, String fileKey, String fileName) {
         JSONObject entry = new JSONObject();
         entry.put("type", part.getType().name());
         entry.put("desc", part.getDesc());
-        entry.put("extNum", getExtNum(part, fallbackIdx));
+        entry.put("extNum", getExtNum(part, entryIndex));
         //have each entry take a fileKey and fileName in case the viewer needs to retrieve the file for that specific entry (e.g. if it's an image or a table that can be retrieved as a separate file)
         if (!StringUtils.isEmpty(fileKey)) entry.put("fileKey", fileKey);
         if (!StringUtils.isEmpty(fileName)) entry.put("fileName", fileName);
         return entry;
     }
 
-    private static int getExtNum(FileAnalysisReport.Part part, int fallbackIdx) {
+    private static JSONObject buildDiaSourceTableChartMeta(FileInfo fileInfo, FileAnalysisReport.Part part) {
+        if (fileInfo == null || fileInfo.getFile() == null || part == null) return null;
+
+        try {
+            int extNum = getExtNum(part, DIASOURCE_TBL_INDEX);
+            DataGroup dg = TableUtil.readAnyFormat(fileInfo.getFile(), extNum, null);
+            if (dg == null || !hasRequiredChartColumns(dg)) return null;
+            boolean hasYError = hasColumn(dg, DEFAULT_CHART_Y_ERROR);
+            return makeDefaultChartMeta(hasYError);
+        } catch (Exception e) {
+            LOGGER.warn(e, "Unable to validate alert chart columns for default chart metadata");
+            return null;
+        }
+    }
+
+    private static boolean hasRequiredChartColumns(DataGroup dg) {
+        return hasColumn(dg, DEFAULT_CHART_X) && hasColumn(dg, DEFAULT_CHART_Y);
+    }
+
+    private static boolean hasColumn(DataGroup dg, String columnName) {
+        if (dg == null || columnName == null) return false;
+        return Arrays.stream(dg.getDataDefinitions())
+                .map(DataType::getKeyName)
+                .filter(Objects::nonNull)
+                .anyMatch(name -> name.equalsIgnoreCase(columnName));
+    }
+
+
+    private static JSONObject makeDefaultChartMeta(boolean includeYError) {
+        JSONObject trace = new JSONObject();
+        trace.put("x", "tables::" + DEFAULT_CHART_X);
+        trace.put("y", "tables::" + DEFAULT_CHART_Y);
+        trace.put("mode", "markers");
+
+        if (includeYError) {
+            JSONObject errorY = new JSONObject();
+            errorY.put("array", "tables::" + DEFAULT_CHART_Y_ERROR);
+            trace.put("error_y", errorY);
+        }
+
+        JSONArray data = new JSONArray();
+        data.add(trace);
+
+        JSONObject defaultChartDef = new JSONObject();
+        defaultChartDef.put("data", data);
+
+        JSONObject chartMeta = new JSONObject();
+        chartMeta.put(MetaConst.DEFAULT_CHART_DEF, defaultChartDef.toJSONString());
+        return chartMeta;
+    }
+
+
+    private static int getExtNum(FileAnalysisReport.Part part, int entryIndex) {
         return part.getFileLocationIndex() > -1 ? part.getFileLocationIndex() :
-                part.getIndex() > -1 ? part.getIndex() : fallbackIdx;
+                part.getIndex() > -1 ? part.getIndex() : entryIndex;
     }
 
     private static String makeError(String source, String message) {

--- a/src/firefly/js/apps/alertviewer/AlertUploadPanel.jsx
+++ b/src/firefly/js/apps/alertviewer/AlertUploadPanel.jsx
@@ -1,7 +1,7 @@
 import React, {useContext, useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
 import {showInfoPopup} from 'firefly/ui/PopupUtil';
-import {Button, IconButton, Input, Stack, Typography} from '@mui/joy';
+import {Button, FormHelperText, IconButton, Input, Link, Stack, Typography} from '@mui/joy';
 import {LoadingMessage} from 'firefly/visualize/ui/FileUploadViewPanel';
 import {addToRecentAlertIDs, showAlertIdDialog} from 'firefly/apps/alertviewer/AlertIDDialog';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
@@ -23,6 +23,7 @@ import {dispatchFormSubmit} from 'firefly/core/AppDataCntlr';
 
 const ALERT_LOAD_REQUEST = 'AlertViewerSearchProcessor';
 const IMAGE_TITLES = ['Science', 'Template', 'Difference'];
+const ALERT_ID_EXAMPLES = ['170059278837088375', '170112073844916273', '170270399209668654', '170301167642345602', '170059294376985743'];
 
 export const AlertIdPanel = ({loadInPlace=false}) => {
     const instruction = 'Enter an Alert ID to load in the Alert Viewer:';
@@ -112,6 +113,25 @@ export const AlertIdPanel = ({loadInPlace=false}) => {
                             <EditOutlinedIcon/>
                         </IconButton>
                     </Stack>
+                    <FormHelperText sx={{justifyContent: 'left', mt: 0}}>
+                        <Typography level='body-sm' sx={{pr: 1}}>Examples:</Typography>
+                        <Stack direction='column' spacing={0.5} alignItems='center' sx={{lineHeight: '1.2em'}}>
+                            <Stack direction='row' spacing={1.5}>
+                                {ALERT_ID_EXAMPLES.slice(0, 2).map((exampleId) => (
+                                    <Link fontSize='smaller' key={exampleId} onClick={() => setAlertId(exampleId)}>
+                                        {exampleId}
+                                    </Link>
+                                ))}
+                            </Stack>
+                            <Stack direction='row' spacing={1.5}>
+                                {ALERT_ID_EXAMPLES.slice(2).map((exampleId) => (
+                                    <Link fontSize='smaller' key={exampleId} onClick={() => setAlertId(exampleId)}>
+                                        {exampleId}
+                                    </Link>
+                                ))}
+                            </Stack>
+                        </Stack>
+                    </FormHelperText>
                     {isLoading && <LoadingMessage/>}
             </Stack>
         </Stack>
@@ -178,7 +198,7 @@ function loadFromEntries(result, alertId) {
                 {
                     tbl_id: isDetailsTable ? ALERT.TABLE_2_ID : ALERT.TABLE_1_ID,
                     pageSize: ALERT.TABLE_PAGESIZE,
-                    META_INFO: {}
+                    META_INFO: part?.chartMeta ?? {}
                 }
             );
             tblReq.tbl_index = extNum;

--- a/src/firefly/js/charts/ChartsCntlr.js
+++ b/src/firefly/js/charts/ChartsCntlr.js
@@ -528,6 +528,12 @@ function handleFireflyTraceTypes(payload) {
             if (isFireflyType(d.type)) {
                 const fd = get(d, 'firefly', {});
                 if (!fd.dataType) fd.dataType = d.type;     // use data.type if not defined.
+                if (d?.error_x?.array || d?.error_x?.arrayminus) {
+                    set(fd, 'error_x.visible', 'true');
+                }
+                if (d?.error_y?.array || d?.error_y?.arrayminus) {
+                    set(fd, 'error_y.visible', 'true');
+                }
                 fireflyData.push(fd);
                 plotlyData.push(omit(d, ['firefly']));
             } else {


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-2003
- Add these default columns for the alert viewer's DIASOURCE tbl: `midpointMjdTai` and `psfFLux` (with error `psfFluxErr`) (as opposed to `ra` vs `dec`).
- I added some safety checks to make sure these columns exist.
- The reason for code change in `ChartsCntlr.js`: 
  - Without this change, the chart itself would still show error (as plotly gets this trace data directly) but in the chart settings popup, `Error` would still be turned off, which could be confusing for users 
  - This change fixes that and toggles the `Error` selection on, if `error_x` or `error_y` exists on the trace.
   - I think this is a reasonable generic firefly fix: any chart trace that already arrives with `error_x` or `error_y` should have the settings dialog reflect that now.

**Testing**: 
**Firefly**: https://fireflydev.ipac.caltech.edu/firefly-2003-alert-columns/firefly
- To test the search results and chart UI, please check out this branch and run firefly locally (for the rubin tokens to work and results to show up).
- Search using any of these IDs: `170059278837088375`, `170301167642345602`, `170270399209668654`.
- Confirm the chart columns as: `midpointMjdTai` and `psfFlux`.
- Notice the `Error` via mouse redout anywhere on the chart, but confirm via the chart settings dialog that the `Y` axis `Error` is toggled on and set to `psfFluxErr` .