### PR TITLE
FIREFLY-1977: Make Select Row Filter button optional 

### DIFF
--- a/src/firefly/js/tables/tables-typedefs.jsdoc
+++ b/src/firefly/js/tables/tables-typedefs.jsdoc
@@ -285,6 +285,7 @@
  * @prop {boolean} [showPaging=true]    enable/disable paging feature.  When false, all data will be displayed.
  * @prop {boolean} [showSave=true]
  * @prop {boolean} [showFilterButton=true]
+ * @prop {boolean} [showSelectRowFilter=true] show the checkbox-header action to filter on selected rows
  * @prop {boolean} [showAddColumn=true]  when true, allow add column to table
  * @prop {boolean} [showInfoButton=true] when true, shows additional information about table, if available
  * @prop {boolean} [showOptionButton=true]

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -109,13 +109,16 @@ const BasicTableViewInternal = React.memo(({ selectable:selectableIn= false, sho
             error, tbl_ui_id=uniqueTblUiId(), currentPage, startIdx=0, highlightedRowHandler, cellRenderers, onRowDoubleClick} = props;
 
     const uiStates = getTableUiById(tbl_ui_id) || {};
-    const {tbl_id, columnWidths, scrollLeft=0, scrollTop=0, triggeredBy, showTypes, showFilters, showUnits, filterInfo,
-            selectable, sortInfo, textView} = uiStates;
+    const {tbl_id, columnWidths, scrollLeft=0, scrollTop=0, triggeredBy, showTypes, showFilters, showSelectRowFilter,
+            showUnits, filterInfo, selectable, sortInfo, textView} = uiStates;
     const tableRef = useRef();
 
     useEffect( () => {
         if (!isEmpty(columns)) {
-            const changes = omitBy(pick(props, 'showTypes', 'showFilters', 'showUnits', 'filterInfo','selectable', 'sortInfo', 'textView'), isUndefined);
+            const changes = omitBy(
+                pick(props, 'showTypes', 'showFilters', 'showSelectRowFilter', 'showUnits', 'filterInfo', 'selectable', 'sortInfo', 'textView'),
+                isUndefined
+            );
 
             const showUnits = !!columns.find?.((col) => col?.units);
             if (isUndefined(changes.showUnits)) changes.showUnits = showUnits;
@@ -169,7 +172,7 @@ const BasicTableViewInternal = React.memo(({ selectable:selectableIn= false, sho
     }, [columns, columnWidths, width, adjScrollLeft, adjScrollTop]);
 
     const makeColumnsProps = {columns, data, selectable, selectInfoCls, renderers,
-        columnWidths, filterInfo, sortInfo, showHeader, showUnits, showTypes, showFilters,
+        columnWidths, filterInfo, sortInfo, showHeader, showUnits, showTypes, showFilters, showSelectRowFilter,
         onSort, onFilter, onRowSelect, onSelectAll, onFilterSelected, startIdx, cellRenderers, tbl_id};
 
     const rowClassNameGetter = highlightedRowHandler || defHighlightedRowHandler(tbl_id, hlRowIdx, startIdx);
@@ -474,7 +477,8 @@ function makeColumnTag(props, col, idx) {
     );
 }
 
-function makeSelColTag({selectable, onSelectAll, showUnits, showTypes, showFilters, onFilterSelected, selectInfoCls, onRowSelect}) {
+function makeSelColTag({selectable, onSelectAll, showUnits, showTypes, showFilters, showSelectRowFilter,
+                           onFilterSelected, selectInfoCls, onRowSelect}) {
 
     if (!selectable) return false;
 
@@ -483,7 +487,7 @@ function makeSelColTag({selectable, onSelectAll, showUnits, showTypes, showFilte
         <Column
             key='selectable-checkbox'
             columnKey='selectable-checkbox'
-            header={<SelectableHeader {...{checked, onSelectAll, showUnits, showTypes, showFilters, onFilterSelected}} />}
+            header={<SelectableHeader {...{checked, onSelectAll, showUnits, showTypes, showFilters, showSelectRowFilter, onFilterSelected}} />}
             cell={<SelectableCell selectInfoCls={selectInfoCls} onRowSelect={onRowSelect} />}
             fixed={true}
             width={25}
@@ -491,4 +495,3 @@ function makeSelColTag({selectable, onSelectAll, showUnits, showTypes, showFilte
         />
     );
 }
-

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -51,6 +51,7 @@ const defaultOptions = {
     showSave: true,
     showOptionButton: true,
     showFilterButton: true,
+    showSelectRowFilter: true,
     showInfoButton: true,
     showAddColumn: true,
     showTypes: true,
@@ -88,7 +89,7 @@ export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', s
 
     const {selectable, renderers, title, removable, rowHeight, rowHeightGetter,
         showToolbar, showTitle, showMetaInfo,
-        columns, showHeader, showUnits, allowUnits, showTypes, showFilters, textView,
+        columns, showHeader, showUnits, allowUnits, showTypes, showFilters, showSelectRowFilter, textView,
         error, startIdx, hlRowIdx, currentPage, selectInfo, showMask,
         filterInfo, sortInfo, data, backgroundable, highlightedRowHandler, cellRenderers, onRowDoubleClick} = tblState;
 
@@ -132,7 +133,7 @@ export function TablePanel({tbl_id, tbl_ui_id, tableModel, variant='outlined', s
                         <BasicTableView
                             callbacks={connector}
                             { ...{columns, data, hlRowIdx, rowHeight, rowHeightGetter, selectable, showUnits,
-                                allowUnits, showTypes, showFilters, selectInfoCls, filterInfo, sortInfo, textView,
+                                allowUnits, showTypes, showFilters, showSelectRowFilter, selectInfoCls, filterInfo, sortInfo, textView,
                                 showMask, currentPage, showHeader, renderers, tbl_ui_id, highlightedRowHandler,
                                 startIdx, cellRenderers, onRowDoubleClick} }
                         />
@@ -169,6 +170,7 @@ TablePanel.propTypes = {
     showToggleTextView: PropTypes.bool,
     showOptionButton: PropTypes.bool,
     showFilterButton: PropTypes.bool,
+    showSelectRowFilter: PropTypes.bool,
     showAddColumn: PropTypes.bool,
     showInfoButton: PropTypes.bool,
     showSearchButton: PropTypes.bool,

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -216,7 +216,8 @@ function EnumSelect({col, tbl_id, filterInfoCls, onFilter}) {
     );
 }
 
-export function SelectableHeader ({checked, onSelectAll, showUnits, showTypes, showFilters, onFilterSelected, sx}) {
+export function SelectableHeader ({checked, onSelectAll, showUnits, showTypes, showFilters, showSelectRowFilter=true,
+                                      onFilterSelected, sx}) {
     return (
         <Stack alignItems='center' height={1} justifyContent='space-between' py='2px' sx={sx}>
             <Checkbox size='sm'
@@ -225,7 +226,7 @@ export function SelectableHeader ({checked, onSelectAll, showUnits, showTypes, s
                 onChange={(e) => onSelectAll(e.target.checked)}/>
             {/*{showUnits && <Box height='1em'/>}*/}
             {/*{showTypes && <Box height='1em'/>}*/}
-            {showFilters && <FilterButton  iconButtonSize='28px'
+            {showFilters && showSelectRowFilter && <FilterButton  iconButtonSize='28px'
                                  onClick={onFilterSelected}
                                  tip='Filter on selected rows'/>}
         </Stack>

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -641,7 +641,7 @@ function AnalysisInfo({report,supported=true,UNKNOWN_FORMAT}) {
     );
 }
 
-const tblOptions = {showToolbar:false, border:false, showOptionButton:false, showFilters:true};
+const tblOptions = {showToolbar:false, border:false, showOptionButton:false, showFilters:true, showSelectRowFilter:false};
 
 function AnalysisTable({summaryModel, detailsModel, report, isMoc, UNKNOWN_FORMAT, acceptList, acceptOneItem}) {
     if (!summaryModel) return null;
@@ -916,4 +916,3 @@ const FileAnalysis = ({report, summaryModel, detailsModel, isMoc, UNKNOWN_FORMAT
         );
     }
 };
-


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-1977
- Pass through a new prop `showSelectRowFilter` (defaults to true, but false for File Upload panel) 

**Testing**: 
**Firefly**: https://fireflydev.ipac.caltech.edu/firefly-1977-upload-filter-bug/firefly
- Upload a file in the upload panel
- Notice the Filter on Rows button is now gone (compare against https://fireflydev.ipac.caltech.edu/firefly/)
  - other filters should still be available  