### PR TITLE
FIREFLY-2005: Fix Euclid Downloads bug

### DIFF
--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -85,10 +85,17 @@ function setupObsCorePackaging(tbl_id) {
     dispatchTableUiUpdate({ tbl_ui_id, leftButtons});
 }
 
+function getHostname(url) {
+    if (!url) return undefined;
+    try {
+        return new URL(url).hostname;
+    } catch {
+        return undefined;
+    }
+}
+
 function updateSearchRequest( tbl_id='', dlParams='', sRequest=null) {
-    const hostname = sRequest?.source || sRequest?.serviceUrl
-        ? new URL(sRequest.source || sRequest.serviceUrl).hostname
-        : null;
+    const hostname = getHostname(sRequest?.source) ?? getHostname(sRequest?.serviceUrl);
     const serviceId= getMetaEntry(tbl_id,MetaConst.DATA_SERVICE_ID);
     const ops= getDataServiceOptionsFallback(serviceId, hostname) ?? {};
     const template= ops.productTitleTemplate;


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-2005
**IFE PR**: https://github.com/IPAC-SW/irsa-ife/pull/465
- Euclid downloads were broken
- upon inspection, found the reason is `sRequest.source` for Euclid in `ttFeatureWatchers` is something like:
  - `${stage}/jobs/Ab/MerTilesQuery7219919268352559969.tbl`
  - as opposed to, for instance, for spherex this would be a TAP async url like:
    - `https://irsadev.ipac.caltech.edu/TAP/async/949620/results/result`
- so it `new URL()` would not work for Euclid's source. 
  - this fix ensures we only use new URL when there's a valid URL, else return null and rely on `serviceId` to continue. 
- What I couldn't really figure out is when exactly this broke! 
  - I looked at recent changes in a few places but couldn't figure exactly when Euclid downloads stopped working...?
  - Either way, I think this is a good general fix that fixes this latent bug.  
- This also fixes the Prepare Download bug in SIAv2 Searches on firefly: 
  - https://jira.ipac.caltech.edu/browse/FIREFLY-2001
 

**Testing**: 
- [Euclid](https://firefly-2005-euclid-bug.irsakubedev.ipac.caltech.edu/applications/euclid/)
  - Do `Image`, `Object` and `Search by ID` searches
   - Ensure download script works for each of them. Open a products table from a selected row, check download script works here as well.
- [Spherex](https://firefly-2005-euclid-bug.irsakubedev.ipac.caltech.edu/applications/spherex/) and [DCE](https://firefly-2005-euclid-bug.irsakubedev.ipac.caltech.edu/irsaviewer/dce)
  -  Regression testing:
     - Do a couple of searches and ensure downloads work here as expected.
- **Firefly**: https://fireflydev.ipac.caltech.edu/firefly-2005-euclid-bug/firefly
  - `Prepare Download` for SIA v2 Searches was not working. Do a SIAv2 Search and make sure it works now:  
