### PR TITLE
FIREFLY-1864: Improve application security and configuration hardening

### DIFF
--- a/buildScript/dependencies.gradle
+++ b/buildScript/dependencies.gradle
@@ -90,7 +90,7 @@ dependencies {
     implementation 'junit:junit:4.12'
 
     // duckdb - SQL support for parquet, csv, and tsv files
-    implementation 'org.duckdb:duckdb_jdbc:1.1.3'
+    implementation 'org.duckdb:duckdb_jdbc:1.5.2.1'
 
     // embedded redis server; version ~ 6.2
     implementation 'com.github.codemonstur:embedded-redis:1.4.3'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -200,7 +200,7 @@ RUN sed -i 's/<Connector port="8080" protocol="HTTP\/1.1"/<Connector port="8080"
     && sed -i 's/<Connector /<Connector server="" allowTrace="false" /' \
         $CATALINA_HOME/conf/server.xml \
     # Disable runtime auto-deploy
-    && sed -i 's/autoDeploy="true"/autoDeploy="false">/' \
+    && sed -i 's/autoDeploy="true"/autoDeploy="false"/' \
         $CATALINA_HOME/conf/server.xml  \
     && sed -i '/<\/Host>/i\    <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />' \
           $CATALINA_HOME/conf/server.xml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -139,7 +139,7 @@ ARG uid=91
 ARG gid=91
 ARG TARGETARCH=amd64
 ARG TARGETOS=linux
-ARG DUCKDB_VERSION=v1.1.3
+ARG DUCKDB_VERSION=v1.5.2.1
 
 # These are the users replaceable environment variables, basically runtime arguments
 #          - Set the available memory on the command line with --memory="4g"
@@ -195,13 +195,13 @@ COPY --from=builder /opt/work/${build_dir}/build/dist/*.war ${CATALINA_HOME}/web
 # - useSendfile="false" →  avoids bypassing compression for static files
 # - compressibleMimeType → list of text-based formats to compress (HTML, CSS, JS, JSON, VOTable, XML, CSV, SVG, Fonts)
 RUN sed -i 's/<Connector port="8080" protocol="HTTP\/1.1"/<Connector port="8080" protocol="HTTP\/1.1" compression="on" useSendfile="false" compressibleMimeType="text\/html,text\/plain,text\/css,text\/javascript,application\/javascript,application\/json,application\/xml,text\/xml,application\/x-votable+xml,application\/x-yaml,application\/ld+json,image\/svg+xml,text\/csv,application\/xhtml+xml,application\/rss+xml,application\/atom+xml,application\/x-font-ttf,font\/otf,font\/woff,font\/woff2,application\/octet-stream"/' \
-    $CATALINA_HOME/conf/server.xml
-
-# preinstall DuckDB extensions; remember to update version when DuckDB is updated
-ENV DUCKDB_TARGET=${DUCKDB_VERSION}/${TARGETOS}_${TARGETARCH}_gcc4
-RUN mkdir -p temp/$DUCKDB_TARGET \
-    && wget -P temp/$DUCKDB_TARGET https://community-extensions.duckdb.org/$DUCKDB_TARGET/magic.duckdb_extension.gz \
-    && gunzip -f temp/$DUCKDB_TARGET/magic.duckdb_extension.gz
+        $CATALINA_HOME/conf/server.xml \
+    # Strip version from Server header and disable TRACE
+    && sed -i -e 's/\(<Connector[^>]*\)>/\1 server="" allowTrace="false">/' \
+        $CATALINA_HOME/conf/server.xml \
+    # Disable runtime auto-deploy
+    && sed -i 's/autoDeploy="true"/autoDeploy="false">/' \
+        $CATALINA_HOME/conf/server.xml
 
 # Add permission to files and directories needed for runtime
 # increase max header size to avoid failing on large auth token

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -197,11 +197,13 @@ COPY --from=builder /opt/work/${build_dir}/build/dist/*.war ${CATALINA_HOME}/web
 RUN sed -i 's/<Connector port="8080" protocol="HTTP\/1.1"/<Connector port="8080" protocol="HTTP\/1.1" compression="on" useSendfile="false" compressibleMimeType="text\/html,text\/plain,text\/css,text\/javascript,application\/javascript,application\/json,application\/xml,text\/xml,application\/x-votable+xml,application\/x-yaml,application\/ld+json,image\/svg+xml,text\/csv,application\/xhtml+xml,application\/rss+xml,application\/atom+xml,application\/x-font-ttf,font\/otf,font\/woff,font\/woff2,application\/octet-stream"/' \
         $CATALINA_HOME/conf/server.xml \
     # Strip version from Server header and disable TRACE
-    && sed -i -e 's/\(<Connector[^>]*\)>/\1 server="" allowTrace="false">/' \
+    && sed -i 's/<Connector /<Connector server="" allowTrace="false" /' \
         $CATALINA_HOME/conf/server.xml \
     # Disable runtime auto-deploy
     && sed -i 's/autoDeploy="true"/autoDeploy="false">/' \
-        $CATALINA_HOME/conf/server.xml
+        $CATALINA_HOME/conf/server.xml  \
+    && sed -i '/<\/Host>/i\    <Valve className="org.apache.catalina.valves.ErrorReportValve" showReport="false" showServerInfo="false" />' \
+          $CATALINA_HOME/conf/server.xml
 
 # Add permission to files and directories needed for runtime
 # increase max header size to avoid failing on large auth token

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestAgent.java
@@ -4,6 +4,7 @@
 package edu.caltech.ipac.firefly.server;
 
 import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.StringUtils;
 
 import jakarta.servlet.http.Cookie;
@@ -29,6 +30,8 @@ import static edu.caltech.ipac.util.StringUtils.applyIfNotEmpty;
  * @version $Id: $
  */
 public class RequestAgent {
+
+    public static final String SERVER_HOST = AppProperties.getProperty("server.host");
 
     private Map<String, Cookie> cookies;
     private String requestUrl;      // the request url
@@ -153,7 +156,7 @@ public class RequestAgent {
 //  RequestAgent implementations...
 //====================================================================
 
-    public static class HTTP extends RequestAgent {
+    public static final class HTTP extends RequestAgent {
         private static final String AUTH_KEY = "JOSSO_SESSIONID";
         private static final Logger.LoggerImpl LOG = Logger.getLogger();
         private final HashMap<String, String> headers = new HashMap<>();      // key stored as lowercase;
@@ -173,46 +176,52 @@ public class RequestAgent {
                 Arrays.stream(v).forEach(c -> cookies.put(c.getName(), c));
             });
 
-            // getting the base url including the application path is a bit tricky when behind reverse proxy(ies)
-            String port = String.valueOf(request.getServerPort());
-            String host  = getHeader("X-Forwarded-Host", getHeader("X-Forwarded-Server", getHeader("host", request.getServerName())));
-            String[] parts = host.split(":");       // host may contains port; needs to handle it.
-            if (parts.length > 1) {
-                host = parts[0];
-                port = parts[1];
-            }
-            port  = getHeader("X-Forwarded-Port", port);
-            String proto = getHeader("X-Forwarded-Proto", port.equals("443") ? "https" : "http");
-            port = port.matches("443|80") ? "" : ":" + port;
-            String proxiedPath = getHeader("X-Forwarded-Path", getHeader("X-Forwarded-Prefix", "") + request.getContextPath());
+            OriginInfo origin = resolveOrigin(request);
 
-            String hostUrl = String.format("%s://%s%s", proto, host, port);
-            String baseUrl = hostUrl + proxiedPath;
+            String hostUrl = String.format("%s://%s%s", origin.proto, origin.host, origin.port);
+            String baseUrl = hostUrl + origin.path;
             baseUrl = baseUrl.endsWith("/") ? baseUrl :  baseUrl + "/";
 
-            String requestUrl =  getHeader("X-Original-URI");
+            String requestUrl = getHeader("X-Original-URI");
             if (requestUrl == null) {
                 String queryStr = request.getQueryString() == null ? "" : "?" + request.getQueryString();
-                String path = request.getRequestURI();
-                if (!proxiedPath.equals(request.getContextPath())) {
-                    path = path.replace(request.getContextPath(), proxiedPath);
-                }
+                String path = request.getRequestURI().replace(request.getContextPath(), origin.path);
                 requestUrl = path + queryStr;
             }
-            requestUrl = requestUrl.startsWith(proto) ? requestUrl : hostUrl + requestUrl;
-
-            String remoteIP = getHeader("x-original-forwarded-for", getHeader("X-Forwarded-For", request.getRemoteAddr()));
+            requestUrl = requestUrl.startsWith(origin.proto + "://") ? requestUrl : hostUrl + requestUrl;
 
             setBaseUrl(baseUrl);
             setHostUrl(hostUrl);
-            setHost(host);
+            setHost(origin.host);
             setRequestUrl(requestUrl);
             setContextPath(request.getContextPath());
-            setRemoteIP(remoteIP);
+            setRemoteIP(origin.remoteIP());
             setSessId(request.getSession(true).getId());
             setServletPath(request.getServletPath());
 
             realPath = request.getServletContext().getRealPath("/");
+        }
+
+        private record OriginInfo(String host, String port, String proto, String path, String remoteIP) {}
+
+        // Trusts the 'server.host' property/env over request headers, which can be spoofed.
+        private OriginInfo resolveOrigin(HttpServletRequest request) {
+            String raw = !StringUtils.isEmpty(SERVER_HOST) ? SERVER_HOST
+                    : getHeader("X-Forwarded-Host", getHeader("X-Forwarded-Server", getHeader("host", request.getServerName())));
+            // X-Forwarded-Host may be a comma-separated list when behind multiple proxies; take the first entry
+            raw = raw.split(",")[0].trim();
+            // host may contain a port, e.g. hostname:8080
+            String[] parts = raw.split(":");
+            String host = parts.length == 2 && parts[1].matches("\\d+") ? parts[0] : raw;
+            String port  = getHeader("X-Forwarded-Port", parts.length == 2 ? parts[1] : String.valueOf(request.getServerPort()));
+            String proto = getHeader("X-Forwarded-Proto", port.equals("443") ? "https" : "http");
+            port = port.matches("443|80") ? "" : ":" + port;
+            String path = getHeader("X-Forwarded-Path", getHeader("X-Forwarded-Prefix", "") + request.getContextPath());
+            // X-Forwarded-For is a comma-separated list of IPs; the leftmost is the original client
+            String remoteIP = getHeader("x-original-forwarded-for", getHeader("X-Forwarded-For", request.getRemoteAddr()));
+            remoteIP = remoteIP.split(",")[0].trim();
+
+            return new OriginInfo(host, port, proto, path, remoteIP);
         }
 
         @Override
@@ -222,6 +231,7 @@ public class RequestAgent {
 
         @Override
         public String getRealPath(String relPath) {
+            if (realPath == null) return null;
             return new File(realPath, relPath).getAbsolutePath();
         }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -187,10 +187,7 @@ abstract public class BaseDbAdapter implements DbAdapter {
             execUpdate(sql);
 
             // copy dd
-            List<String> cnames = getColumnNamesFromSys(resultSetID, "'");
-            String ddSql = "select * from DATA_DD" + (cnames.size() > 0 ? " where cname in (%s)".formatted(StringUtils.toString(cnames)) : "");
-            ddSql = createTableFromSelect(resultSetID + "_DD", ddSql);
-            execUpdate(ddSql);
+            copyDDFromSource(resultSetID, getDataTable());
 
             // copy meta
             String metaSql = "select * from DATA_META";
@@ -958,6 +955,15 @@ abstract public class BaseDbAdapter implements DbAdapter {
 
     void handleSpecialDTypes(DataType dtype, DataGroup dg, ResultSet rs) {
         applyIfNotEmpty(deserialize(rs, "links"), v -> dtype.setLinkInfos((List<LinkInfo>) v));
+    }
+
+    public void copyDDFromSource(String tblName, String sourceTbl) {
+        List<String> cnames = getColumnNamesFromSys(tblName, "'");
+        String ddSql = "select * from %s_DD".formatted(sourceTbl) +
+                (cnames.isEmpty() ? " WHERE 1=0" : " where cname in (%s)".formatted(StringUtils.toString(cnames)));
+        try {
+            execUpdate(createTableFromSelect(tblName + "_DD", ddSql));
+        } catch (Exception ignored) {}
     }
 
     void ddToDb(DataGroup dg, String tblName) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
@@ -7,23 +7,18 @@ import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.firefly.server.query.ResourceProcessor;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.DataGroupPart;
-import edu.caltech.ipac.table.TableMeta;
 import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.table.DataType;
-import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.StringUtils;
 import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Function;
 
-import static edu.caltech.ipac.firefly.data.TableServerRequest.TBL_FILE_TYPE;
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 
 /**
@@ -86,13 +81,9 @@ public interface DbAdapter {
     DbAdapter.DbStats getDbStats();
 
     default boolean hasTable(String tableName) {
-        try {
-            if (isEmpty(tableName) || getDbFile() == null || !getDbFile().exists()) return false;
-            return getTableNames().stream()
-                    .anyMatch(s -> s.equalsIgnoreCase(tableName));
-        } catch (Exception e) {
-            return false;
-        }
+        if (isEmpty(tableName) || getDbFile() == null || !getDbFile().exists()) return false;
+        return getTableNames().stream()
+                .anyMatch(s -> s.equalsIgnoreCase(tableName));
     }
 
 
@@ -188,6 +179,16 @@ public interface DbAdapter {
     void deleteColumn(String cname);
 
     DataAccessException handleSqlExp(String msg, Exception e);
+
+    /**
+     * Create a _DD table for tblName by copying matching column metadata from sourceTbl's _DD.
+     */
+    default void copyDDFromSource(String tblName, String sourceTbl) {}
+
+    /**
+     * Persist a DataGroup's table metadata into the tblName_META table.
+     */
+    default void metaToDb(DataGroup dg, String tblName) {}
 
 //====================================================================
 //  management functions
@@ -296,6 +297,7 @@ public interface DbAdapter {
         boolean isCompact;
         DbStats dbStats;
         boolean isResourceDb;
+        volatile Connection rootConn;
 
         EmbeddedDbInstance(String type, DbAdapter dbAdapter, String dbUrl, String driver) {
             this(type, dbAdapter, dbUrl, driver, System.currentTimeMillis());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbInstance.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbInstance.java
@@ -3,8 +3,10 @@
  */
 package edu.caltech.ipac.firefly.server.db;
 
+import edu.caltech.ipac.firefly.server.db.jdbc.DbInstanceDataSource;
 import edu.caltech.ipac.util.AppProperties;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -107,6 +109,7 @@ public class DbInstance {
     }
     public boolean isPooled() { return isPooled; }
     public void setPooled(boolean pooled) { isPooled = pooled;}
+    public DataSource createDataSource() { return new DbInstanceDataSource(this); }
     public boolean testConn(Connection conn) {
         try (Statement stmt = conn.createStatement()) {
             stmt.execute("SELECT 1 FROM (VALUES (0)) AS dummy");     // HSQL required FROM clause; postgres required alias

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
@@ -6,6 +6,7 @@ package edu.caltech.ipac.firefly.server.db;
 import edu.caltech.ipac.firefly.core.Util;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.server.ServerContext;
+import edu.caltech.ipac.firefly.server.db.jdbc.DbInstanceDataSource;
 import edu.caltech.ipac.firefly.server.db.jdbc.JdbcFactory;
 import edu.caltech.ipac.firefly.server.db.jdbc.JdbcTemplate;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
@@ -18,6 +19,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 
 
+import javax.sql.DataSource;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -27,8 +29,10 @@ import java.sql.Statement;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static edu.caltech.ipac.firefly.core.Util.Try;
 import static edu.caltech.ipac.firefly.server.db.DuckDbUDF.*;
@@ -45,6 +49,7 @@ public class DuckDbAdapter extends BaseDbAdapter {
     public static final String EXT_DIR = AppProperties.getProperty("duckdb.ext.dir", System.getProperty("java.io.tmpdir"));
     public static String maxMemory = AppProperties.getProperty("duckdb.max.memory");        // in GB; 2G, 5.5G, etc
     private static int threadCnt=1;    // min 125mb per thread.  recommend 5gb per thread; we will config 1gb per thread but not more than 4.
+    private static String allowedDirs = null;
 
     static {
         if (DEF_DB_TYPE.equals(NAME)) {
@@ -78,16 +83,48 @@ public class DuckDbAdapter extends BaseDbAdapter {
         String filePath = getDbFile() == null ? "" : getDbFile().getAbsolutePath();
         String dbUrl = "jdbc:duckdb:" + filePath;
         var db = new EmbeddedDbInstance(getName(), this, dbUrl, DRIVER) {
-            public boolean testConn(Connection conn) {
-                // test connection plus additional session-scoped properties
-                try (Statement stmt = conn.createStatement()) {
-                    stmt.execute("SET errors_as_json = true");
-                    return true;
-                } catch (SQLException e) { return false; }
+            @Override
+            public DataSource createDataSource() {
+                EmbeddedDbInstance self = this;
+                return new DbInstanceDataSource(this) {
+                    @Override
+                    public Connection getConnection(String username, String password) throws SQLException {
+                        synchronized (self) {
+                            if (self.rootConn == null || self.rootConn.isClosed()) {
+                                self.rootConn = super.getConnection(username, password);
+                            }
+                            try {
+                                return ((DuckDBConnection) self.rootConn).duplicate();
+                            } catch (SQLException e) {
+                                // rootConn may be in a dirty state; reset and retry once
+                                try { self.rootConn.close(); } catch (Exception ignored) {}
+                                self.rootConn = super.getConnection(username, password);
+                                return ((DuckDBConnection) self.rootConn).duplicate();
+                            }
+                        }
+                    }
+                };
             }
         };
         db.consumeProps("memory_limit=%s,threads=%d,extension_directory=%s".formatted(maxMemory, threadCnt, EXT_DIR));
+        db.getProps().put("errors_as_json", "true");
+        // As of v1.5.2.1, security can only be enforced if external access is disabled.
+        // When we need to query from s3 or other external sources, we will need enforce security at a different layer.
+        db.getProps().put("enable_external_access", "false");
+        db.getProps().put("allowed_directories", "[%s]".formatted(getAllowedDirs()));
         return db;
+    }
+
+    private static String getAllowedDirs() {
+        if (allowedDirs == null) {
+            List<File> dirs = new ArrayList<>();
+            dirs.add(ServerContext.getWorkingDir());
+            dirs.add(ServerContext.getSharedWorkingDir());
+            allowedDirs = dirs.stream()
+                    .map(f -> "'" + f.getAbsolutePath() + "'")
+                    .collect(Collectors.joining(", "));
+        }
+        return allowedDirs;
     }
 
     void createUDFs() {
@@ -126,7 +163,14 @@ public class DuckDbAdapter extends BaseDbAdapter {
         ((EmbeddedDbInstance) getDbInstance()).setCompact(true);
     }
 
-    protected void shutdown(EmbeddedDbInstance db) {}
+    @Override
+    protected void shutdown(EmbeddedDbInstance db) {
+        try {
+            if (db.rootConn != null && !db.rootConn.isClosed()) db.rootConn.close();
+        } catch (SQLException ignored) {}
+        db.rootConn = null;
+    }
+
     protected void removeDbFile() {
         var dbFile = getDbFile();
         if (dbFile.exists()) {
@@ -207,7 +251,7 @@ public class DuckDbAdapter extends BaseDbAdapter {
         appender.beginRow();
         for (Object d : row) {
             switch (d) {
-                case null -> appender.append(null);
+                case null -> appender.appendNull();
                 case Boolean v -> appender.append(v);
                 case Byte v -> appender.append(v);
                 case Short v -> appender.append(v);
@@ -218,10 +262,10 @@ public class DuckDbAdapter extends BaseDbAdapter {
                 case String v -> appender.append(v);
                 case Character v -> appender.append(String.valueOf(v));
                 case BigDecimal v -> appender.append(v.doubleValue());
-                case java.sql.Date v -> appender.appendLocalDateTime(v.toLocalDate().atStartOfDay());
-                case LocalDate v -> appender.appendLocalDateTime(v.atStartOfDay());
-                case LocalDateTime v -> appender.appendLocalDateTime(v.atZone(ZoneOffset.UTC).toLocalDateTime());
-                case Date v -> appender.appendLocalDateTime(LocalDateTime.ofInstant(v.toInstant(), ZoneOffset.UTC));    // date/time should be stored as utc.
+                case java.sql.Date v -> appender.append(v.toLocalDate().atStartOfDay());
+                case LocalDate v -> appender.append(v.atStartOfDay());
+                case LocalDateTime v -> appender.append(v.atZone(ZoneOffset.UTC).toLocalDateTime());
+                case Date v -> appender.append(LocalDateTime.ofInstant(v.toInstant(), ZoneOffset.UTC));    // date/time should be stored as utc.
                 default -> throw new IllegalStateException("Unexpected value: " + d);
             }
         }
@@ -251,7 +295,10 @@ public class DuckDbAdapter extends BaseDbAdapter {
     public String interpretError(Throwable e) {
         try {
             if (e instanceof SQLException ex) {
-                JSONObject json = (JSONObject) JSONValue.parse(ex.getMessage().replace("%s:".formatted(ex.getClass().getName()), ""));
+                String raw = ex.getMessage();
+                int jsonStart = raw.indexOf('{');
+                if (jsonStart > 0) raw = raw.substring(jsonStart);
+                JSONObject json = (JSONObject) JSONValue.parse(raw);
                 String msg = json.get("exception_message").toString().split("\n")[0];
                 String type = Try.it(() -> json.get("error_subtype").toString())
                                     .getOrElse(json.get("exception_type").toString());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/jdbc/DbInstanceDataSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/jdbc/DbInstanceDataSource.java
@@ -18,11 +18,11 @@ import static edu.caltech.ipac.util.StringUtils.isEmpty;
 /**
  * DataSource implementation backed by a {@link DbInstance}, creating a new connection per call via DriverManager.
  */
-public class DriverManagerDataSource implements DataSource {
+public class DbInstanceDataSource implements DataSource {
 
     private final DbInstance dbInstance;
 
-    public DriverManagerDataSource(DbInstance dbInstance) {
+    public DbInstanceDataSource(DbInstance dbInstance) {
         this.dbInstance = dbInstance;
         if (dbInstance.jdbcDriver != null) {
             try { Class.forName(dbInstance.jdbcDriver); } catch (ClassNotFoundException ignored) {}

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/jdbc/JdbcFactory.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/jdbc/JdbcFactory.java
@@ -64,7 +64,7 @@ public class JdbcFactory {
     }
 
     private static DataSource getDirectDataSource(DbInstance dbInstance) {
-        DriverManagerDataSource ds = new DriverManagerDataSource(dbInstance);
+        DataSource ds = dbInstance.createDataSource();
         logger.trace("Getting a new database connection for " + dbInstance.dbUrl + " using DriverManager",
                 "DataSource returned: " + ds);
         return ds;

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/DecimationProcessor.java
@@ -6,7 +6,6 @@ package edu.caltech.ipac.firefly.server.query;
 import edu.caltech.ipac.firefly.data.DecimateInfo;
 import edu.caltech.ipac.firefly.data.ServerRequest;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
-import edu.caltech.ipac.firefly.server.db.BaseDbAdapter;
 import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.db.DuckDbAdapter;
 import edu.caltech.ipac.firefly.server.util.QueryUtil;
@@ -109,8 +108,10 @@ public class DecimationProcessor extends TableFunctionProcessor {
             long maxW = (long) minMax.getData("maxWeight", 0);
             DataGroup meta = new DataGroup();
             insertDecimateInfo(meta, deciInfo, deciKey, minW, maxW);
-            ((BaseDbAdapter)dbAdapter).metaToDb(meta, tblName);
+            dbAdapter.metaToDb(meta, tblName);
         }
+
+        dbAdapter.copyDDFromSource(tblName, dataTbl);
     }
 
     /* Old method of doing decimation */

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/StatisticsProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/StatisticsProcessor.java
@@ -48,8 +48,10 @@ public class StatisticsProcessor extends TableFunctionProcessor {
         // check to see if a resultset table exists... if not, use original data table.
         if (!dbAdapter.hasTable(origDataTblName)) {
             origDataTblName = dbAdapter.getDataTable();
+            if (!dbAdapter.hasTable(origDataTblName)) {
+                throw new DataAccessException("Original DATA table does not exist in the database.");
+            }
         }
-
         // get all column info from DATA table
         DataGroup dd = dbAdapter.getHeaders(origDataTblName);
         var cols = dd.getDataDefinitions();

--- a/src/firefly/java/edu/caltech/ipac/util/AppProperties.java
+++ b/src/firefly/java/edu/caltech/ipac/util/AppProperties.java
@@ -3,7 +3,6 @@
  */
 package edu.caltech.ipac.util;
 
-
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -13,6 +12,8 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+
+import static edu.caltech.ipac.firefly.core.Util.Try;
 
 
 /**
@@ -207,27 +208,22 @@ public class AppProperties {
   }
 
   public static String getProperty(String key, String def, Properties overridePDB) {
-      // NOTE use of == on String instead of .equal is intentional
-      //
-      // Applications property search order
-      //    - search the system database
-      //    - search the mainProperties database
-      //    - the priority for application properties
-      //        follows from highest to lowest:
-      //        1. system
-      //        2. mainProperties
 
-      String retval= def;
-      if (overridePDB==null) {
-          try {
-               retval= System.getProperty(key, def);
-          } catch (Exception e) { /*do nothing*/ }
-          if (retval==def) retval= mainProperties.getProperty(key, def);
+      // Applications property lookup order
+      //   - overridePDB (if not null)
+      //   - environment variable
+      //   - system properties
+      //   - configured properties
+
+      String retval;
+      if (overridePDB == null) {
+          retval = Try.it(() -> System.getenv(key)).get();
+          if (retval == null) retval = Try.it(() -> System.getProperty(key)).get();
+          if (retval == null) retval = mainProperties.getProperty(key);
+      } else {
+          retval = overridePDB.getProperty(key, def);
       }
-      else {
-          retval= overridePDB.getProperty(key, def);
-      }
-      return retval;
+      return retval == null ? def : retval;
   }
 
     public static Map<String,String> getWithStartingMatch(String startOfKey) {

--- a/src/firefly/test/edu/caltech/ipac/table/DuckDbAdapterTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/DuckDbAdapterTest.java
@@ -8,8 +8,10 @@ import edu.caltech.ipac.firefly.data.DecimateInfo;
 import edu.caltech.ipac.firefly.data.ServerParams;
 import edu.caltech.ipac.firefly.data.SortInfo;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.db.DbMonitor;
+import edu.caltech.ipac.firefly.server.db.DuckDbAdapter;
 import edu.caltech.ipac.firefly.server.db.DuckDbReadable;
 import edu.caltech.ipac.firefly.server.db.HsqlDbAdapter;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
@@ -28,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -276,6 +279,27 @@ public class DuckDbAdapterTest extends ConfigTest {
 		// mixing single and double quotes
 		assertEquals("'test ILIKE inside\" badly quoted ILIKE ",
 				replaceLike("'test like inside\" badly quoted like "));
+	}
+
+	@Test
+	public void testDuckDbExternalAccessIsRestrictedToAllowedDirs() throws Exception {
+		DuckDbAdapter db = new DuckDbAdapter((File) null);
+
+		File allowedCsv = new File(ServerContext.getWorkingDir(), "duckdb-allowed.csv");
+		Files.writeString(allowedCsv.toPath(), "id,name\n1,allowed\n");
+		assertEquals(1, db.execQuery("select * from read_csv('%s')".formatted(allowedCsv.getAbsolutePath()), null).size());
+
+		File deniedCsv = new File(ServerContext.getWorkingDir().getParentFile(), "duckdb-denied.csv");
+		Files.writeString(deniedCsv.toPath(), "id,name\n1,denied\n");
+		try {
+			db.execQuery("select * from read_csv('%s')".formatted(deniedCsv.getAbsolutePath()), null);
+			fail("DuckDB should block reads outside allowed_directories");
+		} catch (DataAccessException expected) {
+			assertNotNull(expected.getMessage());
+		} finally {
+			allowedCsv.delete();
+			deniedCsv.delete();
+		}
 	}
 
 //====================================================================


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1864

**Changes:**
- Avoid using Host header when server host is explicitly configured
- Tomcat hardening: strip Server header, disable TRACE method, set autoDeploy=false
- Updated DuckDB to v1.5.2.1
  - Restrict file access via `enable_external_access=false` and `allowed_directories`
  - Query performance improvements

**Test**: https://firefly-1864-security-config.irsakubedev.ipac.caltech.edu/irsaviewer/
- Added 'server.host' properties to defined host instead of relying on http header
- Verify 404-Not Found without server info  (https://firefly-1864-security-config.irsakubedev.ipac.caltech.edu/irsaviewer/something-that-does-not-exists)
- I tested 'enable_external_access=false' from the debugger by sending SQL statement the try to read file from the local filesystem and verified it worked.
- Improved performance based on times from logs.