### PR TITLE
FIREFLY-2011: Spatial search bug fix

### DIFF
--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -234,7 +234,9 @@ export function SpatialSearch({sx, cols, serviceUrl, serviceLabel, serviceId, co
         );
 
         return makeConstraintEntry(constraints);
-    }, [...fldListAry.map((v) => getVal(v))]);  // eslint-disable-line
+    }, [isSpatialPanelActive, columnsModel, obsCoreEnabled, uploadInfo, tableName, canUpload,
+        useSIAv2, ...fldListAry.map((v) => getVal(v)),
+    ]);
 
     useEffect(() => {
         setConstraintFragment(panelPrefix, constraintResult);


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-2011'
- Made some non-field inputs explicit in the dependency list (`isSpatialPanelActive` is what fixes this bug, but the others are important to be explicitly defined as well) 

**Testing**: 
**Firefly**: https://fireflydev.ipac.caltech.edu/firefly-2011-spatial-bug-fix/firefly
- test the bug according to the ticket, should be fixed now and you should navigate to `Edit ADQL` when clicking on `Populate and Edit ADQL` with spatial search unselected (and no target) 
- Since this is on TAP, if you can think of and test any more edge cases, go for it! Let me know if something is broken, it's all working in my testing. 