### PR TITLE
IRSA-7677: Fix broken URL API for SPHEREx Spectral Image search

### DIFF
--- a/src/firefly/js/ui/QuantityInputField.jsx
+++ b/src/firefly/js/ui/QuantityInputField.jsx
@@ -203,18 +203,24 @@ const quantityBoundsValidator = (min, max, nullAllowed, unit, quantityName, form
 /**Uncontrolled component for Quantity Input that wires QuantityInputFieldView's state with the FieldGroup store.**/
 export const QuantityInputField = memo((props) => {
     const { quantityBaseUnit, convertQuantityUnits, quantityName, formatQuantity } = props;
+    const normalizedInitialState = normalizeInitState(props?.initialState, quantityBaseUnit, convertQuantityUnits);
+    const { unit: initUnit } = normalizedInitialState;
     const { viewProps, fireValueChange } = useFieldGroupConnector({
         ...props,
-        initialState: normalizeInitState(props?.initialState, quantityBaseUnit, convertQuantityUnits),
+        initialState: normalizedInitialState,
     });
 
     useEffect(() => {
-        // if value changed in the store (for e.g. by a setFieldValue()) and there's no displayValue, set it
-        if ((viewProps?.value || viewProps?.value===0) && viewProps?.unit && !viewProps?.displayValue) {
+        if (!viewProps?.unit && initUnit) {
+            // if unit is missing from store, set it from initialState
+            fireValueChange({unit: initUnit});
+        } else if ((viewProps?.value || viewProps?.value===0) && viewProps?.unit && !viewProps?.displayValue) {
+            // if value changed in the store (for e.g. by a setFieldValue()) and there's no displayValue, set it
             const newDisplayValue = convertQuantityUnits(viewProps.value, quantityBaseUnit, viewProps.unit);
             fireValueChange({displayValue: newDisplayValue});
         }
-        }, [viewProps?.value, viewProps?.unit, viewProps?.displayValue, fireValueChange, convertQuantityUnits, quantityBaseUnit]);
+        }, [viewProps?.value, viewProps?.unit, viewProps?.displayValue,
+            fireValueChange, convertQuantityUnits, quantityBaseUnit, initUnit]);
 
     const handleOnChange = (ev, quantityInfoUpdate) => {
         const { value, displayValue, unit=quantityBaseUnit, validator,


### PR DESCRIPTION
In url API of SPHEREx spectral image search, for some unclear reason, `unit` doesn't get registered in field group state of Spatial search `SizeInputField` (which manifests as `viewProps.unit=undefined|null` in underlying `QuantityInputField`). This was breaking unit conversion and throwing the error. Now ensuring `unit` is always initialized in store from `initialState`.

## Testing
https://irsa-7677-spherex-api-fix.irsakubedev.ipac.caltech.edu/applications/spherex/?api
- the first two examples in above should work instead of throwing errors like before
- rest of examples should be working as they were before

Regression test other TAP queries in [firefly url api](https://fireflydev.ipac.caltech.edu/irsa-7677-spherex-api-fix/firefly/?api=tap). Here's a ObsTAP example (since spherex also uses ObsTAP): https://fireflydev.ipac.caltech.edu/irsa-7677-spherex-api-fix/firefly/?api=tap&service=https://ws.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/argus&schema=ivoa&table=ivoa.ObsCore&WorldPt=202.48417;47.23056;EQ_J2000&sr=20s&spatialRegionOperation=intersects