### PR TITLE
Firefly 2017 duckdb memory usage

### DIFF
--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -305,6 +305,7 @@ def main():
             f"-XX:MaxRAMPercentage={os.getenv('MAX_RAM_PERCENT', '80')}",
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:TrimNativeHeapInterval=30000",
+            "-XX:+UseZGC",
             f"-DADMIN_USER={admin_user}",
             f"-DADMIN_PASSWORD={admin_password}",
             f"-Dhost.name={os.getenv('HOSTNAME', '')}",

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheProvider.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheProvider.java
@@ -62,8 +62,8 @@ public class EhcacheProvider implements Cache.Provider {
      *   permManager — PERM_SMALL only; no custom SizeOfEngine so entry-count heap works, and
      *                 arbitrary objects (Semaphore, ConcurrentHashMap, …) are never deep-sized.
      */
-    private static final CacheManager visManager;
-    private static final CacheManager permManager;
+    private static CacheManager visManager;
+    private static CacheManager permManager;
     private static final DefaultStatisticsService visStats  = new DefaultStatisticsService();
     private static final DefaultStatisticsService permStats = new DefaultStatisticsService();
 
@@ -73,15 +73,10 @@ public class EhcacheProvider implements Cache.Provider {
      */
     private static final int DEF_TTI_SEC = 60 * 60;
 
-    static {
-        visManager = setupVisCacheManager();
-        permManager = setupPermCacheManager();
-    }
-
     public <T> Cache<T> getCache(String type) {
         org.ehcache.Cache<String, Object> ehcache = switch (type) {
-            case VIS_SHARED_MEM -> visManager.getCache(type, String.class, Object.class);
-            case PERM_SMALL     -> permManager.getCache(type, String.class, Object.class);
+            case VIS_SHARED_MEM -> getVisManager().getCache(type, String.class, Object.class);
+            case PERM_SMALL     -> getPermManager().getCache(type, String.class, Object.class);
             default -> throw new IllegalArgumentException("Unknown cache type.  Make sure cache type '" +
                     type + "' is defined in EhcacheProvider.");
         };
@@ -89,8 +84,8 @@ public class EhcacheProvider implements Cache.Provider {
     }
 
     public void shutdown() {
-        visManager.close();
-        permManager.close();
+        getVisManager().close();
+        getPermManager().close();
     }
 
     /** Returns live statistics for a named cache, or null if not found. */
@@ -102,8 +97,15 @@ public class EhcacheProvider implements Cache.Provider {
         };
     }
 
-    public CacheManager getVisManager()  { return visManager; }
-    public CacheManager getPermManager() { return permManager; }
+    public synchronized CacheManager getVisManager() {
+        if (visManager == null) visManager = setupVisCacheManager();
+        return visManager;
+    }
+
+    public synchronized CacheManager getPermManager() {
+        if (permManager == null) permManager = setupPermCacheManager();
+        return permManager;
+    }
 
     //====================================================================
     // VIS_SHARED_MEM: byte-based heap with CustomSizeOfEngine to handle HasSizeOf objects

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -83,12 +83,7 @@ abstract public class BaseDbAdapter implements DbAdapter {
             getRuntimeStats().peakMemDbs = Math.max(getDbInstances().size(), getRuntimeStats().peakMemDbs);
         }
         if (ins != null && create) {        // only update access time when create is requested.
-            try {
-                ins.getLock().lock();
-                ins.touch();
-            } finally {
-                ins.getLock().unlock();
-            }
+            ins.touch();
         }
         return ins;
 
@@ -591,16 +586,13 @@ abstract public class BaseDbAdapter implements DbAdapter {
         LOGGER.debug("%s -> closing DB, delete(%s): %s".formatted(getName(), deleteFile, getDbFile().getPath()));
         EmbeddedDbInstance db = getDbInstances().get(getDbFile().getPath());
         if (db != null) {
-            try {
-                db.getLock().lock();
+            synchronized (db) {
                 if (!deleteFile) {
                     compact();
                 }
                 shutdown(db);
-            } finally {
-                db.getLock().unlock();
-                getDbInstances().remove(db.getDbFile().getPath());
             }
+            getDbInstances().remove(db.getDbFile().getPath());
         }
         if (deleteFile) removeDbFile();
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
@@ -298,6 +299,7 @@ public interface DbAdapter {
         DbStats dbStats;
         boolean isResourceDb;
         volatile Connection rootConn;
+        final AtomicInteger activeConns = new AtomicInteger(0);
 
         EmbeddedDbInstance(String type, DbAdapter dbAdapter, String dbUrl, String driver) {
             this(type, dbAdapter, dbUrl, driver, System.currentTimeMillis());

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DbAdapter.java
@@ -18,7 +18,6 @@ import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.ReentrantLock;
 
 import static edu.caltech.ipac.util.StringUtils.isEmpty;
 
@@ -291,7 +290,6 @@ public interface DbAdapter {
      * so Firefly can enforce policy to manage memory usage.
      */
     class EmbeddedDbInstance extends DbInstance {
-        ReentrantLock lock = new ReentrantLock();
         long lastAccessed;
         long created;
         DbAdapter dbAdapter;
@@ -348,9 +346,6 @@ public interface DbAdapter {
             return isResourceDb ? DbMonitor.MAX_IDLE_TIME_RSC : DbMonitor.MAX_IDLE_TIME;
         }
 
-        public ReentrantLock getLock() {
-            return lock;
-        }
         public void setCompact(boolean compact) { isCompact = compact;}
         public boolean isCompact() { return isCompact; }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
@@ -22,6 +22,8 @@ import org.json.simple.JSONValue;
 import javax.sql.DataSource;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -95,12 +97,12 @@ public class DuckDbAdapter extends BaseDbAdapter {
                                 self.rootConn = super.getConnection(username, password);
                             }
                             try {
-                                return ((DuckDBConnection) self.rootConn).duplicate();
+                                return newTrackedConn(self, self.rootConn);
                             } catch (SQLException e) {
                                 // rootConn may be in a dirty state; reset and retry once
                                 try { self.rootConn.close(); } catch (Exception ignored) {}
                                 self.rootConn = super.getConnection(username, password);
-                                return ((DuckDBConnection) self.rootConn).duplicate();
+                                return newTrackedConn(self, self.rootConn);
                             }
                         }
                     }
@@ -174,10 +176,53 @@ public class DuckDbAdapter extends BaseDbAdapter {
 
     @Override
     protected void shutdown(EmbeddedDbInstance db) {
-        try {
-            if (db.rootConn != null && !db.rootConn.isClosed()) db.rootConn.close();
-        } catch (SQLException ignored) {}
-        db.rootConn = null;
+        synchronized (db) {
+            try {
+                if (db.rootConn != null && !db.rootConn.isClosed()) db.rootConn.close();
+            } catch (SQLException ignored) {}
+            db.rootConn = null;
+            db.activeConns.set(0);
+        }
+    }
+
+    /** Wraps a duplicate connection in a proxy that closes the root when the last active connection is released. */
+    private static Connection newTrackedConn(EmbeddedDbInstance db, Connection rootConn) throws SQLException {
+        DuckDBConnection dup = ((DuckDBConnection) rootConn).duplicate();
+        db.activeConns.incrementAndGet();
+        return (Connection) Proxy.newProxyInstance(
+            Connection.class.getClassLoader(),
+            new Class[]{Connection.class},
+            (proxy, method, args) -> {
+                if ("close".equals(method.getName())) {
+                    releaseConn(db, dup);
+                    return null;
+                }
+                if ("isWrapperFor".equals(method.getName()) && args != null && args[0] == DuckDBConnection.class) {
+                    return true;
+                }
+                if ("unwrap".equals(method.getName()) && args != null && args[0] == DuckDBConnection.class) {
+                    return dup;
+                }
+                try {
+                    return method.invoke(dup, args);
+                } catch (InvocationTargetException e) {
+                    throw e.getCause();
+                }
+            }
+        );
+    }
+
+    private static void releaseConn(EmbeddedDbInstance db, DuckDBConnection dup) {
+        try { dup.close(); } catch (Exception ignored) {}
+        synchronized (db) {
+            if (db.activeConns.decrementAndGet() <= 0) {
+                db.activeConns.set(0);
+                if (db.rootConn != null) {
+                    try { db.rootConn.close(); } catch (Exception ignored) {}
+                    db.rootConn = null;
+                }
+            }
+        }
     }
 
     protected void removeDbFile() {
@@ -230,11 +275,12 @@ public class DuckDbAdapter extends BaseDbAdapter {
 
         String createDataSql = createDataSql(colsAry, tblName);
 
-        try (DuckDBConnection conn = (DuckDBConnection) JdbcFactory.getDataSource(getDbInstance()).getConnection();
-             Statement  stmt = conn.createStatement() ) {
-
+        try (Connection wrapper = JdbcFactory.getDataSource(getDbInstance()).getConnection()) {
+            DuckDBConnection conn = wrapper.unwrap(DuckDBConnection.class);
             conn.setAutoCommit(false);
-            stmt.execute(createDataSql);
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute(createDataSql);
+            }
 
             if (totalRows > 0) {
                 // using try-with-resources to automatically close the appender at the end of the scope

--- a/src/firefly/java/edu/caltech/ipac/table/io/TableParseHandler.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/TableParseHandler.java
@@ -15,6 +15,7 @@ import org.duckdb.DuckDBAppender;
 import org.duckdb.DuckDBConnection;
 
 import java.io.IOException;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -103,6 +104,7 @@ public interface TableParseHandler {
         DataType[] cols;
         int rowCnt;
         DuckDBAppender appender;
+        Connection connWrapper;
         DuckDBConnection conn;
         List<Integer> aryIdx;
 
@@ -121,7 +123,8 @@ public interface TableParseHandler {
                 dbAdapter.ingestData(() -> table, dbAdapter.getDataTable());
 
                 // prepare to ingest data into database
-                conn = (DuckDBConnection) JdbcFactory.getDataSource(dbAdapter.getDbInstance()).getConnection();
+                connWrapper = JdbcFactory.getDataSource(dbAdapter.getDbInstance()).getConnection();
+                conn = connWrapper.unwrap(DuckDBConnection.class);
                 conn.setAutoCommit(false);
                 appender = conn.createAppender(DuckDBConnection.DEFAULT_SCHEMA, dbAdapter.getDataTable());
             } catch (SQLException | DataAccessException e) {
@@ -139,9 +142,9 @@ public interface TableParseHandler {
         }
 
         public void end() {
-            if (conn != null)       Try.it(() -> conn.commit());
-            if (appender != null)   Try.it(() -> appender.close());
-            if (conn != null)       Try.it(() -> conn.close());
+            if (conn != null)           Try.it(() -> conn.commit());
+            if (appender != null)       Try.it(() -> appender.close());
+            if (connWrapper != null)    Try.it(() -> connWrapper.close());
         }
     }
 }

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/packagedata/obscorepackager/DatalinkUtilTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/packagedata/obscorepackager/DatalinkUtilTest.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.server.packagedata.obscorepackager;
 
+import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.DataObject;
 import edu.caltech.ipac.table.DataType;
@@ -20,7 +21,7 @@ import java.util.List;
  * @author kartik
  * @version : $
  */
-public class DatalinkUtilTest {
+public class DatalinkUtilTest extends ConfigTest {
 
     @Test
     public void testCreateUrlFromServDesc_withValuesAndRefs() {

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/packagedata/obscorepackager/ObsCoreUtilTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/packagedata/obscorepackager/ObsCoreUtilTest.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.server.packagedata.obscorepackager;
 
+import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.table.MappedData;
 import org.junit.Assert;
 import org.junit.Test;
@@ -20,7 +21,7 @@ import java.util.Map;
  * @author kartik
  * @version : $
  */
-public class ObsCoreUtilTest {
+public class ObsCoreUtilTest extends ConfigTest {
 
     @Test
     public void testTestSem() {

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/query/PhaseFoldedLightCurveTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/query/PhaseFoldedLightCurveTest.java
@@ -1,5 +1,6 @@
 package edu.caltech.ipac.firefly.server.query;
 
+import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.table.io.IpacTableException;
 import edu.caltech.ipac.firefly.server.query.lc.PhaseFoldedLightCurve;
 import edu.caltech.ipac.firefly.util.FileLoader;
@@ -15,7 +16,7 @@ import org.junit.Test;
  *  DM-8028
  *    Use teh UnitTestUtility to load file
  */
-public class PhaseFoldedLightCurveTest {
+public class PhaseFoldedLightCurveTest extends ConfigTest {
 
     private static final float period = 0.140630f;
     private static final String timeColName = "mjd";

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/rpc/ResolveNaifidNameTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/rpc/ResolveNaifidNameTest.java
@@ -1,5 +1,6 @@
 package edu.caltech.ipac.firefly.server.rpc;
 
+import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.firefly.data.ServerParams;
 import edu.caltech.ipac.firefly.server.SrvParam;
 import org.junit.Assert;
@@ -8,7 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 
-public class ResolveNaifidNameTest {
+public class ResolveNaifidNameTest extends ConfigTest {
 
     @Test
     public void testDoCommand() throws Exception {

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/DataGroupReadTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/DataGroupReadTest.java
@@ -43,7 +43,7 @@ import static edu.caltech.ipac.firefly.TestUtil.logMemUsage;
  * @author loi
  * @version $Id: IpacTableParser.java,v 1.18 2011/12/08 19:34:02 loi Exp $
  */
-public class DataGroupReadTest {
+public class DataGroupReadTest extends ConfigTest {
 
     private static final File largeIpacTable = getDataFile("large-ipac-tables/wise-950000.tbl");
     private static final File midIpacTable = getDataFile(DataGroupReadTest.class, "50k.tbl");

--- a/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/IpacTableTest.java
+++ b/src/firefly/test/edu/caltech/ipac/firefly/server/util/tables/IpacTableTest.java
@@ -3,6 +3,7 @@
  */
 package edu.caltech.ipac.firefly.server.util.tables;
 
+import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.firefly.data.DecimateInfo;
 import edu.caltech.ipac.firefly.data.SortInfo;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
@@ -33,7 +34,7 @@ import static edu.caltech.ipac.table.JsonTableUtil.getMetaFromAllMeta;
  * @author loi
  * @version $Id: IpacTableParser.java,v 1.18 2011/12/08 19:34:02 loi Exp $
  */
-public class IpacTableTest {
+public class IpacTableTest extends ConfigTest {
 
     private static final File ipacTable = FileLoader.resolveFile(IpacTableTest.class,  "IpacTableTest.tbl");
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-2017
- Revert back to open/close connection on each use model
- Close when there's no active connections
- When open, return duplicate connection to avoid multiple connections to the same db

Also:
- Fix intermittently failing tests
- Lazy load ehcache manager.  May resolve failure during redeploy.

Test: https://fireflydev.ipac.caltech.edu/firefly-2017-duckdb-memory-usage/firefly/
It’s hard to test. I checked to ensure that the pod’s memory usage doesn’t increase over time.  I then compare it to nightly builds, as that’s where the bug was introduced.  In nightly builds, the memory usage steadily increased and never decreased.
