### PR TITLE
FIREFLY-2018: Changes to remove JSP from alertviewer

### DIFF
--- a/config/web.xml
+++ b/config/web.xml
@@ -105,7 +105,7 @@
 
     <servlet>
         <servlet-name>alertviewer</servlet-name>
-        <jsp-file>/alertviewer.html</jsp-file>
+        <servlet-class>edu.caltech.ipac.firefly.server.servlets.AlertViewerServlet</servlet-class>
     </servlet>
     <servlet-mapping>
         <servlet-name>alertviewer</servlet-name>

--- a/src/firefly/html/alertviewer.html
+++ b/src/firefly/html/alertviewer.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-    <link rel="icon" type="image/x-icon" href="${pageContext.request.contextPath}/images/fftools-logo-16x16.png">
+    <link rel="icon" type="image/x-icon" href="./images/fftools-logo-16x16.png">
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <title>Alert Viewer</title>
 
@@ -15,7 +15,7 @@
             }
         };
     </script>
-    <script  type="text/javascript" src="${pageContext.request.contextPath}/firefly_loader.js"></script>
+    <script  type="text/javascript" src="./firefly_loader.js"></script>
 </head>
 
 <body style="margin: 0">
@@ -28,4 +28,3 @@
 </body>
 
 </html>
-

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AlertViewerServlet.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/AlertViewerServlet.java
@@ -1,0 +1,19 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.servlets;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+public class AlertViewerServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        req.getRequestDispatcher("/alertviewer.html").forward(req, res);
+    }
+}


### PR DESCRIPTION
**Ticket**: [FIREFLY-2018](https://jira.ipac.caltech.edu/browse/FIREFLY-2018)
- removed JSP usage
- added a small servlet to make the `/alertviewer/*` paths routed paths work
- Updated `xml` file on suit as well to remove JSP: https://github.com/lsst/suit/pull/85

**Testing**: 
[Firefly](https://fireflydev.ipac.caltech.edu/firefly-2018-alerts-jsp/firefly) & [Suit](https://alertviewer-test-portal.irsakubedev.ipac.caltech.edu/suit) 
- Check if you can get to the Alert Viewer
- To test searches and results, check out this branch locally and run firefly and suit