### PR TITLE
FIREFLY-2023: Prepare Download button sometimes not appearing

### DIFF
--- a/src/firefly/js/tables/TableUtil.js
+++ b/src/firefly/js/tables/TableUtil.js
@@ -262,7 +262,8 @@ export function getTableUiById(tbl_ui_id) {
  */
 export function getTableUiByTblId(tbl_id) {
     const uiRoot = get(flux.getState(), [TblCntlr.TABLE_SPACE_PATH, 'ui'], {});
-    return Object.values(uiRoot).find( (tblUiState) => tblUiState?.tbl_id === tbl_id);
+    const tblUiStates = Object.values(uiRoot).filter( (tblUiState) => tblUiState?.tbl_id === tbl_id);
+    return tblUiStates.find( (tblUiState) => tblUiState?.tbl_ui_id) ?? tblUiStates[0];
 }
 
 /**
@@ -1690,4 +1691,3 @@ function watchForTableLoaded(afterLoaded, tbl_id) {
         });
     }
 }
-

--- a/src/firefly/js/templates/common/ttFeatureWatchers.js
+++ b/src/firefly/js/templates/common/ttFeatureWatchers.js
@@ -54,8 +54,6 @@ function isObsCoreish(tableOrId) {
 
 function watchForObsCoreTable(tbl_id, action, cancelSelf) {
     if (action) return;
-    const {leftButtons=[]} = getTableUiByTblId(tbl_id);
-    if (leftButtons.some((lb) => lb.prepareDownloadBtn)) return;
     setupObsCorePackaging(tbl_id);
     cancelSelf();
 }
@@ -78,7 +76,7 @@ function setupObsCorePackaging(tbl_id) {
 
     const dlProps = getDataServiceOptionByTable('obsCoreDownloadProps', table, {}) || {};
 
-    const {tbl_ui_id, leftButtons=[]}= getTableUiByTblId(tbl_id) ?? {} ;
+    const {tbl_ui_id, leftButtons=[]}= getTableUiByTblId(tbl_id) ?? {};
     const prepareDownloadFunc = () => <PrepareDownload {...dlProps} />;
     prepareDownloadFunc.prepareDownloadBtn = true;
     leftButtons.unshift(prepareDownloadFunc);
@@ -281,5 +279,5 @@ export const PrepareDownload = React.memo(({table_id, tbl_title, viewerId, showF
 });
 
 PrepareDownload.Props = {
-    tbl_id: String,
+    table_id: String,
 };


### PR DESCRIPTION
**Ticket**: https://jira.ipac.caltech.edu/browse/FIREFLY-2023
- Upon further inspection, this bug exists for all tables loaded from `Job Monitor` (they will miss `Prepare Download` button if it should exist for the table)
- this is due to potentially multiple (more than 1) tbl ui states found in `getTableUiByTblId`, one of which may contain the valid `tbl_ui_id` (which is required to show `Prepare Download` button)
- As a hot fix, filter the multiple tbl ui states and return the one that contains `tbl_ui_id`
  - more robust fix to determine why multiple UI states are being created will need to be inspected and fixed in a new `dev` ticket

**Testing**: 
- On ops/test, you can verify this bug for any app: 
  - Do any of the searches below, Send to background (before results load, or close any open results) and load the results from Job Monitor. You'll notice missing `Prepare Download` button. 
- [Firefly](https://fireflydev.ipac.caltech.edu/firefly-2023-prepare-download-bug/firefly): Do an SIAv2 Search in firefly. Send to background. Load from background, check if the `Prepare Download` button exists. 
- [Euclid](https://firefly-2023-prepare-download-bug.irsakubedev.ipac.caltech.edu/applications/euclid): Do an Image of Object search. Send to background. (if the table is already loaded, close the table and load it again from job monitor). Check if `Prepare Download` button exists. 
- [Spherex](https://firefly-2023-prepare-download-bug.irsakubedev.ipac.caltech.edu/applications/spherex): Do a Spectrophotometry Search (I would load up 2  default examples and send to background). Come back in few mins and load results from Job Monitor. Check if the `Prepare Download` button exists. 
- [DCE](https://firefly-2023-prepare-download-bug.irsakubedev.ipac.caltech.edu/irsaviewer/dce): Repeat the steps above.  