### PR TITLE
FIREFLY-2038: Add support for cross origin session affinity cookies

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -5,14 +5,20 @@
     {{- $affinityAnnotations = dict
       "nginx.ingress.kubernetes.io/affinity" "cookie"
       "nginx.ingress.kubernetes.io/affinity-mode" "persistent"
-      "nginx.ingress.kubernetes.io/session-cookie-change-on-failure" "true" }}
+      "nginx.ingress.kubernetes.io/session-cookie-change-on-failure" "true"
+      "nginx.ingress.kubernetes.io/session-cookie-samesite" "None"
+      "nginx.ingress.kubernetes.io/session-cookie-secure" "true" }}
   {{- else if eq .Values.ingress.className "traefik" }}
     {{- $affinityAnnotations = dict
-      "traefik.ingress.kubernetes.io/service.sticky.cookie" "true" }}
+      "traefik.ingress.kubernetes.io/service.sticky.cookie" "true"
+      "traefik.ingress.kubernetes.io/service.sticky.cookie.secure" "true"
+      "traefik.ingress.kubernetes.io/service.sticky.cookie.samesite" "none" }}
   {{- else if eq .Values.ingress.className "haproxy" }}
     {{- $affinityAnnotations = dict
       "haproxy.org/load-balance" "leastconn"
-      "haproxy.org/cookie-persistence" "SERVERID" }}
+      "haproxy.org/cookie-persistence" "SERVERID"
+      "haproxy.org/cookie-samesite" "None"
+      "haproxy.org/cookie-secure" "true" }}
   {{- end }}
 {{- end }}
 {{- $mergedAnnotations := merge .Values.ingress.annotations $affinityAnnotations }}

--- a/src/firefly/config/app.prop
+++ b/src/firefly/config/app.prop
@@ -29,3 +29,5 @@ irsa.gator.service.periodogram.keys=x y alg step_method pmin pmax step_size peak
 # IRSA HiPS map service
 irsa.hips.masterUrl=@irsa.hips.masterUrl@
 inventory.serverURLAry=@inventory.serverURLAry@
+
+allow.cross.origin = true

--- a/src/firefly/config/app.prop
+++ b/src/firefly/config/app.prop
@@ -30,4 +30,4 @@ irsa.gator.service.periodogram.keys=x y alg step_method pmin pmax step_size peak
 irsa.hips.masterUrl=@irsa.hips.masterUrl@
 inventory.serverURLAry=@inventory.serverURLAry@
 
-allow.cross.origin = true
+allow.cross.origin=true

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/RequestOwner.java
@@ -236,6 +236,7 @@ public class RequestOwner implements Cloneable {
         Cookie cookie = new Cookie(USER_KEY, userKey);
         cookie.setMaxAge(USER_KEY_EXPIRY);
         cookie.setPath(requestAgent.getContextPath());
+        cookie.setHttpOnly(true);
         requestAgent.sendCookie(cookie);
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/filters/CommonFilter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/filters/CommonFilter.java
@@ -3,17 +3,16 @@
  */
 package edu.caltech.ipac.firefly.server.filters;
 
-import edu.caltech.ipac.firefly.server.RequestOwner;
 import edu.caltech.ipac.firefly.server.ServerContext;
-import edu.caltech.ipac.firefly.server.cache.EhcacheProvider;
-import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
-import edu.caltech.ipac.util.cache.CacheManager;
 
+import edu.caltech.ipac.util.AppProperties;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Set;
 
 
 /**
@@ -24,18 +23,26 @@ import java.io.IOException;
  */
 public class CommonFilter implements Filter {
 
+    private static final boolean ALLOW_CROSS_ORIGIN = AppProperties.getBooleanProperty("allow.cross.origin", true);
+
     public void init(FilterConfig filterConfig) throws ServletException {
     }
 
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
-        ServerContext.clearRequestOwner();
-        if (request instanceof HttpServletRequest) {
-            HttpServletRequest httpReq = (HttpServletRequest) request;
-            setupRequestOwner(httpReq, (HttpServletResponse)response);
+        if (request instanceof HttpServletRequest httpReq) {
+            try {
+                ServerContext.clearRequestOwner();
+                setupRequestOwner(httpReq, (HttpServletResponse)response);
+
+                filterChain.doFilter( request, response );
+            } finally {
+                if (ALLOW_CROSS_ORIGIN) {
+                    applyCookieAttributes((HttpServletResponse)response, Set.of("JSESSIONID", "usrkey"));
+                }
+                // clean up ThreadLocal instances.
+                StopWatch.clear();
+            }
         }
-        filterChain.doFilter( request, response );
-        // clean up ThreadLocal instances.
-        StopWatch.clear();
     }
 
     public void destroy() {}
@@ -43,6 +50,34 @@ public class CommonFilter implements Filter {
     public static void setupRequestOwner(HttpServletRequest request, HttpServletResponse response) {
         // Initialize the RequestOwner for the current request.
         ServerContext.getRequestOwner().init(ServerContext.getHttpRequestAgent(request, response));
+    }
+
+    public static void applyCookieAttributes(HttpServletResponse response, Set<String> cookieNames) {
+        Collection<String> headers = response.getHeaders("Set-Cookie");
+        boolean first = true;
+        for (String header : headers) {
+            String modified = header;
+            String lowerCase = header.toLowerCase();
+            boolean matches = cookieNames.stream()
+                    .anyMatch(name -> lowerCase.contains(name.toLowerCase()));
+            if (matches) {
+                if (!lowerCase.contains("samesite")) {
+                    modified = modified + "; SameSite=None";
+                }
+                if (!lowerCase.contains("secure")) {
+                    modified = modified + "; Secure";
+                }
+                if (!lowerCase.contains("httponly")) {
+                    modified = modified + "; HttpOnly";
+                }
+            }
+            if (first) {
+                response.setHeader("Set-Cookie", modified);
+                first = false;
+            } else {
+                response.addHeader("Set-Cookie", modified);
+            }
+        }
     }
 
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/filters/CommonFilter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/filters/CommonFilter.java
@@ -11,7 +11,6 @@ import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Set;
 
 
@@ -29,19 +28,19 @@ public class CommonFilter implements Filter {
     }
 
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
-        if (request instanceof HttpServletRequest httpReq) {
-            try {
-                ServerContext.clearRequestOwner();
+        try {
+            ServerContext.clearRequestOwner();
+            if (request instanceof HttpServletRequest httpReq) {
                 setupRequestOwner(httpReq, (HttpServletResponse)response);
-
-                filterChain.doFilter( request, response );
-            } finally {
-                if (ALLOW_CROSS_ORIGIN) {
-                    applyCookieAttributes((HttpServletResponse)response, Set.of("JSESSIONID", "usrkey"));
-                }
-                // clean up ThreadLocal instances.
-                StopWatch.clear();
             }
+
+            filterChain.doFilter( request, response );
+
+        } finally {
+            if (ALLOW_CROSS_ORIGIN) {
+                applyCookieAttributes((HttpServletResponse)response, Set.of("JSESSIONID", "usrkey"));
+            }
+            StopWatch.clear();
         }
     }
 
@@ -53,7 +52,7 @@ public class CommonFilter implements Filter {
     }
 
     public static void applyCookieAttributes(HttpServletResponse response, Set<String> cookieNames) {
-        Collection<String> headers = response.getHeaders("Set-Cookie");
+        java.util.List<String> headers = new java.util.ArrayList<>(response.getHeaders("Set-Cookie"));
         boolean first = true;
         for (String header : headers) {
             String modified = header;

--- a/src/firefly/js/Firefly.js
+++ b/src/firefly/js/Firefly.js
@@ -476,8 +476,6 @@ function bootstrap(props, clientAppSpecificOptions, webApiCommands) {
         bootstrapRedux( getBootstrapRegistry(), processDecor);
         flux.process( {type : APP_LOAD} );  // setup initial store/state
 
-        ensureUsrKey();
-
         let srvAppSpecificOptions={};
         try {
             srvAppSpecificOptions= await getJsonProperty('FIREFLY_OPTIONS');
@@ -576,32 +574,3 @@ function handleWebApi(webApiCommands, appProps, element, doAppRender) {
             break;
     }
 }
-
-function ensureUsrKey() {
-    if (hasOldUsrKey()) {
-        document.cookie = 'usrkey=;path=/;max-age=-1';
-        document.cookie = `usrkey=;path=${location.pathname};max-age=-1`;
-    }
-    const usrKey = getCookie('usrkey');
-    if (!usrKey) {
-        document.cookie = `usrkey=${uuid()};max-age=${3600 * 24 * 7 * 2}`;
-    }
-}
-
-function hasOldUsrKey() {
-    return document.cookie.split(';').map((s) => s.trim())
-        .some( (c) => {
-            const [name='', val=''] = c.split('=');
-            return name === 'usrkey' && val.includes('/');
-        });
-
-}
-
-function getCookie(name) {
-    return ('; ' + document.cookie)
-        .split('; ' + name + '=')
-        .pop()
-        .split(';')
-        .shift();
-}
-


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-2038

Configures ingress session affinity for cross-site requests and adds a configurable option to stamp cookies with attributes required for cross-origin.

Test: https://firefly-2038-samesite-cookies.irsakubedev.ipac.caltech.edu/irsaviewer/

- Open a private window and ensure all cookies are deleted.
- Reload the webpage or application. Verify that the INGRESSCOOKIE, JSESSIONID, and usrkey cookies have the SameSite attribute set to “none” and the secure attribute checked.

- Start Jupiter Lab and point FIREFLY_URL to this built instance.
- Verify that the INGRESSCOOKIE, JSESSIONID, and usrkey cookies still have the SameSite attribute set to “none” and the secure attribute checked.
- Inspect the HTTP request to ensure that these cookies are included in the request.