### PR TITLE
Firefly 2045: Fix WebSocket connection leak on client and server

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheProvider.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/cache/EhcacheProvider.java
@@ -89,8 +89,16 @@ public class EhcacheProvider implements Cache.Provider {
     }
 
     public void shutdown() {
-        visManager.close();
-        permManager.close();
+        try {
+            visManager.close();
+            permManager.close();
+        } finally {
+            new File(getPermDiskDir(), ".lock").delete();
+        }
+    }
+
+    private static File getPermDiskDir() {
+        return new File(new File(System.getProperty("java.io.tmpdir"), "ehcache"), ServerContext.getAppName());
     }
 
     /** Returns live statistics for a named cache, or null if not found. */
@@ -144,8 +152,7 @@ public class EhcacheProvider implements Cache.Provider {
     //====================================================================
     private static CacheManager setupPermCacheManager() {
         // Disk store for PERM_SMALL persistence
-        File ehcacheRoot = new File(System.getProperty("java.io.tmpdir"), "ehcache");
-        File diskDir = new File(ehcacheRoot, ServerContext.getAppName());
+        File diskDir = getPermDiskDir();
         PersistentCacheManager manager = CacheManagerBuilder.newCacheManagerBuilder()
                 .using(permStats)
                 .with(CacheManagerBuilder.persistence(diskDir))

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventManager.java
@@ -13,10 +13,14 @@ import edu.caltech.ipac.firefly.data.ServerEvent;
 import edu.caltech.ipac.firefly.server.ServerContext;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.firefly.util.event.Name;
+import edu.caltech.ipac.util.AppProperties;
 import edu.caltech.ipac.util.StringUtils;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 /**
  * @author Trey Roby
@@ -24,6 +28,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class ServerEventManager {
 
     private static final boolean USE_MESSAGE_EVENT_WORKER = true;
+    static final int MAX_WS_PER_CHANNEL = AppProperties.getIntProperty("max.ws.per.channel", 10);
     private static final EventWorker eventWorker = USE_MESSAGE_EVENT_WORKER ?
                                                     new MessageEventWorker() : new LocalEventWorker();
     private static final List<ServerEventQueue> localEventQueues = new CopyOnWriteArrayList<>();
@@ -100,10 +105,27 @@ public class ServerEventManager {
         }
     }
 
-    public static void addEventQueue(ServerEventQueue queue) {
+    public static synchronized void addEventQueue(ServerEventQueue queue) {
         Logger.info("Channel: create new Queue for: "+ queue.getQueueID() );
+        enforceChannelLimit(queue.getChannel(), MAX_WS_PER_CHANNEL);
         localEventQueues.add(queue);
-        allEventQueues.setQueueListForNode(localEventQueues);
+        allEventQueues.setQueueListForNode(new ArrayList<>(localEventQueues));
+    }
+
+    private static void enforceChannelLimit(String channelID, int maxConn) {
+        List<ServerEventQueue> channelConns = localEventQueues.stream()
+                .filter(q -> channelID.equals(q.getChannel()) && q.getEventConnector().isOpen())
+                .collect(Collectors.toList());
+        if (channelConns.size() >= maxConn) {
+            channelConns.sort(Comparator.comparing(ServerEventQueue::getConnID));
+            int toEvict = channelConns.size() - (maxConn - 1);
+            Logger.warn("Channel: " + channelID + " at limit (" + maxConn + "), evicting " + toEvict + " oldest connection(s)");
+            for (int i = 0; i < toEvict; i++) {
+                ServerEventQueue q = channelConns.get(i);
+                q.getEventConnector().close();
+                localEventQueues.remove(q);
+            }
+        }
     }
 
     /**
@@ -148,9 +170,9 @@ public class ServerEventManager {
         if (delivered) deliveredEventCnt++;
     }
 
-    public static void removeEventQueue(ServerEventQueue queue) {
+    public static synchronized void removeEventQueue(ServerEventQueue queue) {
         localEventQueues.remove(queue);
-        allEventQueues.setQueueListForNode(localEventQueues);
+        allEventQueues.setQueueListForNode(new ArrayList<>(localEventQueues));
     }
 
 //====================================================================
@@ -167,10 +189,16 @@ public class ServerEventManager {
         return cnt;
     }
 
-    public static List<ServerEventQueue.QueueDescription> getQueueDescriptionList(int limit) {
-        return localEventQueues.stream()
+    public record ChannelSummary(String channel, int count, long lastPutTime) {}
+
+    public static List<ChannelSummary> getChannelSummary(int limit) {
+        return getAllEventQueue().stream()
                 .map(ServerEventQueue::convertToDescription)
-                .sorted((d1,d2) -> (int)(d2.lastPutTime()-d1.lastPutTime()))
+                .collect(Collectors.groupingBy(ServerEventQueue.QueueDescription::channel))
+                .entrySet().stream()
+                .map(e -> new ChannelSummary(e.getKey(), e.getValue().size(),
+                        e.getValue().stream().mapToLong(ServerEventQueue.QueueDescription::lastPutTime).max().orElse(0)))
+                .sorted(Comparator.comparingInt(ChannelSummary::count).reversed())
                 .limit(limit)
                 .toList();
     }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventManager.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventManager.java
@@ -189,17 +189,10 @@ public class ServerEventManager {
         return cnt;
     }
 
-    public record ChannelSummary(String channel, int count, long lastPutTime) {}
-
-    public static List<ChannelSummary> getChannelSummary(int limit) {
+    public static List<ServerEventQueue.QueueDescription> getQueueList() {
         return getAllEventQueue().stream()
                 .map(ServerEventQueue::convertToDescription)
-                .collect(Collectors.groupingBy(ServerEventQueue.QueueDescription::channel))
-                .entrySet().stream()
-                .map(e -> new ChannelSummary(e.getKey(), e.getValue().size(),
-                        e.getValue().stream().mapToLong(ServerEventQueue.QueueDescription::lastPutTime).max().orElse(0)))
-                .sorted(Comparator.comparingInt(ChannelSummary::count).reversed())
-                .limit(limit)
+                .sorted(Comparator.comparingLong(ServerEventQueue.QueueDescription::lastPutTime).reversed())
                 .toList();
     }
 

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventQueue.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventQueue.java
@@ -28,6 +28,7 @@ public class ServerEventQueue implements Serializable {
     private String channel;
     private String userKey;
     private transient long lastPutTime= 0;
+    private transient long createTime= System.currentTimeMillis();
 
     protected ServerEventQueue() {
         this.eventTerminal = null;
@@ -159,7 +160,7 @@ public class ServerEventQueue implements Serializable {
         public void close();
     }
 
-    public QueueDescription convertToDescription() { return new QueueDescription(connID,channel,userKey,lastPutTime); }
+    public QueueDescription convertToDescription() { return new QueueDescription(connID,channel,userKey, lastPutTime > 0 ? lastPutTime : createTime); }
 
     public record QueueDescription(String connID, String channel, String userKey, long lastPutTime) {}
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventQueue.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/ServerEventQueue.java
@@ -27,8 +27,7 @@ public class ServerEventQueue implements Serializable {
     private String connID;
     private String channel;
     private String userKey;
-    private transient long lastPutTime= 0;
-    private transient long createTime= System.currentTimeMillis();
+    private transient long lastPutTime= System.currentTimeMillis();
 
     protected ServerEventQueue() {
         this.eventTerminal = null;
@@ -160,7 +159,7 @@ public class ServerEventQueue implements Serializable {
         public void close();
     }
 
-    public QueueDescription convertToDescription() { return new QueueDescription(connID,channel,userKey, lastPutTime > 0 ? lastPutTime : createTime); }
+    public QueueDescription convertToDescription() { return new QueueDescription(connID,channel,userKey,lastPutTime); }
 
     public record QueueDescription(String connID, String channel, String userKey, long lastPutTime) {}
 }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/events/WebsocketConnector.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/events/WebsocketConnector.java
@@ -59,6 +59,7 @@ public class WebsocketConnector implements ServerEventQueue.EventConnector {
             LOG.info(PREFIX+" open "+makeChannelStr(session));
         } catch (Exception e) {
             LOG.error(e, PREFIX+" Unable to open websocket connection:" + makeChannelStr(session));
+            try { session.close(new CloseReason(CloseReason.CloseCodes.UNEXPECTED_CONDITION, "Server error during connection setup")); } catch (Exception ignored) {}
         }
     }
 
@@ -93,8 +94,18 @@ public class WebsocketConnector implements ServerEventQueue.EventConnector {
 
     @OnClose
     public void onClose(Session session, CloseReason closeReason) {
-        ServerEventManager.removeEventQueue(eventQueue);
-        updateClientConnections(CONN_UPDATED, channelID, userKey);
+
+        try {
+            ServerEventManager.removeEventQueue(eventQueue);
+        } catch (Exception e) {
+            LOG.error(e, PREFIX+" Failed to remove event queue on close: " + (eventQueue != null ? eventQueue.getConnID() : "null"));
+        }
+        try {
+            updateClientConnections(CONN_UPDATED, channelID, userKey);
+        } catch (Exception e) {
+            LOG.error(e, PREFIX+" Failed to update client connections on close");
+        }
+
         if (closeReason!=null && session!=null) {
             String reason= closeReason.getCloseCode().toString() +
                     (closeReason.getReasonPhrase()!=null ? " - "+closeReason.getReasonPhrase() : "");

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
@@ -382,15 +382,16 @@ public class ServerStatus extends BaseHttpServlet {
         int qCnt= ServerEventManager.getActiveQueueCnt();
         w.println("  - Total active queues:" + qCnt);
         if(qCnt>0) {
-            w.println("  - "+ (qCnt>10? "10 Most recently used channels:" :  "Channel list, ordered by last use:"));
-            w.println(makeQueueList());
+            w.println("  - "+ (qCnt>20? "Top 20 channels by connection count:" :  "Channel list, ordered by connection count:"));
+            w.println(makeQueueList(20));
         }
     }
 
-    private static String makeQueueList() {
-        return ServerEventManager.getQueueDescriptionList(10).stream()
-                .map( d -> String.format("     - %s, %s\n",d.channel(), new Date(d.lastPutTime())))
-                .reduce("", (all, entry) -> all+entry);
+    private static String makeQueueList(int limit) {
+        return ServerEventManager.getChannelSummary(limit).stream()
+                .map(s -> String.format("     - %s (%d conn), last use: %s\n",
+                        s.channel(), s.count(), new Date(s.lastPutTime())))
+                .reduce("", (all, entry) -> all + entry);
     }
 
     private static void showMessagingStatus(PrintWriter w) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/servlets/ServerStatus.java
@@ -16,6 +16,7 @@ import edu.caltech.ipac.firefly.server.db.DbMonitor;
 import edu.caltech.ipac.firefly.server.db.DuckDbAdapter;
 import edu.caltech.ipac.firefly.server.db.HsqlDbAdapter;
 import edu.caltech.ipac.firefly.server.events.ServerEventManager;
+import edu.caltech.ipac.firefly.server.events.ServerEventQueue;
 import edu.caltech.ipac.firefly.server.util.Logger;
 import edu.caltech.ipac.util.FileUtil;
 import edu.caltech.ipac.util.KeyVal;
@@ -35,6 +36,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.LinkedList;
@@ -375,20 +377,37 @@ public class ServerStatus extends BaseHttpServlet {
         return (hostname!=null && hostname.contains("-") && !hostname.contains("."));
     }
 
+    private record ChannelSummary(String channel, int count, long lastPutTime) {}
+
+    private static List<ChannelSummary> getChannelSummaries(List<ServerEventQueue.QueueDescription> conns) {
+        return conns.stream()
+                .collect(Collectors.groupingBy(ServerEventQueue.QueueDescription::channel))
+                .entrySet().stream()
+                .map(e -> new ChannelSummary(e.getKey(), e.getValue().size(),
+                        e.getValue().stream().mapToLong(ServerEventQueue.QueueDescription::lastPutTime).max().orElse(0)))
+                .toList();
+    }
+
     private static void showEventsStatus(PrintWriter w) {
         w.println("Server Events Information");
         w.println("  - Total events fired:" + ServerEventManager.getTotalEventCnt());
         w.println("  - Total events delivered:" + ServerEventManager.getDeliveredEventCnt());
         int qCnt= ServerEventManager.getActiveQueueCnt();
         w.println("  - Total active queues:" + qCnt);
-        if(qCnt>0) {
-            w.println("  - "+ (qCnt>20? "Top 20 channels by connection count:" :  "Channel list, ordered by connection count:"));
-            w.println(makeQueueList(20));
+        if (qCnt > 0) {
+            List<ServerEventQueue.QueueDescription> conns = ServerEventManager.getQueueList();
+            w.println("  - Top 10 channels by connection count:");
+            w.println(formatSummaries(getChannelSummaries(conns).stream()
+                    .sorted(Comparator.comparingInt(ChannelSummary::count).reversed())
+                    .limit(10).toList()));
+            w.println("  - Top 10 most recently active connections:");
+            conns.stream().limit(10).forEach(d ->
+                    w.printf("     - id: %-8s  channel: %s, last use: %s\n", d.connID(), d.channel(), new Date(d.lastPutTime())));
         }
     }
 
-    private static String makeQueueList(int limit) {
-        return ServerEventManager.getChannelSummary(limit).stream()
+    private static String formatSummaries(List<ChannelSummary> summaries) {
+        return summaries.stream()
                 .map(s -> String.format("     - %s (%d conn), last use: %s\n",
                         s.channel(), s.count(), new Date(s.lastPutTime())))
                 .reduce("", (all, entry) -> all + entry);

--- a/src/firefly/js/core/messaging/WebSocketClient.js
+++ b/src/firefly/js/core/messaging/WebSocketClient.js
@@ -7,6 +7,7 @@ import {parseUrl, getRootURL} from '../../util/WebUtil.js';
 import {Logger} from '../../util/Logger.js';
 import {WSCH} from '../History.js';
 import {dispatchConnectionStatus, getAppOptions} from '../AppDataCntlr.js';
+import {synchronizeAsyncFunctionById} from '../../util/SynchronizeAsync.js';
 
 export const CH_ID = 'channelID';
 
@@ -29,43 +30,38 @@ const logger = Logger('WebSocket');
 /**
  * returns a wsClient for the given baseUrl
  * @param baseUrl   the base URL to connect to
- * @return {Promise<wsClient>}
+ * @return {wsClient}
  */
 export function getWsConn(baseUrl=getRootURL()) {
-    return conns[baseUrl] || {isConnected: ()=>false, isConnecting: false};
+    return conns[baseUrl] || {isConnected: ()=>false};
 }
 
 /**
- * returns a wsClient for the given baseUrl, create if one does not exists
+ * returns a wsClient for the given baseUrl, create if one does not exist.
+ * guaranteed to only open one connection at a time per baseUrl.
  * @param baseUrl   the base URL to connect to
  * @return {Promise<wsClient>}
  */
 export function getOrCreateWsConn(baseUrl=getRootURL()) {
     const wsProxy = conns[baseUrl];
-    if (wsProxy) {
-        if (wsProxy.isConnected()) {
-            logger.debug(`getOrCreateWsConn -> existing connection: ${baseUrl} :: ${JSON.stringify(wsProxy)}`);
-            return Promise.resolve(wsProxy);
-        } else if (wsProxy.isConnecting) {
-            logger.debug('getOrCreateWsConn -> isConnecting ' + baseUrl);
-            return wsProxy.promise;
-        }
+    if (wsProxy?.isConnected()) {
+        logger.debug(`getOrCreateWsConn -> existing connection: ${baseUrl}`);
+        return Promise.resolve(wsProxy);
     }
-    const p = new Promise( (resolve, reject) => {
-        const mResolve = (proxy) => {
-            conns[baseUrl] = proxy;
-            dispatchConnectionStatus({lost: false, reason: null});
-            resolve?.(proxy);
-        };
-        const mReject = (e) => {
-            Reflect.deleteProperty(conns, baseUrl);
-            reject?.(e);
-        };
+    return synchronizeAsyncFunctionById(baseUrl, () => new Promise((resolve, reject) => {
         logger.debug('getOrCreateWsConn -> create new connection ' + baseUrl);
-        makeWsConn(baseUrl, mResolve, mReject);
-    });
-    conns[baseUrl] = {isConnecting: true, isConnected: ()=>false, promise: p};
-    return p;
+        makeWsConn(baseUrl,
+            (proxy) => {
+                conns[baseUrl] = proxy;
+                dispatchConnectionStatus({lost: false, reason: null});
+                resolve(proxy);
+            },
+            (e) => {
+                Reflect.deleteProperty(conns, baseUrl);
+                reject(e);
+            }
+        );
+    }));
 }
 
 const listeners = [];
@@ -176,7 +172,7 @@ function makeWsConn(baseUrl, resolve, reject) {
     wsConn.onmessage = onMessage;
     wsConn.onopen = () => {};
     wsConn.onerror = (e) => {
-        onClose('WebSocket onerror: ' + JSON.stringify(e));
+        logger.warn('WebSocket onerror: ' + JSON.stringify(e));
         reject?.(e);
     };
     wsConn.onclose = (r) => {


### PR DESCRIPTION
https://jira.ipac.caltech.edu/browse/FIREFLY-2045

**Server:**
- Cap WS connections at 10 per channel (`max.ws.per.channel`), evicting oldest
  under a synchronized block to prevent race conditions.
- Fix `ArrayIndexOutOfBoundsException` in `ReplicatedQueueList` by passing a
  snapshot copy to MessagePack serialization.
- Delete ehcache `.lock` on shutdown to allow hot redeployment without Tomcat restart.

**Client:**
- Wrap `getOrCreateWsConn()` with `synchronizeAsyncFunctionById()` so concurrent
  callers share a single in-flight connection attempt instead of each opening their own.
- Remove redundant `onClose()` call from `onerror` handler — browser always fires
  `onclose` after `onerror`, so cleanup now happens exactly once.
  
#### Test
https://fireflydev.ipac.caltech.edu/firefly-2045-runaway-websocket/firefly/
- [ ] Verify normal WebSocket connection and event flow in the browser
- [ ] Verify multiple tabs each receive their own events and closing one doesn't affect others
- [ ] Verify that flooding connections to the same channel results in no more than 10 active connections
- [ ] Verify that a fresh connection can always be established after the limit is reached
- [ ] Verify client reconnects automatically after a network interruption with no duplicate connections
  