### PR TITLE
FIREFLY-1954: React Split Pane version upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ There are several branches in the repository.  Here are the ones that you should
  -  [Tomcat 11] (https://tomcat.apache.org/download-11.cgi)
     Apache Tomcat is an open source software implementation of the Java Servlet and JavaServer Pages technologies.
 
- -  [Node v18] (https://nodejs.org/)
+ -  [Node v26] (https://nodejs.org/)
     Javascript interpreter for command line environment, used for development tools
 
 ### Prepare before the build

--- a/component-library/developer-guide.md
+++ b/component-library/developer-guide.md
@@ -51,7 +51,7 @@ Store-connected components (`ValidationField`, `TargetPanel`, `ListBoxInputField
 
 ### Prerequisites
 
-- Node.js and yarn installed
+- Node.js v26 and yarn installed
 - Firefly monorepo cloned
 - Gradle (for build tasks that inject global properties)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN echo "============> Build platform: $(uname -m)"
 
 RUN apt-get update && apt-get install -y \
       curl git unzip wget ca-certificates gnupg htmldoc \
-    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_26.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g yarn \
 # gradle version 8.10  Not available via apt-get

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-grid-layout": "~1.5",
     "react-router-dom": "^6.14.0",
     "react-slick": "~0.31",
-    "react-split-pane": "~0.1",
+    "react-split-pane": "~3.2.0",
     "redux": "~3.7",
     "redux-logger": "~3.0",
     "redux-saga": "~1.1",

--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -177,13 +177,11 @@ div.rootStyle img {
 .standard-border { border: solid #a3aeb9 1px; } /*borderColor */
 
 /* react-split-pane style <BEGIN> */
-.Pane.vertical, .Pane.horizontal {
+.split-pane-pane {
     display: flex;
 }
 
-.Resizer {
-    /*background: #000;*/
-    /*opacity: .2;*/
+.split-pane-divider {
     z-index: 1;
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
@@ -191,43 +189,60 @@ div.rootStyle img {
     -moz-background-clip: padding;
     -webkit-background-clip: padding;
     background-clip: padding-box;
-    /*border-radius: 5px;*/
 
     /* allows consumer to control resizer styling for all the style definitions below */
     --resizer-color: var(--joy-palette-neutral-outlinedDisabledColor);
     --resizer-border-size: 2px;
+    --resizer-hover-line-size: 2px;
     --resizer-border-style: solid;
 }
 
-.Resizer:hover {
-    -webkit-transition: all 2s ease;
-    transition: all 2s ease;
+.split-pane-divider::after {
+    content: '';
+    position: absolute;
+    background-color: var(--resizer-color);
+    opacity: 0;
+    pointer-events: none;
+    -webkit-transition: opacity 2s ease;
+    transition: opacity 2s ease;
 }
 
-.Resizer.horizontal {
-    margin: calc(-2 * var(--resizer-border-size)) 0;
+.split-pane-divider.vertical {
+    box-sizing: content-box;
+    margin: calc(-1 * var(--resizer-border-size)) 0;
     border-top: var(--resizer-border-size) var(--resizer-border-style) transparent;
     border-bottom: var(--resizer-border-size) var(--resizer-border-style) transparent;
     cursor: row-resize;
     width: 100%;
 }
 
-.Resizer.horizontal:hover {
-    border-top: var(--resizer-border-size) var(--resizer-border-style) var(--resizer-color);
-    border-bottom: var(--resizer-border-size) var(--resizer-border-style) var(--resizer-color);
+.split-pane-divider.vertical::after {
+    left: 0;
+    right: 0;
+    top: 50%;
+    height: var(--resizer-hover-line-size);
+    transform: translateY(-50%);
 }
 
-.Resizer.vertical {
-    margin: 0 calc(-2 * var(--resizer-border-size));
+.split-pane-divider.horizontal {
+    box-sizing: content-box;
+    margin: 0 calc(-1 * var(--resizer-border-size));
     border-left: var(--resizer-border-size) var(--resizer-border-style) transparent;
     border-right: var(--resizer-border-size) var(--resizer-border-style) transparent;
     cursor: col-resize;
     height: 100%;
 }
 
-.Resizer.vertical:hover {
-    border-left: var(--resizer-border-size) var(--resizer-border-style) var(--resizer-color);
-    border-right: var(--resizer-border-size) var(--resizer-border-style) var(--resizer-color);
+.split-pane-divider.horizontal::after {
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: var(--resizer-hover-line-size);
+    transform: translateX(-50%);
+}
+
+.split-pane-divider:hover::after {
+    opacity: 1;
 }
 /* react-split-pane style <END> */
 

--- a/src/firefly/js/charts/ui/PinnedChartContainer.jsx
+++ b/src/firefly/js/charts/ui/PinnedChartContainer.jsx
@@ -32,7 +32,7 @@ import {ActiveChartsPanel} from './ChartsContainer';
 import {StatefulTabs, switchTab, Tab} from '../../ui/panel/TabPanel';
 import {HelpIcon} from '../../ui/HelpIcon';
 import {getComponentState, dispatchComponentStateChange} from '../../core/ComponentCntlr';
-import {SplitPanel} from '../../ui/panel/DockLayoutPanel';
+import {SplitPanel, Pane} from '../../ui/panel/DockLayoutPanel';
 import {hideInfoPopup, showInfoPopup, showPinMessage} from '../../ui/PopupUtil.jsx';
 import {dispatchAddActionWatcher} from 'firefly/core/MasterSaga';
 import {PinButton, ShowTableButton} from 'firefly/visualize/ui/Buttons.jsx';
@@ -61,19 +61,23 @@ export const PinnedChartContainer = (props) => {
         return (
             <Stack id='chart-pinned-sideBySide' overflow='hidden' flexGrow={1}>
                 <Stack flexGrow={1} position='relative'>
-                    <SplitPanel split='vertical' defaultSize={400} style={{display: 'inline-flex'}} pKey='chart-sideBySide'>
-                        <Stack>
-                            <Typography level='title-md'>
-                                {activeLabel}
-                            </Typography>
-                            <ActiveChartsPanel {...props}/>
-                        </Stack>
-                        <Stack>
-                            <Typography level='title-md'>
-                                {pinnedLabel}
-                            </Typography>
-                            <PinnedChartPanel {...props}/>
-                        </Stack>
+                    <SplitPanel direction='horizontal' defaultSize={400} style={{display: 'inline-flex'}} pKey='chart-sideBySide'>
+                        <Pane>
+                            <Stack>
+                                <Typography level='title-md'>
+                                    {activeLabel}
+                                </Typography>
+                                <ActiveChartsPanel {...props}/>
+                            </Stack>
+                        </Pane>
+                        <Pane>
+                            <Stack>
+                                <Typography level='title-md'>
+                                    {pinnedLabel}
+                                </Typography>
+                                <PinnedChartPanel {...props}/>
+                            </Stack>
+                        </Pane>
                     </SplitPanel>
                 </Stack>
             </Stack>

--- a/src/firefly/js/tables/ui/FilterEditor.jsx
+++ b/src/firefly/js/tables/ui/FilterEditor.jsx
@@ -6,13 +6,12 @@ import React, {useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
 import {Box, Button, Link, Sheet, Stack, Typography} from '@mui/joy';
 import {cloneDeep, get} from 'lodash';
-import SplitPane from 'react-split-pane';
 import Tree from 'rc-tree';
 import 'rc-tree/assets/index.css';
 
 import {FilterInfo, getFiltersAsSql} from '../FilterInfo.js';
 import {getTableUiById, getSqlFilter, DOC_FUNCTIONS_URL} from '../TableUtil.js';
-import {SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
+import {SplitPanel, Pane, SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
 import {InputAreaFieldConnected} from '../../ui/InputAreaField.jsx';
 import {RadioGroupInputField} from '../../ui/RadioGroupInputField.jsx';
 import {insertAtCursor} from '../../ui/tap/AdvancedADQL.jsx';
@@ -105,54 +104,58 @@ export function SqlTableFilter({tbl_ui_id, tbl_id, onChange, style={}, samples, 
     placeholder = placeholder || 'e.g., "ra" > 180 AND "ra" < 185';
 
     return (
-        <SplitPane split='vertical' defaultSize={200} style={{display: 'inline-flex', ...style}}>
-            <SplitContent style={{display: 'flex', flexDirection: 'column'}}>
-                <Typography level='title-md'>Columns (sorted)</Typography>
-                <Box  style={{overflow: 'auto', flexGrow: 1}}>
-                    <Tree defaultExpandAll showLine onSelect={onNodeClick} icon={iconGen} treeData={treeData}/>
-                </Box>
-            </SplitContent>
-            <SplitContent style={{overflow: 'auto'}}>
-                <Stack height={1} spacing={1} overflow='hidden'>
-                    <ColumnFilter {...{colFilters, tbl_id}}/>
-                    <Stack direction='row' justifyContent='space-between' alignItems='center'>
-                        <Typography level='title-md'>{inputLabel}</Typography>
-                        <Stack direction='row' alignItems='center' spacing={1}>
-                            <Button title='Apply the constraints' onClick={onApply}>Apply</Button>
-                            {colFilters &&
-                                <Stack direction='row' alignItems='center' spacing={1}>
-                                    <Typography> with: </Typography>
-                                    <RadioGroupInputField
-                                        fieldKey={opKey}
-                                        groupKey={groupKey}
-                                        alignment='horizontal'
-                                        options={[
-                                            {label: 'AND', value: 'AND'},
-                                            {label: 'OR', value: 'OR'}
-                                        ]}/>
-                                </Stack>
-                            }
+        <SplitPanel direction='horizontal' defaultSize={200} style={{display: 'inline-flex', ...style}} pKey='filter-editor'>
+            <Pane>
+                <SplitContent style={{display: 'flex', flexDirection: 'column'}}>
+                    <Typography level='title-md'>Columns (sorted)</Typography>
+                    <Box style={{overflow: 'auto', flexGrow: 1}}>
+                        <Tree defaultExpandAll showLine onSelect={onNodeClick} icon={iconGen} treeData={treeData}/>
+                    </Box>
+                </SplitContent>
+            </Pane>
+            <Pane>
+                <SplitContent style={{overflow: 'auto'}}>
+                    <Stack height={1} spacing={1} overflow='hidden'>
+                        <ColumnFilter {...{colFilters, tbl_id}}/>
+                        <Stack direction='row' justifyContent='space-between' alignItems='center'>
+                            <Typography level='title-md'>{inputLabel}</Typography>
+                            <Stack direction='row' alignItems='center' spacing={1}>
+                                <Button title='Apply the constraints' onClick={onApply}>Apply</Button>
+                                {colFilters &&
+                                    <Stack direction='row' alignItems='center' spacing={1}>
+                                        <Typography> with: </Typography>
+                                        <RadioGroupInputField
+                                            fieldKey={opKey}
+                                            groupKey={groupKey}
+                                            alignment='horizontal'
+                                            options={[
+                                                {label: 'AND', value: 'AND'},
+                                                {label: 'OR', value: 'OR'}
+                                            ]}/>
+                                    </Stack>
+                                }
+                            </Stack>
+                        </Stack>
+                        <InputAreaFieldConnected
+                            ref={sqlEl}
+                            validator={FilterInfo.validator.bind(null,columns)}
+                            groupKey={groupKey}
+                            fieldKey={sqlKey}
+                            tooltip='Additional filter to apply to the table'
+                            placeholder={placeholder}
+                            slotProps={{
+                                textArea: {id: 'advFilterInput'}
+                            }}
+                        />
+                        {error && <li style={{color: 'red', fontStyle: 'italic'}}>{error}</li>}
+                        <Stack spacing={1} overflow='auto'>
+                            {usages}
+                            {samples}
                         </Stack>
                     </Stack>
-                    <InputAreaFieldConnected
-                        ref={sqlEl}
-                        validator={FilterInfo.validator.bind(null,columns)}
-                        groupKey={groupKey}
-                        fieldKey={sqlKey}
-                        tooltip='Additional filter to apply to the table'
-                        placeholder={placeholder}
-                        slotProps={{
-                            textArea: {id: 'advFilterInput'}
-                        }}
-                    />
-                    {error && <li style={{color: 'red', fontStyle: 'italic'}}>{error}</li>}
-                    <Stack spacing={1} overflow='auto'>
-                        {usages}
-                        {samples}
-                    </Stack>
-                </Stack>
-            </SplitContent>
-        </SplitPane>
+                </SplitContent>
+            </Pane>
+        </SplitPanel>
     );
 }
 

--- a/src/firefly/js/templates/fireflyviewer/ResultsPanel.jsx
+++ b/src/firefly/js/templates/fireflyviewer/ResultsPanel.jsx
@@ -12,7 +12,7 @@ import {LO_VIEW} from '../../core/LayoutCntlr.js';
 const wrapperStyle = { flex: 'auto', display: 'flex', flexFlow: 'column', overflow: 'hidden'};
 const eastWest = {east: {index: 0,  defaultSize: '50%'}, west: {index: 1} };
 const northSouth = {north: {index: 0,  defaultSize: '50%'}, south: {index: 1} };
-const triView = {east: {index: 0, defaultSize: '50%'}, west: {index: 1}, south: {index: 2, defaultSize: 'calc(100% - 300px)'}};
+const triView = {east: {index: 0, defaultSize: '50%'}, west: {index: 1}, south: {index: 2, primary: 'second', defaultSize: 300}};
 const singleView = {center: {index: 0,  defaultSize: '100%',  resize: false}};
 
 

--- a/src/firefly/js/templates/hydra/SampleHydra.jsx
+++ b/src/firefly/js/templates/hydra/SampleHydra.jsx
@@ -5,12 +5,11 @@
 
 import React from 'react';
 import {get} from 'lodash';
-import SplitPane from 'react-split-pane';
+import {SplitPanel, Pane, SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
 
 import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
 import {ChartsContainer} from '../../charts/ui/ChartsContainer.jsx';
 import {LO_VIEW} from '../../core/LayoutCntlr.js';
-import {SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
 import {TABLE_SEARCH} from '../../tables/TablesCntlr.js';
 
 import {TargetPanel} from '../../ui/TargetPanel.jsx';
@@ -113,24 +112,32 @@ function Triview({layout}) {
     return (
         <div style={{flexGrow:1, display:'flex', flexDirection:'column'}}>
             <div style={{flexGrow:1, position:'relative'}}>
-                <SplitPane split='horizontal' maxSize={-20} minSize={20} defaultSize={'60%'}>
-                    <SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={'50%'}>
+                <SplitPanel direction='vertical' maxSize={-20} minSize={20} defaultSize={'60%'} pKey='sample-hydra-triview-outer'>
+                    <Pane>
+                        <SplitPanel direction='horizontal' maxSize={-20} minSize={20} defaultSize={'50%'} pKey='sample-hydra-triview-inner'>
+                            <Pane>
+                                <SplitContent>
+                                    <TriViewImageSection key='res-tri-img'
+                                                         closeable={closeable}
+                                                         imageExpandedMode={expanded===LO_VIEW.images}
+                                                         {...images}  />
+                                </SplitContent>
+                            </Pane>
+                            <Pane>
+                                <SplitContent>
+                                    <TablesContainer expandedMode={expanded===LO_VIEW.tables}
+                                                     tableOptions={{help_id:'main1TSV.table'}}/>
+                                </SplitContent>
+                            </Pane>
+                        </SplitPanel>
+                    </Pane>
+                    <Pane>
                         <SplitContent>
-                            <TriViewImageSection key='res-tri-img'
-                                                 closeable={closeable}
-                                                 imageExpandedMode={expanded===LO_VIEW.images}
-                                {...images}  />
+                            <ChartsContainer closeable={true}
+                                             expandedMode={expanded===LO_VIEW.xyPlots}/>
                         </SplitContent>
-                        <SplitContent>
-                            <TablesContainer expandedMode={expanded===LO_VIEW.tables}
-                                             tableOptions={{help_id:'main1TSV.table'}}/>
-                        </SplitContent>
-                    </SplitPane>
-                    <SplitContent>
-                        <ChartsContainer closeable={true}
-                                         expandedMode={expanded===LO_VIEW.xyPlots}/>
-                    </SplitContent>
-                </SplitPane>
+                    </Pane>
+                </SplitPanel>
             </div>
         </div>
     );
@@ -140,16 +147,20 @@ function Triview({layout}) {
 function TableChart ({layout}) {
     const expanded = get(layout, 'mode.expanded');
     return (
-        <SplitPane split='horizontal' maxSize={-20} minSize={20} defaultSize={'60%'}>
-            <SplitContent>
-                <TablesContainer expandedMode={expanded===LO_VIEW.tables}
-                                 tableOptions={{help_id:'main1TSV.table'}}/>
-            </SplitContent>
-            <SplitContent>
-                <ChartsContainer closeable={true}
-                                 expandedMode={expanded===LO_VIEW.xyPlots}/>
-            </SplitContent>
-        </SplitPane>
+        <SplitPanel direction='vertical' maxSize={-20} minSize={20} defaultSize={'60%'} pKey='sample-hydra-table-chart'>
+            <Pane>
+                <SplitContent>
+                    <TablesContainer expandedMode={expanded===LO_VIEW.tables}
+                                     tableOptions={{help_id:'main1TSV.table'}}/>
+                </SplitContent>
+            </Pane>
+            <Pane>
+                <SplitContent>
+                    <ChartsContainer closeable={true}
+                                     expandedMode={expanded===LO_VIEW.xyPlots}/>
+                </SplitContent>
+            </Pane>
+        </SplitPanel>
     );
 }
 

--- a/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
@@ -7,7 +7,6 @@ import React, {PureComponent, useContext} from 'react';
 import PropTypes from 'prop-types';
 
 import {get, set,  pick,  debounce} from 'lodash';
-import SplitPane from 'react-split-pane';
 import {flux} from '../../core/ReduxFlux.js';
 import CompleteButton from '../../ui/CompleteButton.jsx';
 import HelpIcon from '../../ui/HelpIcon.jsx';
@@ -16,7 +15,7 @@ import {FieldGroup, FieldGroupCtx} from '../../ui/FieldGroup.jsx';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {ValidationField} from '../../ui/ValidationField.jsx';
 import {showInfoPopup, INFO_POPUP} from '../../ui/PopupUtil.jsx';
-import {SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
+import {SplitPanel, Pane, SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
 import Validate from '../../util/Validate.js';
 import {dispatchActiveTableChanged} from '../../tables/TablesCntlr.js';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
@@ -222,23 +221,33 @@ const PeriodStandardView = (props) => {
         <FieldGroup groupKey={pfinderkey} sx={{ display: 'flex', flexDirection: 'column', position: 'relative', flexGrow: 1, minHeight: 500 }}
                     reducerFunc={LcPFReducer(initState)}  keepState={true}>
             <div style={{flexGrow: 1, position: 'relative'}}>
-                <SplitPane split='horizontal' primary='second' maxSize={-100} minSize={100} defaultSize={400}>
-                    <SplitContent>
+                <SplitPanel direction='vertical' primary='second' maxSize={-100} minSize={100} defaultSize={400}
+                            pKey='lc-period-plotly-outer'>
+                    <Pane>
+                        <SplitContent>
 
-                        <SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={565}>
-                            <SplitContent>
-                                <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow:'auto'}}>
-                                    <LcPFOptionsBox/>
-                                </Box>
-                            </SplitContent>
-                            <SplitContent>
-                                <PhaseFoldingChart/>
-                            </SplitContent>
-                        </SplitPane>
+                            <SplitPanel direction='horizontal' maxSize={-20} minSize={20} defaultSize={565}
+                                        pKey='lc-period-plotly-inner'>
+                                <Pane>
+                                    <SplitContent>
+                                        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow:'auto'}}>
+                                            <LcPFOptionsBox/>
+                                        </Box>
+                                    </SplitContent>
+                                </Pane>
+                                <Pane>
+                                    <SplitContent>
+                                        <PhaseFoldingChart/>
+                                    </SplitContent>
+                                </Pane>
+                            </SplitPanel>
 
-                    </SplitContent>
-                    <LcPeriodogram displayMode={displayMode}/>
-                </SplitPane>
+                        </SplitContent>
+                    </Pane>
+                    <Pane>
+                        <LcPeriodogram displayMode={displayMode}/>
+                    </Pane>
+                </SplitPanel>
             </div>
         </FieldGroup>
     );
@@ -1005,4 +1014,3 @@ export function resetPeriodDefaults(defPeriod) {
         dispatchMultiValueChange(pfinderkey, multiVals);
     }
 }
-

--- a/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodogram.jsx
@@ -6,8 +6,7 @@ import {Button, Chip, Stack, Typography} from '@mui/joy';
 import React, {PureComponent} from 'react';
 import PropTypes from 'prop-types';
 import { get, set, has} from 'lodash';
-import SplitPane from 'react-split-pane';
-import {SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
+import {SplitPanel, Pane, SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
 import {LC, getValidValueFrom, updateLayoutDisplay} from './LcManager.js';
 import {getTypeData} from './LcUtil.jsx';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils';
@@ -596,12 +595,16 @@ const  PeriodogramResult = ({expanded}) => {
 
     if (!expanded || expanded === LO_VIEW.none) {
         return (
-            <SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={565}>
-                <SplitContent>
-                    <div style={{height: 'calc(100% - 28px)'}}>{tables}</div>
-                </SplitContent>
-                <SplitContent>{xyPlot}</SplitContent>
-            </SplitPane>
+            <SplitPanel direction='horizontal' maxSize={-20} minSize={20} defaultSize={565} pKey='lc-periodogram'>
+                <Pane>
+                    <SplitContent>
+                        <div style={{height: 'calc(100% - 28px)'}}>{tables}</div>
+                    </SplitContent>
+                </Pane>
+                <Pane>
+                    <SplitContent>{xyPlot}</SplitContent>
+                </Pane>
+            </SplitPanel>
         );
     } else {
         return (<div style={{flexGrow: 1}}>

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -15,14 +15,13 @@ import {Box, Button, Card, Divider, Sheet, Stack} from '@mui/joy';
 import React, {PureComponent, useContext} from 'react';
 import PropTypes from 'prop-types';
 import {pick, get, isEmpty, cloneDeep} from 'lodash';
-import SplitPane from 'react-split-pane';
 import {flux} from '../../core/ReduxFlux.js';
 import {LO_VIEW, getLayouInfo, dispatchUpdateLayoutInfo} from '../../core/LayoutCntlr.js';
 import {TablesContainer} from '../../tables/ui/TablesContainer.jsx';
 import {ChartsContainer} from '../../charts/ui/ChartsContainer.jsx';
 import {AppPropertiesCtx} from '../../ui/AppPropertiesCtx.jsx';
 import {LcImageViewerContainer} from './LcImageViewerContainer.jsx';
-import {SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
+import {SplitPanel, Pane, SplitContent} from '../../ui/panel/DockLayoutPanel.jsx';
 import {LC, getViewerGroupKey, updateLayoutDisplay} from './LcManager.js';
 import FieldGroupUtils from '../../fieldGroup/FieldGroupUtils.js';
 import {DownloadOptionPanel, DownloadButton} from '../../ui/DownloadDialog.jsx';
@@ -183,40 +182,52 @@ const StandardView = ({visToolbar, title, searchDesc, imagePlot, xyPlot, tables,
 
         if (!err) {
             return (
-                <SplitPane split='horizontal' maxSize={-20} minSize={20} defaultSize={'60%'}>
-                    <SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={buttonW}>
-                        <SplitContent>
-                            <Stack {...{height: '100%', spacing:1}}>
-                                {settingBox}
-                                <Box {...{flexGrow: 1, position: 'relative'}}>
-                                    <div className='abs_full'>{tables}</div>
-                                </Box>
-                            </Stack>
-                        </SplitContent>
-                        <SplitContent>
-                            <Sheet variant='outlined' sx={ (theme) => ({ml:1/2, height:1, borderRadius:theme.radius.md})}>
-                                <Stack sx={{height:1, width:1, p:1/4}}>
-                                    {xyPlot}
-                                </Stack>
-                            </Sheet>
-                        </SplitContent>
-                    </SplitPane>
-                    <SplitContent>{imagePlot}</SplitContent>
-                </SplitPane>
+                <SplitPanel direction='vertical' maxSize={-20} minSize={20} defaultSize={'60%'} pKey='lc-result-standard-outer'>
+                    <Pane>
+                        <SplitPanel direction='horizontal' maxSize={-20} minSize={20} defaultSize={buttonW} pKey='lc-result-standard-inner'>
+                            <Pane>
+                                <SplitContent>
+                                    <Stack {...{height: '100%', spacing:1}}>
+                                        {settingBox}
+                                        <Box {...{flexGrow: 1, position: 'relative'}}>
+                                            <div className='abs_full'>{tables}</div>
+                                        </Box>
+                                    </Stack>
+                                </SplitContent>
+                            </Pane>
+                            <Pane>
+                                <SplitContent>
+                                    <Sheet variant='outlined' sx={ (theme) => ({ml:1/2, height:1, borderRadius:theme.radius.md})}>
+                                        <Stack sx={{height:1, width:1, p:1/4}}>
+                                            {xyPlot}
+                                        </Stack>
+                                    </Sheet>
+                                </SplitContent>
+                            </Pane>
+                        </SplitPanel>
+                    </Pane>
+                    <Pane>
+                        <SplitContent>{imagePlot}</SplitContent>
+                    </Pane>
+                </SplitPanel>
             );
         } else {
             return (
-                <SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={buttonW}>
-                    <SplitContent>
-                        <div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
-                            <div className='settingBox'>{settingBox}</div>
-                            <div style={{flexGrow: 1, position: 'relative'}}>
-                                <div className='abs_full'>{tables}</div>
+                <SplitPanel direction='horizontal' maxSize={-20} minSize={20} defaultSize={buttonW} pKey='lc-result-no-image'>
+                    <Pane>
+                        <SplitContent>
+                            <div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
+                                <div className='settingBox'>{settingBox}</div>
+                                <div style={{flexGrow: 1, position: 'relative'}}>
+                                    <div className='abs_full'>{tables}</div>
+                                </div>
                             </div>
-                        </div>
-                    </SplitContent>
-                    <SplitContent>{xyPlot}</SplitContent>
-                </SplitPane>
+                        </SplitContent>
+                    </Pane>
+                    <Pane>
+                        <SplitContent>{xyPlot}</SplitContent>
+                    </Pane>
+                </SplitPanel>
             );
         }
 

--- a/src/firefly/js/ui/panel/DockLayoutPanel.jsx
+++ b/src/firefly/js/ui/panel/DockLayoutPanel.jsx
@@ -1,6 +1,6 @@
 import React, {createContext, useContext, useState} from 'react';
 import PropTypes from 'prop-types';
-import SplitPane from 'react-split-pane';
+import {SplitPane, Pane} from 'react-split-pane';
 import {Stack, Box, Sheet, Tooltip, IconButton} from '@mui/joy';
 
 import {dispatchComponentStateChange, getComponentState} from '../../core/ComponentCntlr.js';
@@ -9,14 +9,17 @@ import {ArrowDropDown, ArrowDropUp} from '@mui/icons-material';
 
 
 const SplitContext = createContext({});
+export {Pane};
 
 /**
  * A wrapper for SplitPane with persistent split position.
  *
  * @param p  props accepted by `SplitPane` (from react-split-pane) besides the following:
- * @param p.children pass-through children component, usually two `SplitContent`s. If one of the `SplitContent` has
- * `isCollapsible` prop set as true, then its state will be implicitly managed by `SplitPanel`.
- * @param p.pKey {string}  an identifier for this panel.  One will be created if not given
+ * @param p.children pass-through children component, usually two `Pane`s wrapping `SplitContent`s. If one of the
+ * `SplitContent`s has `isCollapsible` prop set as true, then its state will be implicitly managed by `SplitPanel`.
+ * @param p.pKey {string}  an identifier for this panel.
+ * @param p.primary {'first'|'second'} which pane receives sizing props such as `defaultSize`, `size`, `minSize`,
+ * and `maxSize`.
  * @param p.openCollapsibleSize {string|number} the size of the collapsible content panel when it is open.
  * Can be a relative size like 'm%' or absolute size like n (in px). Will be used only if one of the `SplitContent`
  * has `isCollapsible` prop set as true, otherwise ignored.
@@ -25,28 +28,91 @@ const SplitContext = createContext({});
 export const SplitPanel = ({children, pKey, openCollapsibleSize='50%', ...props}) => {
     pKey = 'SplitPanel-' + pKey;
 
-    const {pos}  = useStoreConnector(() => getComponentState(pKey));
-    const onChange = (size) => {
-        dispatchComponentStateChange(pKey, {pos: size});
-        props?.onChange?.(size);
+    const {direction = 'vertical', primary = 'first', defaultSize,
+        minSize, maxSize, size, onChange, style, divider, ...rest
+    } = props;
+
+    //react-split-pane (v3 onwards) sizes individual Pane elements; primary selects which pane owns the sizing props
+    const primaryIdx = primary === 'second' ? 1 : 0;
+    //negative maxSize is translated into minSize on the non-primary pane (to support behavior of older versions of react-split-pane)
+    const oppositeIdx = primaryIdx === 0 ? 1 : 0;
+    const {pos} = useStoreConnector(() => getComponentState(pKey));
+    const childArray = React.Children.toArray(children).filter(Boolean);
+    const collapsibleContentIdx = childArray.findIndex((c) => {
+        return React.Children.toArray(c?.props?.children).filter(Boolean).some((child) => child?.props?.isCollapsible);
+    });
+
+    const splitLayoutState = useCollapsibleSplitLayout({
+        collapseSecondContent:
+            collapsibleContentIdx === 1 ? true :
+                (collapsibleContentIdx === 0 ? false : null),
+        openSize: openCollapsibleSize,
+        collapsedSize: minSize,
+    });
+
+    const getPaneProps = (idx) => {
+        const paneProps = {};
+        if (collapsibleContentIdx === -1 && idx === primaryIdx) { //neither pane is collapsible, apply sizing props to the primary pane
+            paneProps.defaultSize = pos ?? defaultSize;
+            if (minSize !== undefined) paneProps.minSize = minSize;
+            if (size !== undefined) paneProps.size = size;
+            if (maxSize !== undefined && !(typeof maxSize === 'number' && maxSize < 0)) paneProps.maxSize = maxSize;
+        }
+
+        const splitLayoutPanel = idx === 0 ? splitLayoutState.panel1 : splitLayoutState.panel2;
+        if (splitLayoutPanel) Object.assign(paneProps, splitLayoutPanel);
+
+        if (idx === oppositeIdx && typeof maxSize === 'number' && maxSize < 0 && !splitLayoutState.isCollapsed) {
+            //older versions (v0) of react-split-pane allowed maxSize={-N}, effectively setting minSize={N} on the non-primary pane.
+            //this is not supported in react-split-pane versions v3 onwards, so we expicityly translate it here.
+            paneProps.minSize = Math.max(paneProps.minSize ?? 0, Math.abs(maxSize));
+        }
+
+        return paneProps;
     };
 
-    const collapsibleContentIdx = React.Children.toArray(children).filter((c) => c).findIndex(
-        (c) => c?.props?.isCollapsible);
-    const splitLayoutState = useCollapsibleSplitLayout({
-        collapseSecondContent: collapsibleContentIdx === 1 ? true : (collapsibleContentIdx === 0 ? false : null),
-        openSize: openCollapsibleSize,
-        collapsedSize: props?.minSize,
-    });
+    const handleResize = (sizes, event) => {
+        splitLayoutState.onResize?.(sizes, event);
+        const primarySize = sizes?.[primaryIdx];
+        dispatchComponentStateChange(pKey, {pos: primarySize});
+        onChange?.(primarySize, sizes, event);
+    };
+
+    const handleResizeStart = (event) => {
+        splitLayoutState.onResizeStart?.(event);
+    };
+
+    const handleResizeEnd = (sizes, event) => {
+        splitLayoutState.onResizeEnd?.(sizes, event);
+    };
 
     return (
         <SplitContext.Provider value={splitLayoutState.collapsibleContent}>
-            <SplitPane split='horizontal'
-                       defaultSize={pos ?? props?.defaultSize}
-                       onChange={onChange}
-                       {...props}
-                       {...splitLayoutState.panel}>
-                {children}
+            <SplitPane
+                {...rest}
+                direction={direction}
+                divider={divider}
+                style={style}
+                onResize={handleResize}
+                onResizeStart={handleResizeStart}
+                onResizeEnd={handleResizeEnd}
+            >
+                {childArray.map((child, idx) => {
+                    const paneProps = getPaneProps(idx);
+                    const paneStyle = {
+                        overflow: 'hidden',
+                        minWidth: 0,
+                        minHeight: 0,
+                        ...paneProps.style,
+                        ...child.props?.style,
+                    };
+                    return React.cloneElement(child, {
+                        key: child.key ?? idx,
+                        ...paneProps,
+                        ...child.props,
+                        style: paneStyle,
+                    });
+                })}
             </SplitPane>
         </SplitContext.Provider>
     );
@@ -72,8 +138,10 @@ export function SplitContent({sx={}, style={}, children, panelTitle,
             </CollapsibleSplitContent>
         )
         : (
-            <Stack overflow='hidden' position='relative' width={1} m={1/2}>
-                <Box overflow='hidden' position='absolute' sx={{inset:'0', ...style, ...sx}} {...props}>
+            <Stack overflow='hidden' position='relative'
+                   sx={{width: 1, height: 1, minWidth: 0, minHeight: 0, p: 1/4, boxSizing: 'border-box'}}>
+                <Box overflow='hidden' position='relative'
+                     sx={{width: 1, height: 1, minWidth: 0, minHeight: 0, ...style, ...sx}} {...props}>
                     {children}
                 </Box>
             </Stack>
@@ -92,12 +160,15 @@ export function SplitContent({sx={}, style={}, children, panelTitle,
  */
 function CollapsibleSplitContent({sx={}, panelTitle, children, ...props}) {
     const {isOpen, onToggle} = useContext(SplitContext);
-    
+
     // TODO: dynamically calculate styles based on the position of toggle button and split direction (passed as props)
-    //  e.g. for the redesign of EmbeddedSearchPositionPanel, the toggle button should appear on the middle of the right side of a vertical split
+    // e.g. for the redesign of EmbeddedSearchPositionPanel, the toggle button should appear on the middle of the right side of a vertical split
+
     return (
         <Sheet variant='outlined'
-               sx={{display: 'flex', flexGrow: 1, position: 'relative',
+               aria-label={panelTitle}
+               sx={{display: 'flex', flexGrow: 1, width: 1, height: 1, position: 'relative',
+                   overflow: 'visible', minWidth: 0, minHeight: 0,
                    borderRadius: '5px', borderTopRightRadius: 0, // since toggle btn is right positioned
                    ...sx}}
                {...props}>
@@ -112,11 +183,12 @@ function CollapsibleSplitContent({sx={}, panelTitle, children, ...props}) {
                     {isOpen ? <ArrowDropDown/> : <ArrowDropUp/>}
                 </IconButton>
             </Tooltip>
-            {children}
+            <Box sx={{display: 'flex', flexGrow: 1, width: 1, height: 1, overflow: 'hidden', minWidth: 0, minHeight: 0}}>
+                {children}
+            </Box>
         </Sheet>
     );
 }
-
 
 /**@typedef {Object} CollapsibleSplitState Collapsible Split Layout state
  * @property {Object} panel stateful props to be passed to SplitPanel
@@ -139,32 +211,54 @@ function CollapsibleSplitContent({sx={}, panelTitle, children, ...props}) {
 const useCollapsibleSplitLayout = ({collapseSecondContent, openSize, collapsedSize=0}) => {
     const [isCollapsibleOpen, setIsCollapsibleOpen] = useState(true);
     const [isSplitterDragging, setIsSplitterDragging] = useState(false);
+    const [collapsibleSize, setCollapsibleSize] = useState(openSize);
 
     // TODO: animate width if the split is vertical
     const animationStyle = {transition: isSplitterDragging ? 'none' : 'height 0.2s ease-in-out'};
 
-    if (collapseSecondContent===null) { //No-op
-        return {panel: {}, collapsibleContent: {}};
+    if (collapseSecondContent === null) {
+        return {
+            panel1: null,
+            panel2: null,
+            isCollapsed: false,
+            onResizeStart: null,
+            onResize: null,
+            onResizeEnd: null,
+            collapsibleContent: {},
+        };
     }
 
+    const collapsiblePane = {
+        size: isCollapsibleOpen ? collapsibleSize : collapsedSize,
+        minSize: collapsedSize,
+        style: {...animationStyle, overflow: 'visible'},
+    };
+
+    const collapsibleIdx = collapseSecondContent ? 1 : 0;
+
     return {
-        panel: {
-            // to let SplitPane manage sizing of the collapsible content panel, and let the other content panel grow/shrink
-            primary: collapseSecondContent ? 'second' : 'first',
-            // control the sizing of collapsible content panel
-            size: isCollapsibleOpen ? openSize : collapsedSize,
-            minSize: collapsedSize,
-            // to create collapsing animation effect only when not dragging otherwise it will be jerky
-            onDragStarted: () => setIsSplitterDragging(true),
-            onDragFinished: (currentSize) => {
-                setIsSplitterDragging(false);
-                setIsCollapsibleOpen(currentSize > collapsedSize); // update the open state after dragging
-            },
-            [collapseSecondContent ? 'pane2Style' : 'pane1Style']: animationStyle,
+        // to let SplitPane manage sizing of the collapsible content panel, and let the other content panel grow/shrink
+        panel1: collapseSecondContent ? null : collapsiblePane,
+        panel2: collapseSecondContent ? collapsiblePane : null,
+        isCollapsed: !isCollapsibleOpen,
+        // to create collapsing animation effect only when not dragging otherwise it will be jerky
+        onResizeStart: () => setIsSplitterDragging(true),
+        // control the sizing of collapsible content panel
+        onResize: (sizes) => {
+            const nextSize = sizes?.[collapsibleIdx];
+            if (nextSize !== undefined) setCollapsibleSize(nextSize);
+        },
+        onResizeEnd: (sizes) => {
+            setIsSplitterDragging(false);
+            const collapsibleSize = sizes?.[collapsibleIdx];
+            setIsCollapsibleOpen((collapsibleSize ?? 0) > collapsedSize);
         },
         collapsibleContent: {
             isOpen: isCollapsibleOpen,
-            onToggle: () => setIsCollapsibleOpen(!isCollapsibleOpen),
+            onToggle: () => {
+                if (!isCollapsibleOpen && collapsibleSize <= collapsedSize) setCollapsibleSize(openSize);
+                setIsCollapsibleOpen(!isCollapsibleOpen); // update the open state after dragging
+            },
         }
     };
 };
@@ -191,12 +285,16 @@ function two(config, items){
         const bottom = config.south || config.center;
         return (
             <SplitPanel {...top} pKey='one'>
-                <SplitContent>
-                    {items[top.index]}
-                </SplitContent>
-                <SplitContent>
-                    {items[bottom.index]}
-                </SplitContent>
+                <Pane>
+                    <SplitContent>
+                        {items[top.index]}
+                    </SplitContent>
+                </Pane>
+                <Pane>
+                    <SplitContent>
+                        {items[bottom.index]}
+                    </SplitContent>
+                </Pane>
             </SplitPanel>
 
         );
@@ -204,13 +302,17 @@ function two(config, items){
         const left = config.east || config.center;
         const right = config.west || config.center;
         return (
-            <SplitPanel split='vertical' {...left} pKey='one'>
-                <SplitContent>
-                    {items[left.index]}
-                </SplitContent>
-                <SplitContent>
-                    {items[right.index]}
-                </SplitContent>
+            <SplitPanel direction='horizontal' {...left} pKey='one'>
+                <Pane>
+                    <SplitContent>
+                        {items[left.index]}
+                    </SplitContent>
+                </Pane>
+                <Pane>
+                    <SplitContent>
+                        {items[right.index]}
+                    </SplitContent>
+                </Pane>
             </SplitPanel>
         );
     }
@@ -224,17 +326,25 @@ function three(config, items){
             const two = config.east || config.center || config.west;
             return (
                 <SplitPanel  {...config.north} pKey='one'>
-                    <SplitContent>
-                        {items[config.north.index]}
-                    </SplitContent>
-                    <SplitPanel  {...two} pKey='two'>
+                    <Pane>
                         <SplitContent>
-                            {items[two.index]}
+                            {items[config.north.index]}
                         </SplitContent>
-                        <SplitContent>
-                            {items[config.south.index]}
-                        </SplitContent>
-                    </SplitPanel>
+                    </Pane>
+                    <Pane>
+                        <SplitPanel  {...two} pKey='two'>
+                            <Pane>
+                                <SplitContent>
+                                    {items[two.index]}
+                                </SplitContent>
+                            </Pane>
+                            <Pane>
+                                <SplitContent>
+                                    {items[config.south.index]}
+                                </SplitContent>
+                            </Pane>
+                        </SplitPanel>
+                    </Pane>
                 </SplitPanel>
             );
         } else {
@@ -242,17 +352,25 @@ function three(config, items){
             const three = config.west || config.center;
             return (
                 <SplitPanel  {...config.north} pKey='one'>
-                    <SplitContent>
-                        {items[config.north.index]}
-                    </SplitContent>
-                    <SplitPanel split='vertical' {...two.config} pKey='two'>
+                    <Pane>
                         <SplitContent>
-                            {items[two.index]}
+                            {items[config.north.index]}
                         </SplitContent>
-                        <SplitContent>
-                            {items[three.index]}
-                        </SplitContent>
-                    </SplitPanel>
+                    </Pane>
+                    <Pane>
+                        <SplitPanel direction='horizontal' {...two} pKey='two'>
+                            <Pane>
+                                <SplitContent>
+                                    {items[two.index]}
+                                </SplitContent>
+                            </Pane>
+                            <Pane>
+                                <SplitContent>
+                                    {items[three.index]}
+                                </SplitContent>
+                            </Pane>
+                        </SplitPanel>
+                    </Pane>
                 </SplitPanel>
             );
         }
@@ -262,33 +380,49 @@ function three(config, items){
             const two = config.west || config.center;
             return (
                 <SplitPanel  {...config.south} pKey='one'>
-                    <SplitPanel split='vertical' {...one} pKey='two'>
+                    <Pane>
+                        <SplitPanel direction='horizontal' {...one} pKey='two'>
+                            <Pane>
+                                <SplitContent>
+                                    {items[one.index]}
+                                </SplitContent>
+                            </Pane>
+                            <Pane>
+                                <SplitContent>
+                                    {items[two.index]}
+                                </SplitContent>
+                            </Pane>
+                        </SplitPanel>
+                    </Pane>
+                    <Pane>
                         <SplitContent>
-                            {items[one.index]}
+                            {items[config.south.index]}
                         </SplitContent>
-                        <SplitContent>
-                            {items[two.index]}
-                        </SplitContent>
-                    </SplitPanel>
-                    <SplitContent>
-                        {items[config.south.index]}
-                    </SplitContent>
+                    </Pane>
                 </SplitPanel>
             );
         } else {
             return (
-                <SplitPanel split='vertical' {...config.east} pKey='one'>
-                    <SplitContent>
-                        {items[config.east.index]}
-                    </SplitContent>
-                    <SplitPanel split='vertical' {...config.west} pKey='two'>
+                <SplitPanel direction='horizontal' {...config.east} pKey='one'>
+                    <Pane>
                         <SplitContent>
-                            {items[config.center.index]}
+                            {items[config.east.index]}
                         </SplitContent>
-                        <SplitContent>
-                            {items[config.west.index]}
-                        </SplitContent>
-                    </SplitPanel>
+                    </Pane>
+                    <Pane>
+                        <SplitPanel direction='horizontal' {...config.west} pKey='two'>
+                            <Pane>
+                                <SplitContent>
+                                    {items[config.center.index]}
+                                </SplitContent>
+                            </Pane>
+                            <Pane>
+                                <SplitContent>
+                                    {items[config.west.index]}
+                                </SplitContent>
+                            </Pane>
+                        </SplitPanel>
+                    </Pane>
                 </SplitPanel>
             );
         }
@@ -311,7 +445,7 @@ const DockLayoutPanel = function (props) {
 
     return (
         <Box position='relative'  flex='auto'>
-            <Box position='absolute' sx={{inset:'0'}}>
+            <Box position='absolute' sx={{inset: 0, p: 1/4, boxSizing: 'border-box'}}>
                 {layoutDom(config, children)}
             </Box>
         </Box>
@@ -329,12 +463,3 @@ DockLayoutPanel.propTypes = {
 
 
 export default DockLayoutPanel;
-
-
-
-
-
-
-
-
-

--- a/src/firefly/js/ui/panel/TabPanel.jsx
+++ b/src/firefly/js/ui/panel/TabPanel.jsx
@@ -241,11 +241,12 @@ export function switchTab(componentKey, selected) {
  Internal use only
 ----------------------------------------------------------------------------------------------*/
 
+const DEFAULT_MAX_TITLE_WIDTH = 400;
 const ResizeTabHeader = wrapResizeMonitor(TabHeader,16);
 
-function TabHeader({children, slotProps}) {
+function TabHeader({children, slotProps, size}) {
     const toolbarEl = useRef(null);
-    const [maxTitleWidth, setMaxTitleWidth] = useState(400);
+    const [maxTitleWidth, setMaxTitleWidth] = useState(DEFAULT_MAX_TITLE_WIDTH);
 
 
     const childrenAry = React.Children.toArray(children);
@@ -256,12 +257,15 @@ function TabHeader({children, slotProps}) {
     const activeBg = tabListVar === 'plain' ? 'neutral.softBg' : 'background.surface';
 
     useEffect(() => {
-        const tbEl = toolbarEl.current;
-        if (tbEl) {
-            const maxWidth = calcOptimalTabSize(tbEl);
-            setMaxTitleWidth(maxWidth);
-        }
-    }, [toolbarEl?.current?.getBoundingClientRect()?.width]);
+        if (!toolbarEl.current || !size?.width) return;
+
+        const rafId = window.requestAnimationFrame(() => {
+            const tbEl = toolbarEl.current;
+            if (tbEl) setMaxTitleWidth(calcOptimalTabSize(tbEl));
+        });
+
+        return () => window.cancelAnimationFrame(rafId);
+    }, [size?.width]);
 
     return (
         <TabList
@@ -422,6 +426,8 @@ function getAllTabId(children) {
 function calcOptimalTabSize(tabEl) {
     const tabAry = Array.from(tabEl.children).filter((c) => c.offsetWidth > 0);        // ignore hidden children.
     const availW = tabEl.getBoundingClientRect().width;
+    if (!tabAry.length || availW <= 0) return DEFAULT_MAX_TITLE_WIDTH;
+
     const maxW = availW/tabAry.length;
     const relTabs = tabAry.filter((t) => t.offsetWidth > maxW);
     if (relTabs.length === 0) return maxW;      // all tabs fit, no adjustment needed.

--- a/src/firefly/js/ui/tap/AdvancedADQL.jsx
+++ b/src/firefly/js/ui/tap/AdvancedADQL.jsx
@@ -5,7 +5,7 @@
 import {Box, Chip, Divider, FormHelperText, Stack, Switch, Tooltip, Typography} from '@mui/joy';
 import React, {useState, useRef, useEffect, useContext, useCallback} from 'react';
 import PropTypes, {shape, string, object} from 'prop-types';
-import SplitPane from 'react-split-pane';
+import {SplitPanel, Pane, SplitContent} from '../panel/DockLayoutPanel';
 import Tree from 'rc-tree';
 import 'rc-tree/assets/index.css';
 import {cloneDeep, defer, isArray, isObject, groupBy, uniqBy, defaultsDeep} from 'lodash';
@@ -17,7 +17,6 @@ import {FieldGroupCtx} from '../FieldGroup.jsx';
 import {TextButton} from 'firefly/visualize/ui/Buttons.jsx';
 import {InputAreaFieldConnected} from '../InputAreaField.jsx';
 import {InputFieldView} from '../InputFieldView.jsx';
-import {SplitContent} from '../panel/DockLayoutPanel';
 import {useFieldGroupValue} from '../SimpleComponent.jsx';
 import {showUploadTableChooser} from '../UploadTableChooser.js';
 import {defaultADQLExamples} from './TapKnownServices';
@@ -100,13 +99,35 @@ function getExamples(serviceUrl) {
     );
 }
 
+function useRetryUntilReady(tryRun) {
+    useEffect(() => {
+        let cancelled = false;
+        let timeoutId;
+
+        const run = () => {
+            if (cancelled) return;
+            if (!tryRun()) {
+                timeoutId = window.setTimeout(run, 10);
+            }
+        };
+
+        run();
+        return () => {
+            cancelled = true;
+            window.clearTimeout(timeoutId);
+        };
+    }, [tryRun]);
+}
+
 export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, style={}, setError}) {
 
     const [treeData, setTreeData] = useState([]);                               // using a useState hook
     const [displayedTreeData, setDisplayedTreeData] = useState((treeData));
     const {canUpload=false}= capabilities ?? {};
     const adqlEl = useRef(null);                                                // using a useRef hook
+    const sqlExamplesEl = useRef(null);
     const prismLiveRef = useRef(null);
+    const syncStyles = () => window.setTimeout(() => prismLiveRef.current?.syncStyles?.(), 10);
     const {groupKey, setVal, getVal} = useContext(FieldGroupCtx);
     const [getUploadSchema, setUploadSchema]= useFieldGroupValue(TAP_UPLOAD_SCHEMA);
     const [getFullQualified, setFullQualified]= useFieldGroupValue(FULLY_QUALIFIED);
@@ -161,7 +182,7 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
                 setTreeData(treeData);
             }
         });
-        window.setTimeout( () => prismLiveRef.current.syncStyles?.(), 10);
+        syncStyles();
     }, [serviceUrl, uploadSchema]);
 
     useEffect(() => {
@@ -172,17 +193,31 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
                 alias: 'function'
             }
         });
+    }, [serviceUrl]);
 
-        // highlight help text/code snippets
-        Prism.highlightAll();
+    const highlightSqlExamples = useCallback(() => {
+        const codeBlocks = sqlExamplesEl.current?.querySelectorAll('code.language-sql');
+        //react-split-pane v3 waits for ResizeObserver sizing before rendering pane content,
+        //so Prism's static SQL examples may not exist when this effect runs the first time
+        if (!codeBlocks?.length) return false;
+
+        Prism.highlightAllUnder(sqlExamplesEl.current);
+        return true;
     },  [serviceUrl]);
 
-    useEffect(() => {
-        // We need to get prism-live to adopt to the textarea
+    useRetryUntilReady(highlightSqlExamples);
+
+    const initPrismLive = useCallback(() => {
         const textArea = adqlEl.current?.querySelector('textarea');
-        // adopt textArea
+        //react-split-pane v3 measures its container with ResizeObserver before rendering panes
+        //so the textarea may not exist on the first pass
+        if (!textArea) return false;
+
         prismLiveRef.current = new Prism.Live(textArea);
+        return true;
     }, []);
+
+    useRetryUntilReady(initPrismLive);
 
     const onSelect = async (selectedKeys, evt) => {
         const textArea = document.getElementById('adqlEditor');
@@ -201,7 +236,7 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
                     if (uploadTableAlias) insertTname+= ' AS '+uploadTableAlias;
                 }
                 setVal(adqlKey, `SELECT TOP 1000 * FROM ${maybeQuote(insertTname,true)}`);
-                window.setTimeout( () => prismLiveRef.current.syncStyles?.(), 10);
+                    syncStyles();
             }
         } else if (type === 'column') {
             const val = fullyQualified ? `${maybeQuote(tname,true)}.${maybeQuote(cname)}` : maybeQuote(cname);
@@ -244,14 +279,14 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
     const onClear = () => {
         setVal(adqlKey, '');
         // trigger prismLive style sync
-        window.setTimeout( () => prismLiveRef.current.syncStyles?.(), 10);
+        syncStyles();
     };
 
     const onReset = () => {
         const value = getVal(defAdqlKey) ?? '';
         setVal(adqlKey, value);
         // trigger prismLive style sync
-        window.setTimeout( () => prismLiveRef.current.syncStyles?.(), 10);
+        syncStyles();
     };
 
     const onFilter = useCallback((e) => {
@@ -286,7 +321,8 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
         : '#f5f2f0'; //bgColor on L59 in prismLightCss
 
     return (
-            <SplitPane split='vertical' defaultSize={275} style={{position: 'relative', ...style}}>
+            <SplitPanel direction='horizontal' defaultSize={275} style={{position: 'relative', ...style}} pKey='advanced-adql'>
+                <Pane>
                 <SplitContent style={{display:'flex', flexDirection:'column'}}>
                     <Tooltip title={SB_TIP}>
                         <Stack>
@@ -310,10 +346,12 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
                         <Tree treeData={displayedTreeData} defaultExpandAll={true} showLine={true} selectedKeys={[]} loadData={onLoadData} onSelect={onSelect} />
                     </div>
                 </SplitContent>
+                </Pane>
+                <Pane>
                 <SplitContent style={{overflow: 'auto'}}>
                     <CssStrThemeWrapper cssStr={{light: prismLightCss, dark: prismDarkCss}}>
                         <Stack flexGrow={1} ml={1} spacing={1}>
-                            <Stack {...{spacing:4}}>
+                            <Stack ref={sqlExamplesEl} {...{spacing:4}}>
                                 <Stack {...{spacing:1}}>
                                     <Stack {...{direction: 'row', spacing:10, mr: 3, justifyContent: 'flex-start', alignItems: 'center'}}>
                                         <Typography level='title-lg'>ADQL Query</Typography>
@@ -433,7 +471,8 @@ export function AdvancedADQL({adqlKey, defAdqlKey, serviceUrl, capabilities, sty
                         </Stack>
                     </CssStrThemeWrapper>
                 </SplitContent>
-            </SplitPane>
+                </Pane>
+            </SplitPanel>
     );
 }
 

--- a/src/firefly/js/ui/tap/TapViewType.jsx
+++ b/src/firefly/js/ui/tap/TapViewType.jsx
@@ -2,13 +2,12 @@ import {Box, Button, Divider, Sheet, Skeleton, Stack, Tooltip, Typography} from 
 import {truncate} from 'lodash';
 import {bool, string, func, object, shape} from 'prop-types';
 import React, {Fragment, useContext, useEffect, useRef, useState} from 'react';
-import SplitPane from 'react-split-pane';
+import {SplitPanel, Pane, SplitContent} from '../panel/DockLayoutPanel';
 import {getColumnIdx, getColumnValues} from '../../tables/TableUtil.js';
 import {isColumnsMatchingToObsTap} from '../../voAnalyzer/ColumnsModelInfo.js';
 import {FieldGroupCtx} from '../FieldGroup.jsx';
 import {HelpIcon} from '../HelpIcon';
 import {ListBoxInputFieldView} from '../ListBoxInputField.jsx';
-import {SplitContent} from '../panel/DockLayoutPanel';
 import {useFieldGroupMetaState} from '../SimpleComponent.jsx';
 import {AdvancedADQL} from './AdvancedADQL.jsx';
 import {getDataServiceOption} from './DataServicesOptions';
@@ -389,32 +388,36 @@ function BasicUI(props) {
                     <TableColumnsConstraintsToolbar key={tableName} tableName={tableName} columnsModel={columnsModel} />
                 </div>
                 <Box sx={expandableTapSectionSx}>
-                    <SplitPane split='vertical' maxSize={splitMax} mixSize={20} defaultSize={splitDef}>
-                        <SplitContent>
-                            {(capabilities && columnsModel) ?
-                                <TableSearchMethods {...{initArgs, serviceUrl, serviceLabel, columnsModel, obsCoreEnabled,
-                                    capabilities, obsCoreMetadataModel,
-                                    sx:{mt:1},
-                                    tableName:getTapBrowserState().tableName}}/>
-                                : <Skeleton/>
-                            }
-                        </SplitContent>
-                        <SplitContent>
-                            { columnsModel ?
-                                <Stack {...{height:1}}>
-                                    <Typography title='Number of columns to be selected' color='neutral'  level='body-xs'>
-                                        Output Column Selection and Constraints
-                                    </Typography>
-                                    <TableColumnsConstraints
-                                        key={tableName}
-                                        fieldKey={'tableconstraints'}
-                                        columnsModel={columnsModel}
-                                    />
-                                </Stack>
-                                : <TableMask/>
-                            }
-                        </SplitContent>
-                    </SplitPane>
+                    <SplitPanel direction='horizontal' maxSize={splitMax} minSize={20} defaultSize={splitDef} pKey='tap-view-type-basic'>
+                        <Pane>
+                            <SplitContent>
+                                {(capabilities && columnsModel) ?
+                                    <TableSearchMethods {...{initArgs, serviceUrl, serviceLabel, columnsModel, obsCoreEnabled,
+                                        capabilities, obsCoreMetadataModel,
+                                        sx:{mt:1},
+                                        tableName:getTapBrowserState().tableName}}/>
+                                    : <Skeleton/>
+                                }
+                            </SplitContent>
+                        </Pane>
+                        <Pane>
+                            <SplitContent>
+                                {columnsModel ?
+                                    <Stack {...{height:1}}>
+                                        <Typography title='Number of columns to be selected' color='neutral' level='body-xs'>
+                                            Output Column Selection and Constraints
+                                        </Typography>
+                                        <TableColumnsConstraints
+                                            key={tableName}
+                                            fieldKey={'tableconstraints'}
+                                            columnsModel={columnsModel}
+                                        />
+                                    </Stack>
+                                    : <TableMask/>
+                                }
+                            </SplitContent>
+                        </Pane>
+                    </SplitPanel>
                 </Box>
             </Stack>
         </Fragment>

--- a/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
+++ b/src/firefly/js/visualize/ui/FileUploadViewPanel.jsx
@@ -17,7 +17,8 @@ import {
     SPECTRUM_TABLES, TABLES, UWS
 } from 'firefly/ui/FileUploadUtil';
 import React, {useContext, useEffect, useState} from 'react';
-import SplitPane from 'react-split-pane';
+//import SplitPane from 'react-split-pane';
+import {SplitPanel, Pane} from '../../ui/panel/DockLayoutPanel.jsx';
 import shallowequal from 'shallowequal';
 import {FileAnalysisType, Format, TableDataType} from '../../data/FileAnalysis';
 import {getField} from '../../fieldGroup/FieldGroupUtils';
@@ -696,13 +697,17 @@ function MultiDataSet({summaryModel, detailsModel, isMoc, acceptOneItem}) {
                 </Typography>
             }
             <Box sx={{height:1, position:'relative'}}>
-                <SplitPane split='vertical' maxSize={-20} minSize={20} defaultSize={525}>
-                    {acceptOneItem && <TablePanel {...{showTypes:false, title:'File Summary', tableModel:summaryModel,
-                        ...tblOptions, selectable:false, }} />}
-                    {!acceptOneItem && <TablePanel {...{sx:{mr:1}, showTypes:false, title:'File Summary', tableModel:summaryModel,
-                        ...tblOptions}} />}
-                    <Details detailsModel={detailsModel}/>
-                </SplitPane>
+                <SplitPanel direction='horizontal' maxSize={-20} minSize={20} defaultSize={525} pKey='file-upload-multi-dataset'>
+                    <Pane>
+                        {acceptOneItem && <TablePanel {...{showTypes:false, title:'File Summary', tableModel:summaryModel,
+                            ...tblOptions, selectable:false, }} />}
+                        {!acceptOneItem && <TablePanel {...{sx:{mr:1}, showTypes:false, title:'File Summary', tableModel:summaryModel,
+                            ...tblOptions}} />}
+                    </Pane>
+                    <Pane>
+                        <Details detailsModel={detailsModel}/>
+                    </Pane>
+                </SplitPanel>
             </Box>
         </Stack>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6684,7 +6684,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1, prop-types@~15.8:
+prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1, prop-types@~15.8:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -6921,21 +6921,10 @@ react-slick@~0.31:
     lodash.debounce "^4.0.8"
     resize-observer-polyfill "^1.5.0"
 
-react-split-pane@~0.1:
-  version "0.1.92"
-  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.92.tgz#68242f72138aed95dd5910eeb9d99822c4fc3a41"
-  integrity sha512-GfXP1xSzLMcLJI5BM36Vh7GgZBpy+U/X0no+VM3fxayv+p1Jly5HpMofZJraeaMl73b3hvlr+N9zJKvLB/uz9w==
-  dependencies:
-    prop-types "^15.7.2"
-    react-lifecycles-compat "^3.0.4"
-    react-style-proptype "^3.2.2"
-
-react-style-proptype@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.2.2.tgz#d8e998e62ce79ec35b087252b90f19f1c33968a0"
-  integrity sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==
-  dependencies:
-    prop-types "^15.5.4"
+react-split-pane@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-3.2.0.tgz#4b3da8b77addfb98293c8354fdd028411f0ecefc"
+  integrity sha512-tH2SaMqBZ7Ypcmj6I/2fIR0gdeE0Q5ve66T51UyXcSqIgPGJh40bOMTVCAFjB0Q3OB5+Aw/4ECVWU+YU9SL88Q==
 
 react-transition-group@^4.4.5:
   version "4.4.5"


### PR DESCRIPTION
**Ticket**: [FIREFLY-1954](https://jira.ipac.caltech.edu/browse/FIREFLY-1954)
**[IFE PR](url)**: https://github.com/IPAC-SW/irsa-ife/pull/472
- This PR upgrades Firefly from react-split-pane `v0.1.92` to` v3.2.0`
   - Using the [migration doc](https://github.com/tomkp/react-split-pane/blob/master/MIGRATION.md) and [readme](https://github.com/tomkp/react-split-pane/blob/master/README.md) for reference 
- The core changes are in `DockLayoutPanel`. v0 allowed sizing props to be applied at the parent `SplitPane` level, but v3 moves that to the individual `Pane` components. 
  - collapsible split panel logic is also slightly altered now to handle v3's pane sizing requirement.
- Changed several consumers of `SplitPane` (using `react-split-pane` directly) to use our `SplitPanel` wrapper instead
- `AdvancedADQL` and `TabPanel` include timing fixes for react-split-pane's v3 onwards ResizeObserver-based layout
  - In `AdvancedADQL` in particular, earlier the code assumed DOM was present when the useEffect for `Prism.highlighAll` ran), but with v3.2.0 of react-split-pane using ResizeObserver for layout measurements, I noticed the Pane content can become available after the useEffect where we try to initialize `Prism`
    - This led to crashes and/or the SQL examples not being highlighted 
    - So the new retry logic aims to fix this race issue. Could possibly be polished further by extracting the logic into a small separate hook. Open to other feedback as well. 
- The `dockerfile` change to Node 20 from Node 18 was needed because `react-split-pane@3.2.0` declares `node >= 20` and my Jenkins builds were failing without this change. I will talk to @loitly about this before deciding if we need to keep this. 

**Testing**: 
[Firefly](https://firefly-1954-react-split-pane.irsakubedev.ipac.caltech.edu/firefly), [Euclid](https://firefly-1954-react-split-pane.irsakubedev.ipac.caltech.edu/applications/euclid), [Spherex](https://firefly-1954-react-split-pane.irsakubedev.ipac.caltech.edu/applications/spherex), [Timeseries](https://firefly-1954-react-split-pane.irsakubedev.ipac.caltech.edu/irsaviewer/timeseries)
- Confirm visually in TAP, Advanced ADQL (Edit ADQL), tri view and bi view results, collapsible panels (spherex spectrophotometry) and in Timeseries that the results look good. 
  - Split Pane is used in several places, like the TAP screen as well. Test visually and compare against dev/ops if needed. Move around the panes to make sure there's no bugs there. 
- Dev links, to compare the test builds against: [Firefly Dev,](https://fireflydev.ipac.caltech.edu/firefly/) [Euclid Dev,](https://irsadev.ipac.caltech.edu/applications/euclid) [Spherex Dev,](https://irsadev.ipac.caltech.edu/applications/spherex/) [Timeseries Dev](https://irsadev.ipac.caltech.edu/irsaviewer/timeseries)