### PR TITLE
FIREFLY-1746: Firefly is slow at loading very wide tables

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/EmbeddedDbUtil.java
@@ -297,7 +297,7 @@ public class EmbeddedDbUtil {
         SHORT_TASK_EXEC.submit(() -> {
             enumeratedValuesCheck(dbAdapter, results, treq);
             DataGroup updates = new DataGroup(null, results.getData().getDataDefinitions());
-            updates.getTableMeta().setTblId(results.getData().getTableMeta().getTblId());
+            updates.getTableMeta().setTblId(TableUtil.getTblId(treq));
             JSONObject changes = JsonTableUtil.toJsonDataGroup(updates);
             changes.remove("totalRows");        //changes contains only the columns with 0 rows.. we don't want to update totalRows
 
@@ -311,35 +311,53 @@ public class EmbeddedDbUtil {
         StopWatch.getInstance().stop("enumeratedValuesCheck: " + treq.getRequestId()).printLog("enumeratedValuesCheck: " + treq.getRequestId());
     }
 
+    /*
+      This function uses DuckDB specific functions
+     */
     public static void enumeratedValuesCheck(DbAdapter dbAdapter, DataType[] inclCols) {
         if (inclCols != null && inclCols.length > 0)
         try {
-            String cols = Arrays.stream(inclCols)
+            JdbcTemplate jdbc = JdbcFactory.getTemplate(dbAdapter.getDbInstance());
+            String dataTable = dbAdapter.getDataTable();
+
+            // pass 1: cheap cardinality estimate for every candidate column, in one query over the whole table.
+            String countCols = Arrays.stream(inclCols)
                     .filter(dt -> maybeEnums(dt))
-                    .map(dt -> "count(distinct \"%s\") as \"%s\"".formatted(dt.getKeyName(), dt.getKeyName()))
+                    .map(dt -> "approx_count_distinct(\"%s\") as \"%s\"".formatted(dt.getKeyName(), dt.getKeyName()))
                     .collect(Collectors.joining(", "));
 
-            List<Map<String, Object>> rs = JdbcFactory.getTemplate(dbAdapter.getDbInstance())
-                    .queryForList("SELECT %s FROM %s limit 500".formatted(cols, dbAdapter.getDataTable()));
+            Map<String, Object> counts = jdbc.queryForMap("SELECT %s FROM %s".formatted(countCols, dataTable));
 
+            List<String> qualified = counts.entrySet().stream()
+                    .filter(e -> {
+                        long count = ((Number) e.getValue()).longValue();
+                        return count > 0 && count <= MAX_COL_ENUM_COUNT;
+                    })
+                    .map(Map.Entry::getKey)
+                    .toList();
+
+            // pass 2: exact distinct values for the qualifying columns only, in one query over the whole table.
             List<Object[]> params = new ArrayList<>();
-            rs.get(0).forEach( (cname,v) -> {
-                Long count = (Long) v ;
-                if (count > 0 && count <= MAX_COL_ENUM_COUNT) {
-                    List<Map<String, Object>> vals = JdbcFactory.getTemplate(dbAdapter.getDbInstance())
-                            .queryForList("SELECT distinct \"%s\" FROM data order by 1".formatted(cname));
+            if (!qualified.isEmpty()) {
+                String valCols = qualified.stream()
+                        .map(cname -> "array_agg(DISTINCT \"%s\" ORDER BY \"%s\") as \"%s\"".formatted(cname, cname, cname))
+                        .collect(Collectors.joining(", "));
 
+                Map<String, Object> valsRow = jdbc.queryForMap("SELECT %s FROM %s".formatted(valCols, dataTable));
+
+                for (String cname : qualified) {
+                    Object[] vals = (Object[]) ((java.sql.Array) valsRow.get(cname)).getArray();
                     DataType col = findColByName(inclCols, cname);
-                    if (col != null && vals.size() <= MAX_COL_ENUM_COUNT) {
-                        String enumVals = vals.stream()
-                                .map(m -> m.get(cname) == null ? NULL_TOKEN : m.get(cname).toString())  // convert to list of value as string
-                                .map(cn -> cn.contains(",") ? "'" + cn + "'" : cn)                      // if there's comma in the column name, enclose it with single quotes
-                                .collect(Collectors.joining(","));                             // combine the values into a comma separated values string.
+                    if (col != null && vals.length <= MAX_COL_ENUM_COUNT) {
+                        String enumVals = Arrays.stream(vals)
+                                .map(v -> v == null ? NULL_TOKEN : v.toString())         // convert to list of value as string
+                                .map(v -> v.contains(",") ? "'" + v + "'" : v)            // if there's comma in the column name, enclose it with single quotes
+                                .collect(Collectors.joining(","));                      // combine the values into a comma separated values string.
                         col.setEnumVals(enumVals);
                         params.add(new Object[]{enumVals, cname});
                     }
                 }
-            });
+            }
             // update dd table
             if (params.size() > 0)  dbAdapter.batchUpdate("UPDATE DATA_DD SET enumVals = ? WHERE cname = ?", params);
         } catch (Exception ex) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/EmbeddedDbProcessor.java
@@ -197,7 +197,11 @@ abstract public class EmbeddedDbProcessor implements SearchProcessor<DataGroupPa
                     SearchProcessor.logStats(treq.getRequestId(), totalRows, 0, false, getDescResolver().getDesc(treq));
                 }
                 // check for values that can be enumerated
-                enumeratedValuesCheck(dbAdapter, new DataGroupPart(headers, 0, totalRows), treq);
+                if (headers.getDataDefinitions().length > 100) {
+                    enumeratedValuesCheckBG(dbAdapter, new DataGroupPart(headers, 0, totalRows), treq);
+                } else {
+                    enumeratedValuesCheck(dbAdapter, new DataGroupPart(headers, 0, totalRows), treq);
+                }
             }
         } catch (Exception e) {
             logger.error(e);

--- a/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/table/TableUtil.java
@@ -113,6 +113,18 @@ public class TableUtil {
         return new DataGroupPart(dg, start, (int) totalRow);
     }
 
+    public static String getTblId(TableServerRequest treq) {
+        if (treq == null) return null;
+        String tblId = null;
+        if (treq.getMeta() != null) {
+            tblId = treq.getMeta().get(TableServerRequest.TBL_ID);
+        }
+        if (tblId == null) {
+            tblId = treq.getParam(TableServerRequest.TBL_ID);
+        }
+        return tblId;
+    }
+
     /**
      * takes all the TableMeta that is column's related and use it to set column's properties.
      * remove the TableMeta that was used.

--- a/src/firefly/js/visualize/ui/SmallLegend.jsx
+++ b/src/firefly/js/visualize/ui/SmallLegend.jsx
@@ -85,8 +85,8 @@ export function SmallLegend(props) {
                     <Box sx={ {maxHeight:'12em', overflowY:'auto', pb: 1/2}}>
                         <Stack>
                             {layersLoading && <Typography level={'body-sm'}>Layers Loading....</Typography>}
-                            {layers.map( (dl) => (
-                                <DrawLayerLegendView key={getShortTitle(plotId,dl)} {...{
+                            {layers.map( (dl, idx) => (
+                                <DrawLayerLegendView key={idx} {...{
                                     maxTitleChars,
                                     color: dl.drawingDef.color,
                                     canUserChangeColor: dl.canUserChangeColor,


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1746
- Replace the per-column SELECT DISTINCT loop with a single array_agg(DISTINCT...) query over all qualifying columns.
- Dispatch the check to a background task when the column count exceeds 100.

Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-1746

Upload the wide tables attached to the ticket. Compare the performance of this version with the nightly build version (https://firefly.irsakubedev.ipac.caltech.edu/firefly/).

In the logs, you’ll also notice that the nightly version issues 1000 distinct queries and takes several seconds.