### PR TITLE
FIREFLY-2059: Table query optimization

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/BaseDbAdapter.java
@@ -164,41 +164,15 @@ abstract public class BaseDbAdapter implements DbAdapter {
     }
     
 
-    public void createTempResults(TableServerRequest treq, String resultSetID) {
+    /**
+     * Builds resultSetID table including _DD/_META/_AUX related tables.
+     */
+    public final void createTempResults(TableServerRequest treq, String resultSetID) {
         StopWatch.getInstance().start("%s:createTempResults for %s".formatted(getName(), resultSetID));
         try {
-            List<String> cols = isEmpty(treq.getInclColumns()) ? getColumnNames(getDataTable(), "\"")
-                    : StringUtils.asList(treq.getInclColumns(), ",");
-            cols = cols.stream().filter((s) -> !ignoreCols.contains(s)).collect(Collectors.toList());   // remove rowIdx and rowNum because it will be automatically added
-
-            String selectPart = (cols.size() == 0 ? "*" : StringUtils.toString(cols) + ", " )+ DataGroup.ROW_IDX;
-            String wherePart = wherePart(treq);
-            String orderBy = orderByPart(treq);
-
-            // copy data
-            String datasetSql = "select %s FROM %s %s %s".formatted(selectPart, getDataTable(), wherePart, orderBy);
-            String datasetSqlWithIdx = "select b.*, (%s -1) as %s from (%s) as b".formatted(rowNumSql(), DataGroup.ROW_NUM, datasetSql);
-            String sql = createTableFromSelect(resultSetID, datasetSqlWithIdx);
-            execUpdate(sql);
-
-            // copy dd
-            copyDDFromSource(resultSetID, getDataTable());
-
-            // copy meta
-            String metaSql = "select * from DATA_META";
-            metaSql = createTableFromSelect(resultSetID + "_META", metaSql);
-            try {
-                getJdbc().update(metaSql);
-            } catch (Exception mx) {/*ignore table may not exist*/}
-
-            // copy aux
-            String auxSql = "select * from DATA_AUX";
-            auxSql = createTableFromSelect(resultSetID + "_AUX", auxSql);
-            try {
-                getJdbc().update(auxSql);
-            } catch (Exception ax) {/*ignore table may not exist*/}
-
-        }catch (RuntimeException e) {
+            buildResultSet(treq, resultSetID);
+            copyAuxTables(resultSetID);
+        } catch (RuntimeException e) {
             LOGGER.error("createTempResults failed with error: " + e.getMessage(),
                     "resultSetID: " + resultSetID,
                     "dbFile: " + getDbFile().getAbsolutePath());
@@ -206,6 +180,54 @@ abstract public class BaseDbAdapter implements DbAdapter {
         } finally {
             StopWatch.getInstance().printLog("%s:createTempResults for ".formatted(getName(), resultSetID));
         }
+    }
+
+    /**
+     * Builds the queryable table named resultSetID
+     */
+    protected void buildResultSet(TableServerRequest treq, String resultSetID) {
+        List<String> cols = getResultSetCols(treq);
+
+        String selectPart = (cols.size() == 0 ? "*" : StringUtils.toString(cols) + ", " )+ DataGroup.ROW_IDX;
+        String wherePart = wherePart(treq);
+        String orderBy = orderByPart(treq);
+
+        String datasetSql = "select %s FROM %s %s %s".formatted(selectPart, getDataTable(), wherePart, orderBy);
+        String datasetSqlWithIdx = "select b.*, (%s -1) as %s from (%s) as b".formatted(rowNumSql(), DataGroup.ROW_NUM, datasetSql);
+        execUpdate(createTableFromSelect(resultSetID, datasetSqlWithIdx));
+    }
+
+    /**
+     * The columns to include in a resultset: the request's inclColumns if given, otherwise all of DATA's
+     * columns.  Either way, with ROW_IDX/ROW_NUM excluded since those are always added automatically.
+     */
+    protected List<String> getResultSetCols(TableServerRequest treq) {
+        List<String> cols = isEmpty(treq.getInclColumns()) ? getColumnNames(getDataTable(), "\"")
+                : StringUtils.asList(treq.getInclColumns(), ",");
+        return cols.stream().filter((s) -> !ignoreCols.contains(s)).collect(Collectors.toList());
+    }
+
+    /**
+     * Copies DATA's _DD, _META, and _AUX tables into resultSetID's own, so the resultset carries the same
+     * column metadata, table metadata, and aux info as the main data table.
+     */
+    protected void copyAuxTables(String resultSetID) {
+        // copy dd
+        copyDDFromSource(resultSetID, getDataTable());
+
+        // copy meta
+        String metaSql = "select * from DATA_META";
+        metaSql = createTableFromSelect(resultSetID + "_META", metaSql);
+        try {
+            getJdbc().update(metaSql);
+        } catch (Exception mx) {/*ignore table may not exist*/}
+
+        // copy aux
+        String auxSql = "select * from DATA_AUX";
+        auxSql = createTableFromSelect(resultSetID + "_AUX", auxSql);
+        try {
+            getJdbc().update(auxSql);
+        } catch (Exception ax) {/*ignore table may not exist*/}
     }
     
     protected String buildSqlFrom(TableServerRequest treq, String forTable) {
@@ -570,11 +592,17 @@ abstract public class BaseDbAdapter implements DbAdapter {
         LOGGER.debug("DbAdapter -> compacting DB: %s".formatted(getDbFile().getPath()));
         List<String> tables = getTempTables();
         if (tables.size() > 0) {
-            // remove all temporary tables
-            String[] stmts = tables.stream().map(s -> "drop table IF EXISTS " + s).toArray(String[]::new);
+            // remove all temp DB objects created for this database
+            String[] stmts = dropStatementsFor(tables);
             getJdbcTmpl().batchUpdate(stmts);
-
         }
+    }
+
+    /**
+     * @return the DROP statements needed to remove the given temporary database objects.
+     */
+    protected String[] dropStatementsFor(List<String> names) {
+        return names.stream().map(s -> "drop table IF EXISTS " + s).toArray(String[]::new);
     }
 
     public void compact() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/db/DuckDbAdapter.java
@@ -11,8 +11,10 @@ import edu.caltech.ipac.firefly.server.db.jdbc.JdbcFactory;
 import edu.caltech.ipac.firefly.server.db.jdbc.JdbcTemplate;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
 import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.DataGroupPart;
 import edu.caltech.ipac.table.DataType;
 import edu.caltech.ipac.util.AppProperties;
+import edu.caltech.ipac.util.StringUtils;
 import org.duckdb.DuckDBAppender;
 import org.duckdb.DuckDBConnection;
 import org.json.simple.JSONObject;
@@ -240,8 +242,99 @@ public class DuckDbAdapter extends BaseDbAdapter {
     }
 
     public List<String> getTableNames() {
-        String sql = "SELECT table_name FROM duckdb_tables()";
+        // includes views because resultset tables (DATA_<hash>) are materialized as views;
+        String sql = "SELECT table_name FROM duckdb_tables() UNION ALL SELECT view_name FROM duckdb_views() WHERE NOT internal";
         return JdbcFactory.getTemplate(getDbInstance()).query(sql, (rs, i) -> rs.getString(1));
+    }
+
+    private List<String> getViewNames() {
+        String sql = "SELECT view_name FROM duckdb_views() WHERE NOT internal";
+        return JdbcFactory.getTemplate(getDbInstance()).query(sql, (rs, i) -> rs.getString(1));
+    }
+
+    /**
+     * Instead of materializing the full resultset, which duplicates every requested
+     * column for every matching row, and is what makes this expensive on a big table.
+     * This builds:
+     *   1. resultSetID_IDX: a small temp table of just (ROW_IDX, ROW_NUM), capturing the row's identity
+     *      and its position in the requested order.
+     *   2. resultSetID: a view joining that thin index back to DATA, projecting only the requested columns.
+     *      Every existing caller keeps working unchanged. A view is still just a named, queryable object with
+     *      the expected columns.  ROW_IDX/ROW_NUM are exposed from the index side so point lookups on them
+     *      (highlighted row, selection remap) don't need the join at all.
+     * See execRequestQuery() for the other half of this: paging against resultSetID must filter explicitly
+     * on ROW_NUM rather than relying on plain LIMIT/OFFSET, or DuckDB ends up joining everything before it
+     * can slice out a page.
+     */
+    @Override
+    protected void buildResultSet(TableServerRequest treq, String resultSetID) {
+        List<String> cols = getResultSetCols(treq);
+
+        String wherePart = wherePart(treq);
+        // without an explicit sort, fall back to ROW_IDX so ROW_NUM is deterministic and matches natural
+        // ingest order. DuckDB does not otherwise guarantee scan order is preserved without an ORDER BY.
+        String orderBy = treq.getSortInfo() != null ? orderByPart(treq) : "ORDER BY ROW_IDX";
+
+        String idxTable = getIdxTable(resultSetID);
+        String idxSql = "select ROW_IDX, (%s -1) as %s from (select ROW_IDX FROM %s %s %s) as b"
+                .formatted(rowNumSql(), DataGroup.ROW_NUM, getDataTable(), wherePart, orderBy);
+        execUpdate("CREATE TABLE IF NOT EXISTS %s AS (%s)".formatted(idxTable, idxSql));
+
+        String selectCols = cols.isEmpty() ? "" : StringUtils.toString(cols) + ",";
+        String viewSql = "select %s i.ROW_IDX, i.ROW_NUM from %s i join %s d on d.ROW_IDX = i.ROW_IDX"
+                .formatted(selectCols, idxTable, getDataTable());
+        execUpdate("CREATE VIEW IF NOT EXISTS %s AS (%s)".formatted(resultSetID, viewSql));
+    }
+
+    /**
+     * A join has no inherent row order the way a materialized, physically-sorted table does, so any read of a
+     * resultset backed by our thin (ROW_IDX, ROW_NUM) index needs an explicit ORDER BY ROW_NUM to be correct.
+     * For paging specifically, ROW_NUM also needs to be filtered (not just sorted) so
+     * DuckDB can prune the (small) index before joining to DATA; plain LIMIT/OFFSET against the view instead
+     * joins everything first and slices afterward.
+     * Only applies when there's no filter/sort of its own (ie. plain reads of an already-resolved resultset);
+     * anything else falls back to normal.
+     */
+    @Override
+    public DataGroupPart execRequestQuery(TableServerRequest treq, String forTable) throws DataAccessException {
+        if (isEmpty(wherePart(treq)) && treq.getSortInfo() == null && hasTable(getIdxTable(forTable))) {
+            return execIndexedPage(treq, forTable);
+        }
+        return super.execRequestQuery(treq, forTable);
+    }
+
+    private DataGroupPart execIndexedPage(TableServerRequest treq, String forTable) throws DataAccessException {
+        String selectPart = selectPart(treq);
+        boolean isPaged = !isEmpty(pagingPart(treq));
+        String rowNumFilter = isPaged
+                ? "WHERE ROW_NUM >= %d AND ROW_NUM < %d".formatted(treq.getStartIndex(), treq.getStartIndex() + treq.getPageSize())
+                : "";
+        String sql = "%s FROM %s %s ORDER BY ROW_NUM".formatted(selectPart, forTable, rowNumFilter);
+        DataGroup data = execQuery(sql, forTable);
+
+        int rowCnt = data.size();
+        if (isPaged) {
+            rowCnt = getJdbc().queryForInt("select count(*) FROM %s".formatted(getIdxTable(forTable)));
+        }
+
+        DataGroupPart page = toDataGroupPart(data, treq);
+        page.setRowCount(rowCnt);
+        if (!isEmpty(treq.getTblTitle())) {
+            page.getData().setTitle(treq.getTblTitle());
+        }
+        return page;
+    }
+
+    private static String getIdxTable(String resultSetID) {
+        return resultSetID + "_IDX";
+    }
+
+    @Override
+    protected String[] dropStatementsFor(List<String> names) {
+        List<String> views = getViewNames();
+        return names.stream()
+                .map(n -> (views.contains(n) ? "drop view IF EXISTS " : "drop table IF EXISTS ") + n)
+                .toArray(String[]::new);
     }
 
     public DbAdapter.DbStats getDbStats() {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/HealpixProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/HealpixProcessor.java
@@ -4,18 +4,14 @@
 package edu.caltech.ipac.firefly.server.query;
 
 import edu.caltech.ipac.firefly.data.TableServerRequest;
-import edu.caltech.ipac.firefly.server.db.BaseDbAdapter;
 import edu.caltech.ipac.firefly.server.db.DbAdapter;
-import edu.caltech.ipac.firefly.server.db.EmbeddedDbUtil;
 import edu.caltech.ipac.firefly.server.util.QueryUtil;
 import edu.caltech.ipac.firefly.server.util.StopWatch;
 import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.table.DataGroupPart;
-import edu.caltech.ipac.table.DataType;
 import edu.caltech.ipac.util.AppProperties;
 
 import static edu.caltech.ipac.firefly.server.query.HealpixProcessor.*;
-import static edu.caltech.ipac.table.DataGroup.HEALPIX_IDX;
 import static edu.caltech.ipac.util.StringUtils.split;
 
 @SearchProcessorImpl(id = HealpixProcessor.ID, params = {
@@ -71,9 +67,10 @@ public class HealpixProcessor extends TableFunctionProcessor {
         EmbeddedDbProcessor proc = (EmbeddedDbProcessor) SearchManager.getProcessor(sreq.getRequestId());
         String dataTable = proc.getResultSetID(sreq);
         String healpixTable = getResultSetTablePrefix() + "_" + dataTable;
+        String healpixIdxTable = healpixTable + "_IDX";
 
         // create healpix table if it does not exist
-        ensureHealpixExists(dbAdapter, sreq, ra, dec, dataTable, healpixTable);
+        ensureHealpixExists(dbAdapter, sreq, ra, dec, dataTable, healpixTable, healpixIdxTable);
 
         DataGroup results;
         if (mode.equals(MAP)) {
@@ -90,9 +87,11 @@ public class HealpixProcessor extends TableFunctionProcessor {
             results = dbAdapter.execQuery(sql, null);
         } else if (mode.equals(POINTS)) {
             if (pixels == null || pixels.length == 0) throw new DataAccessException("POINTS mode: pixels parameter is missing");
-            String lhs = orderDelta > 0 ? "TRUNC(%s/4^%s)".formatted(HEALPIX_IDX, orderDelta) : HEALPIX_IDX;
+            String lhs = orderDelta > 0 ? "TRUNC(i.pixel/4^%s)".formatted(orderDelta) : "i.pixel";
             String rhs =  pixels.length == 1 ? " = %s".formatted(pixels[0]) : " IN (%s)".formatted(String.join(",", pixels));
-            String sql = "SELECT %s, %s, ROW_NUM from %s WHERE %s %s".formatted(ra, dec, dataTable, lhs, rhs);   // need ra,dec(?)
+            // join against the precomputed (ROW_IDX -> pixel) index
+            String sql = "SELECT d.%s, d.%s, d.ROW_NUM from %s d JOIN %s i ON d.ROW_IDX = i.ROW_IDX WHERE %s %s"
+                    .formatted(ra, dec, dataTable, healpixIdxTable, lhs, rhs);
             results = dbAdapter.execQuery(sql, null);
         } else {
             throw new DataAccessException("Unsupported mode: " + mode);
@@ -102,34 +101,31 @@ public class HealpixProcessor extends TableFunctionProcessor {
         return new DataGroupPart(results,0, results.size());
     }
 
-    private void ensureHealpixExists( DbAdapter dbAdapter, TableServerRequest sreq, String ra, String dec, String dataTable, String healpixTable) throws DataAccessException {
+    private void ensureHealpixExists( DbAdapter dbAdapter, TableServerRequest sreq, String ra, String dec, String dataTable, String healpixTable, String healpixIdxTable) throws DataAccessException {
 
         // if search data table does not exist; load it.
         if (!dbAdapter.hasTable(dataTable)) {
             sreq.setPageSize(1);    // load table into database; ignore results.
             new SearchManager().getDataGroup(sreq);
         }
-        // if healpix map doesn't exist, index the data table, then create the map
+        // if healpix map doesn't exist, index the data, then create the map from the index.
         if (!dbAdapter.hasTable(healpixTable)) {
 
-            // create healpix index at BASE_ORDER
-            DataType healpixCol = makeHealPixColumn();
+            // the (ROW_IDX -> pixel) index is kept as its own small table rather than a column on dataTable,
             StopWatch.getInstance().start("HealpixProcessor: create index");
-            EmbeddedDbUtil.addColumn(dbAdapter, dataTable, healpixCol, "deg2pix(%s, %s, %s)".formatted(BASE_ORDER, ra, dec));
+            String healpixExpr = healpixIdxExpr(ra, dec);
+            dbAdapter.execUpdate("create table %s as (select ROW_IDX, %s as pixel from %s)".formatted(healpixIdxTable, healpixExpr, dataTable));
             StopWatch.getInstance().printLog("HealpixProcessor: create index");
 
-            // create healpix map at BASE_ORDER
             StopWatch.getInstance().start("HealpixProcessor: create pixel map");
-            dbAdapter.execUpdate("create table %s as (select %s as 'pixel', count() as 'count' from %s group by 1)".formatted(healpixTable, HEALPIX_IDX, dataTable));
+            dbAdapter.execUpdate("create table %s as (select pixel, count() as 'count' from %s group by 1)".formatted(healpixTable, healpixIdxTable));
             StopWatch.getInstance().printLog("HealpixProcessor: create pixel map");
 
         }
     }
 
-    private static DataType makeHealPixColumn() {
-        DataType dt = new DataType(HEALPIX_IDX, Long.class);
-        dt.setVisibility(DataType.Visibility.hidden);
-        return dt;
+    private static String healpixIdxExpr(String ra, String dec) {
+        return "deg2pix(%s, %s, %s)".formatted(BASE_ORDER, ra, dec);
     }
 
 }

--- a/src/firefly/test/edu/caltech/ipac/table/DuckDbAdapterTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/DuckDbAdapterTest.java
@@ -239,10 +239,11 @@ public class DuckDbAdapterTest extends ConfigTest {
 		proc.getData(treq);
 		assertEquals("Data table and its associated tables are created", 4, dbAdapter.getTableNames().size());
 
-		// sort by model.  this should create a temp table
+		// sort by model.  this should create a resultset: a thin (ROW_IDX, ROW_NUM) index table, a view
+		// joining it back to DATA, plus that view's own _DD, _META, and _AUX -- 5 new objects total.
 		treq.setSortInfo(new SortInfo("sepal.width"));
 		proc.getData(treq);
-		assertEquals("New set of temp tables created for the request", 8, dbAdapter.getTableNames().size());
+		assertEquals("New set of temp tables created for the request", 9, dbAdapter.getTableNames().size());
 
 		dbAdapter.clearCachedData();
 		assertEquals("Temp tables are removed", 4, dbAdapter.getTableNames().size());

--- a/src/firefly/test/edu/caltech/ipac/table/EmbeddedDbUtilTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/EmbeddedDbUtilTest.java
@@ -40,6 +40,7 @@ public class EmbeddedDbUtilTest extends ConfigTest {
 
 	@BeforeClass
 	public static void setUp() {
+		ConfigTest.setupServerContext(null);
 		try {
 			File tmp = new File(System.getProperty("java.io.tmpdir"));
 			var dbAdapter = DbAdapter.getAdapter("", (ext) -> new File(tmp, "%d.%s".formatted(System.currentTimeMillis(), ext)));
@@ -230,7 +231,7 @@ public class EmbeddedDbUtilTest extends ConfigTest {
 
 		DbAdapter dbAdapter = DbAdapter.getAdapter(dbFile);
 
-		Logger.setLogLevel(Level.TRACE, "edu.caltech");
+		Logger.setLogLevel(Level.TRACE, "edu.caltech.ipac.firefly.server.util.StopWatch");
 		DataGroup data = IpacTableReader.read(testFile);
 		StopWatch.getInstance().start("ingest DB file");
 		dbAdapter.initDbFile();

--- a/src/firefly/test/edu/caltech/ipac/table/HealpixProcessorTest.java
+++ b/src/firefly/test/edu/caltech/ipac/table/HealpixProcessorTest.java
@@ -7,7 +7,9 @@ import edu.caltech.ipac.firefly.ConfigTest;
 import edu.caltech.ipac.firefly.data.ServerParams;
 import edu.caltech.ipac.firefly.data.SortInfo;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.firefly.server.db.DbAdapter;
 import edu.caltech.ipac.firefly.server.query.DataAccessException;
+import edu.caltech.ipac.firefly.server.query.EmbeddedDbProcessor;
 import edu.caltech.ipac.firefly.server.query.HealpixProcessor;
 import edu.caltech.ipac.firefly.server.query.SearchManager;
 import edu.caltech.ipac.firefly.server.query.tables.IpacTableFromSource;
@@ -21,12 +23,14 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import static edu.caltech.ipac.firefly.server.query.HealpixProcessor.*;
 import static edu.caltech.ipac.table.JsonTableUtil.toJsonTableRequest;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class HealpixProcessorTest extends ConfigTest {
@@ -121,6 +125,39 @@ public class HealpixProcessorTest extends ConfigTest {
         } catch (Exception e) {
             fail("HealpixProcessorTest.healpixFiltered failed with exception: " + e.getMessage());
         }
+    }
+
+    /**
+     * The healpix map and its (ROW_IDX -> pixel) index are extra temp tables created alongside the
+     * search's own resultset table/view.  They must be swept up by clearCachedData() like any other
+     * temp table, even though dataTable here is filtered (i.e. a view, not the raw DATA table).
+     */
+    @Test
+    public void healpixCleansUpTempTables() throws Exception {
+        TableServerRequest sreq = makeSearchReq();
+        sreq.setFilters(Arrays.asList("auto_flag = 2"));       // force a resultset view rather than plain DATA
+        TableServerRequest req = makeMapReq(sreq);
+
+        new SearchManager().getDataGroup(req).getData();       // creates the healpix map + index
+
+        req.setParam(MODE, POINTS);
+        req.setParam(PIXELS, "6974934");
+        new SearchManager().getDataGroup(req).getData();       // exercises the index-join path
+
+        EmbeddedDbProcessor proc = (EmbeddedDbProcessor) SearchManager.getProcessor(IpacTableFromSource.PROC_ID);
+        DbAdapter dbAdapter = proc.getDbAdapter(sreq);
+
+        List<String> beforeCleanup = dbAdapter.getTableNames();
+        assertTrue("healpix pixel map table was created",
+                beforeCleanup.stream().anyMatch(n -> n.startsWith("HEALPIX_") && !n.endsWith("_IDX")));
+        assertTrue("healpix ROW_IDX->pixel index table was created",
+                beforeCleanup.stream().anyMatch(n -> n.startsWith("HEALPIX_") && n.endsWith("_IDX")));
+
+        dbAdapter.clearCachedData();
+
+        List<String> afterCleanup = dbAdapter.getTableNames();
+        assertTrue("only the main DATA tables remain after cleanup",
+                afterCleanup.stream().allMatch(DbAdapter.MAIN_TABLES::contains));
     }
 
     @Test


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-2059
- Root problem: every sort/filter fully copied every column of every matching row into a new table
- Thin index instead of full copy: store just (ROW_IDX, ROW_NUM) for the resultset, cheap regardless of table width.
- Resultset as a view joining that index to DATA, projecting only requested columns, so every existing consumer keeps working unchanged.
- Healpix index kept separate: its own small (ROW_IDX, pixel) table, computed once and joined at query time, instead of a persisted column on the shared resultset

Test: https://firefly-2059-table-query-optimization.irsakubedev.ipac.caltech.edu/firefly/
Compare this with the nightly build: https://firefly.irsakubedev.ipac.caltech.edu/firefly/

Try this: 10 million rows, 150 columns. The same FITS table converted into parquet to avoid high memory usage during loading.  https://irsawebdev1.ipac.caltech.edu:9201/test-data/10m-150col.parquet
You’ll notice a significant performance improvement during sorting and filtering.

These smaller tables work smoothly.
https://irsawebdev1.ipac.caltech.edu:9201/test-data/table_1mil.parquet
https://irsawebdev1.ipac.caltech.edu:9201/test-data/wise-1_6-million.tbl
