### PR TITLE
Firefly-2062: multiple rubin bugs

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -8,8 +8,43 @@
 
 ---
 
+## Version 2026.2
+- 2026.2.0 — (July 22, 2026), _Docker tag_: `2026.2.0`, `2026.2`, `latest`
+
+This stability release includes numerous bug fixes and introduces the first end-user installable version of Firefly.
+
+#### General Features
+- Updated Standalone Firefly application landing page — Firefly-1981 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1959))
+- Change default menus and tabs for standalone Firefly application — Firefly-2028 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1967))
+- Added support for end-user installation of Firefly — Firefly-1980 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1962))
+- URL API: added SIA support and cleaned up of `hipsPanel` command — Firefly-2026 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1973))
+- Fits Images: Give an error or sometimes silently skip an unsupported 4d+ HDU — Firefly-2049 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1976))
+- MOC: Added support for MOC 2.0, with `ORDERING=NUNIQ` — Firefly-2049 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1976))
+- Tables: Optimize FITS table reading performance — Firefly-2049 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1976))
+- Tables: improve slow loading of wide tables — Firefly-1746 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1980))
+
+
+#### Infrastructure Updates
+- Improved application security and configuration hardening — Firefly-1864 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1955))
+- Upgraded react split pane — Firefly-1854 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1957))
+
+
+#### Bug Fixes
+- Improve duckdb memory usage — Firefly-2017 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1960))
+- Fixed: WCS Match so east-right images align correctly — Firefly-2055 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1978))
+- Fixed: GPU array overflow and optimized color lookup performance — Firefly-2056 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1979))
+- MultiProductViewer: Multi Bug fixes found in Rubin testing — Firefly-2062 ([PR](https://github.com/Caltech-IPAC/firefly/pull/1983))
+
+
+##### _Pull Requests in this Release_
+
+- [All Bug Fixes](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr+milestone%3a2026.2+label%3abug)
+- [All PRs](https://github.com/caltech-ipac/firefly/pulls?q=is%3apr++milestone%3a2026.2+)
+
+---
+
 ## Version 2026.1
-- 2026.1.5 — (June 23, 2026), _docker tag_: `2026.1.5`, `2026.1`, `latest`
+- 2026.1.5 — (June 23, 2026), _docker tag_: `2026.1.5`, `2026.1`,
 - 2026.1.4 — (June 17, 2026), _docker tag_: `2026.1.4`
 - 2026.1.3 — (June 11, 2026), _docker tag_: `2026.1.3`
 - 2026.1.2 — (May 26, 2026), _docker tag_: `2026.1.2`

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/LsstHiPSListSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/LsstHiPSListSource.java
@@ -1,19 +1,31 @@
 package edu.caltech.ipac.firefly.server.visualize.hips;
 
+import edu.caltech.ipac.firefly.data.FileInfo;
 import edu.caltech.ipac.firefly.data.ServerParams;
+import edu.caltech.ipac.firefly.server.servlets.HiPSRetrieve;
+import edu.caltech.ipac.firefly.server.util.Logger;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.DataObject;
+import edu.caltech.ipac.table.TableUtil;
 import edu.caltech.ipac.util.AppProperties;
+import edu.caltech.ipac.util.download.URLDownload;
 
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * Created by cwang on 2/27/18.
- */
 public class LsstHiPSListSource implements HiPSMasterListSourceType {
 
     private static final String lsstHipsListUrl = AppProperties.getProperty(
             "lsst.hips.masterUrl",
             "https://irsa.ipac.caltech.edu/data/hips/list");
+
+    private static final String lsstMocListUrl = AppProperties.getProperty(
+            "lsst.moc.masterUrl",
+            null);
+    static final Logger.LoggerImpl log = Logger.getLogger();
+
 
     public List<HiPSMasterListEntry> getHiPSListData(String[] dataTypes, String source) {
         try {
@@ -25,5 +37,59 @@ public class LsstHiPSListSource implements HiPSMasterListSourceType {
             return null;
         }
     }
+
+    public List<HiPSMasterListEntry> getAdditionalMOCS_NEW(String source) {
+        try {
+            if (lsstMocListUrl==null) return null;
+            URL url= URLDownload.makeURL(lsstMocListUrl);
+            if  (url == null) return null;
+            FileInfo listFileInfo = HiPSRetrieve.retrieveHiPSData(url.toString(), source, false);
+            if (listFileInfo.getResponseCode()!=200 && listFileInfo.getResponseCode()!=304) return null;
+            DataGroup dg= TableUtil.readAnyFormat(listFileInfo.getFile());
+            if (dg == null || dg.isEmpty()) return null;
+            var retList = new ArrayList<HiPSMasterListEntry>();
+            String baseUrl= null;
+            if (url.getQuery()==null) {
+                String s= lsstHipsListUrl.endsWith("/") ? lsstHipsListUrl.substring(0,lsstHipsListUrl.length()-1) : lsstHipsListUrl;
+                var endIdx= s.lastIndexOf("/");
+                baseUrl= endIdx>-1  ? s.substring(0, s.lastIndexOf("/")) : s;
+            }
+
+            for(var i=0; i<dg.size();i++) {
+                DataObject row= dg.get(i);
+                HiPSMasterListEntry entry = new HiPSMasterListEntry();
+                setV(entry,row, HiPSMasterListEntry.PARAMS.FRACTION, "coverage");
+                setV(entry,row, HiPSMasterListEntry.PARAMS.WAVELENGTH, "waveband");
+                setV(entry,row, HiPSMasterListEntry.PARAMS.TITLE, "title");
+                setV(entry,row, HiPSMasterListEntry.PARAMS.ORDER, "order");
+                setV(entry,row, HiPSMasterListEntry.PARAMS.RELEASEDATE, "release");
+                setV(entry,row, HiPSMasterListEntry.PARAMS.PROPERTIES, "info_url");
+                entry.set(HiPSMasterListEntry.PARAMS.SOURCE.getKey(),source);
+
+                var mocUrlStrPath= (String)row.getDataElement("moc_url");
+                if (mocUrlStrPath!=null) {
+                    var mocUrlStr= (mocUrlStrPath.toLowerCase().startsWith("http") || baseUrl==null)
+                            ? mocUrlStrPath
+                            : baseUrl+"/"+mocUrlStrPath;
+                    entry.set(HiPSMasterListEntry.PARAMS.URL.getKey(), mocUrlStr);
+                    entry.set(HiPSMasterListEntry.PARAMS.IVOID.getKey(), mocUrlStr);
+                }
+
+                retList.add(entry);
+            }
+            return retList;
+        } catch (Exception e) {
+            log.error(e, "cannot find additional MOCS for " + source);
+            return null;
+        }
+    }
+
+    public void setV(HiPSMasterListEntry entry, DataObject row, HiPSMasterListEntry.PARAMS key, String col) {
+        Object obj= row.getDataElement(col);
+        if (obj!=null) entry.set(key.getKey(), obj.toString());
+    }
+
+
+
     public String getUrl() { return lsstHipsListUrl; }
 }

--- a/src/firefly/java/edu/caltech/ipac/table/io/SpectrumMetaInspector.java
+++ b/src/firefly/java/edu/caltech/ipac/table/io/SpectrumMetaInspector.java
@@ -28,7 +28,7 @@ public class SpectrumMetaInspector {
     private static final String[] specColNames;
     private static final String[] waveLoColName= new String[] {"wave_lo"};
     private static final String[] waveHiColName= new String[] {"wave_hi"};
-    private static final String[] fluxColNames= new String[] {"flux", "fluxdensity", "flux_density", "flux",
+    private static final String[] fluxColNames= new String[] {"flux", "fluxdensity", "flux_density",
             "flx", "fl", "fls", "flu", "data", "value", "signal", "SurfBrtness",
             "fullap and psf (two different extractions)", "c(lambda)",
             "t_mb", "t(k)", "main beam temperature",

--- a/src/firefly/java/edu/caltech/ipac/visualize/plot/Histogram.java
+++ b/src/firefly/java/edu/caltech/ipac/visualize/plot/Histogram.java
@@ -234,8 +234,10 @@ public class Histogram implements HasSizeOf {
                     else {
                         partialHist[i] ++;
                     }
-                    if (float1dArray[k] < histDatamin) histDatamin = float1dArray[k];
-                    if (float1dArray[k] > histDatamax) histDatamax = float1dArray[k];
+                    if (!Double.isInfinite(float1dArray[k])) {
+                        if (float1dArray[k] < histDatamin) histDatamin = float1dArray[k];
+                        if (float1dArray[k] > histDatamax) histDatamax = float1dArray[k];
+                    }
                 }
             }
             return null;

--- a/src/firefly/js/metaConvert/PartAnalyzer.js
+++ b/src/firefly/js/metaConvert/PartAnalyzer.js
@@ -72,7 +72,7 @@ function imageCouldBeTable(part) {
     const naxisAry= [];
     for(let i=0; i<naxis;i++) naxisAry[i]= getIntHeaderFromAnalysis(`NAXIS${i+1}`,part,0);
     if (naxis===2) return naxisAry[1]<=30;
-    if (naxis===3) return naxisAry[1]===1;
+    if (naxis===3) return naxisAry[1]<=30 && naxisAry[2]===1;
     else {
         let couldBeTable= true;
         for(let i=1; (i<naxis);i++) if (naxisAry[i]>1) couldBeTable= false;
@@ -92,8 +92,8 @@ function is1DImage(part) {
 }
 
 
-const C_COL1= ['index','wave'];
-const C_COL2= ['flux','data','data1','data2'];
+const C_COL1= ['index','wave','wavelength', 'wavelengths', 'wl', 'wls', 'lambda', 'lambda_eff', 'v_lsr', 'centralwavelng'];
+const C_COL2= ['flux','data','data1','data2', 'fluxdensity', 'flux_density', 'flx', 'fl', 'fls', 'flu', 'value', 'signal', 'SurfBrtness',];
 
 const TS_C_COL1= ['mjd'];
 const TS_C_COL2= [ 'psfflux', /psf.*flux/, 'mag','flux',];
@@ -245,15 +245,15 @@ function analyzeChartTableResult(table, row, part, fileFormat, source, title, to
     const imageAsTableColCnt= useImageAsTable ? getImageAsTableColCount(part,fileFormat) : 0;
     const {title:ddTitleStr, dropDownText} = getAnalysisPartTableTitling({title,part,fileFormat:partFormat, table,
         useImageAsTable, imageAsTableColCnt, totalParts, originalTitle});
-    const {chartInfo, imageAsTableInfo}= getTableChartColInfo(title, part, partFormat, table);
+    const {chartInfo, imageAsTableInfo}= getTableChartColInfo(ddTitleStr, part, partFormat, table);
 
-    let titleInfo=title || `table_${part.index}`;
+    let titleInfo=ddTitleStr || `table_${part.index}`;
     if (isSSATable(table)) titleInfo= getAnalysisSSATitle(table,row)??'spectrum';
     
 
     if (chartInfo.hasChart) {
         const chartTableDefOption= getChartTableDefaultOption(part,chartInfo,partFormat);
-        if (isSingleRowChart(part,partFormat,chartInfo)) { // a common case: single row table with array columns
+        if (isSingleRowChart(part,partFormat,chartInfo) && partFormat===Format.FITS) { // a common case: single row table with array columns
             return makeSingleRowChartTableResult({ddTitleStr,source,activateParams,chartInfo,tbl_index, imageAsTableInfo,
                                                        chartTableDefOption, interpretedData, dropDownText});
         }
@@ -280,7 +280,7 @@ function getIds(options,title) {
 
 function makeSingleRowChartTableResult({ddTitleStr,source,activateParams,chartInfo,tbl_index:paIdx, imageAsTableInfo,
                                            chartTableDefOption, interpretedData, dropDownText}) {
-    const titleStr= 'Row 1 Chart';
+    const titleStr= 'Single Row Chart';
     const activate= createChartSingleRowArrayActivate(source,titleStr,activateParams,chartInfo,0,paIdx);
     const extraction= createTableExtraction(source,titleStr,paIdx, imageAsTableInfo,
         0, chartInfo.tableDataType);

--- a/src/firefly/js/metaConvert/VoUITitles.js
+++ b/src/firefly/js/metaConvert/VoUITitles.js
@@ -29,8 +29,8 @@ export const getCutoutTitleFromTitle= (baseTitle) => 'Cutout: ' + baseTitle;
  * @return {string}
  */
 export function getSerDescTitling(serDef,sourceTable,sourceRow) {
-    const name= makeDatalinkTitles({dlData:{serDef},sourceTable,sourceRow});
-    return {name,dropDownText:'Show: '+name};
+    const ret= makeDatalinkTitles({dlData:{serDef},sourceTable,sourceRow});
+    return {...ret,dropDownText:'Show: '+ret.name};
 
 }
 
@@ -146,7 +146,7 @@ export function getAnalysisPartTableTitling({title='',part,fileFormat,table,useI
         retTitle= getAnalysisSSATitle(table,table.highlightedRow);
     }
     else {
-       retTitle= totalParts===1 ? title :`Part #${part.index} ${title}`;
+       retTitle= totalParts===1 ? originalTitle :`Part #${part.index} ${title}`;
     }
 
     const dropDownText= originalTitle ? `${originalTitle} - ${retTitle}` : retTitle;

--- a/src/firefly/js/metaConvert/vo/ServDescProducts.js
+++ b/src/firefly/js/metaConvert/vo/ServDescProducts.js
@@ -68,7 +68,7 @@ export function makeServiceDefDataProduct({ dropDownText, name, serDef, sourceTa
 
         const t= ensureDropDownText(tName,dropDownText);
         return dpdtAnalyze({
-            name: t.title, dropDownText: t.dropDownText,
+            name: t, dropDownText: t,
             activate, url:request.getURL(), serDef, menuKey, dlData,
             activeMenuLookupKey, request, sRegion, semantics, size, serviceDefRef});
     } else {

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -109,8 +109,8 @@ const BasicTableViewInternal = React.memo(({ selectable:selectableIn= false, sho
             error, tbl_ui_id=uniqueTblUiId(), currentPage, startIdx=0, highlightedRowHandler, cellRenderers, onRowDoubleClick} = props;
 
     const uiStates = getTableUiById(tbl_ui_id) || {};
-    const {tbl_id, columnWidths, scrollLeft=0, scrollTop=0, triggeredBy, showTypes, showFilters, showSelectRowFilter,
-            showUnits, filterInfo, selectable, sortInfo, textView} = uiStates;
+    const {tbl_id, columnWidths, scrollLeft=0, scrollTop=0, triggeredBy, showTypes=false, showFilters=false, showSelectRowFilter,
+            showUnits=false, filterInfo, selectable, sortInfo, textView} = uiStates;
     const tableRef = useRef();
 
     useEffect( () => {

--- a/src/firefly/js/ui/dynamic/ServiceDescriptorPanel.jsx
+++ b/src/firefly/js/ui/dynamic/ServiceDescriptorPanel.jsx
@@ -43,7 +43,7 @@ export const ServiceDescriptorPanel= memo(({ serviceDefRef='none', serDef, setSe
         const wp= ShapeDataObj.draw.getCenterPt(drawObj);
         const validPts = drawObj.pts.filter( (pt) => pt);
         const results= computeCentralPtRadiusAverage([validPts],.11);
-        fovSize= results.fovSize * 2.4;
+        fovSize= results.fovSize * 4.5;
         console.log(wp);
     }
 

--- a/src/firefly/js/visualize/ui/ColorBandPanel.jsx
+++ b/src/firefly/js/visualize/ui/ColorBandPanel.jsx
@@ -2,10 +2,10 @@
  * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
  */
 
-import {Box, Skeleton, Stack, Typography} from '@mui/joy';
+import {Skeleton, Stack, Typography} from '@mui/joy';
 import React, {memo, useState, useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
-import {debounce, get, isUndefined} from 'lodash';
+import {debounce, isNil, isUndefined} from 'lodash';
 import {sprintf} from '../../externalSource/sprintf';
 import {ValidationField} from '../../ui/ValidationField.jsx';
 import {ListBoxInputField} from '../../ui/ListBoxInputField.jsx';
@@ -26,11 +26,8 @@ import {useWatcher} from 'firefly/ui/SimpleComponent.jsx';
 import {dispatchForceFieldGroupReducer} from 'firefly/fieldGroup/FieldGroupCntlr.js';
 
 
-const LABEL_WIDTH= 105;
 const HIST_WIDTH= 360;
 const HIST_HEIGHT= 55;
-const maskWrapper= {position:'absolute', left:0, top:0, width:'100%', height:'100%' };
-const textPadding= {paddingBottom:3};
 const cbarImStyle= {width:'100%', height:10, padding: '0 2px 0 2px', boxSizing:'border-box' };
 
 const histImStyle= {
@@ -72,8 +69,8 @@ export const ColorBandPanel= memo(({fields,plot,band, groupKey}) => {
             const dataHistogram= result.DataHistogram;
             const dataBinMeanArray= result.DataBinMeanArray;
             const dataBinColorIdx= result.DataBinColorIdx;
-            const dataMin= result.DataMin;
-            const dataMax= result.DataMax;
+            const dataMin= result.DataMin===null ? undefined : result.DataMin;
+            const dataMax= result.DataMax===null ? undefined : result.DataMax;
             const largeBinPercent= result.LargeBinPercent;
             lastProps.rvStr= plot.plotState.getRangeValues(band).toString();
             lastProps.plotId= plotId;
@@ -339,6 +336,7 @@ function getReplotFunc(groupKey, band) {
 const formatFlux= (value, plot, band) => isNaN(value) ? '' : `${formatFluxValue(value)} ${getFluxUnits(plot,band)}`;
 
 function formatFluxValue(value) {
+    if (isNil(value)) return '';
     const absV= Math.abs(value);
     return (absV>1000||absV<.01) ? value.toExponential(6).replace('e+', 'E') : value.toFixed(6);
 }

--- a/src/firefly/js/voAnalyzer/ColumnsModelInfo.js
+++ b/src/firefly/js/voAnalyzer/ColumnsModelInfo.js
@@ -32,11 +32,14 @@ class ColumnRecognizer {
         return this.centerColumnsInfo;
     }
 
-    getColumnsWithUCDWord(cols, ucdWord) {
+    getColumnsWithUCDWord(cols, ucdWord, maxWords=0) {
         if (isEmpty(cols)) return [];
 
         return cols.filter((oneCol) => {
-            return has(oneCol, 'ucd') && isUCDWith(oneCol.ucd, ucdWord, get(ucdSyntaxMap, ucdWord));
+            if (has(oneCol, 'ucd') && isUCDWith(oneCol.ucd, ucdWord, ucdSyntaxMap[ucdWord])) {
+                return maxWords === 0 || oneCol.ucd.split(';').length <= maxWords;
+            }
+            return false;
         });
     }
 
@@ -84,7 +87,8 @@ class ColumnRecognizer {
         }, []);
 
         const metaMainPair = posPairs.map((posCols, idx) => {
-            const mainMetaCols = this.getColumnsWithUCDWord(posCols, mainMeta);
+            let mainMetaCols = this.getColumnsWithUCDWord(posCols, mainMeta,2);
+            if (isEmpty(mainMetaCols)) mainMetaCols = this.getColumnsWithUCDWord(posCols, mainMeta);
             if (!isEmpty(posCols) && isEmpty(mainMetaCols)) {
                 alternateMainPos.find((oneAlt) => {
                     const altCols = this.getColumnsWithUCDWord(posCols, oneAlt[idx], ucdSyntaxMap.any);


### PR DESCRIPTION
#### [Firefly-2062](https://jira.ipac.caltech.edu/browse/FIREFLY-2062): multiple rubin bugs

- MultiProductViewer: dp2 - object table search - chart should have the title , right now it has the fallback
- MultiProductViewer: dp2 - dia object, filter g_psfFluxNdata, > 10, should have two entries, and they are not labeled
- MultiProductViewer: dp2 - dia object, g_psfFluxNdata = 0, only 1 entry across all 6 filter, the resulting table 1 row and the chart is not correct
- MultiProductViewer: dp2 - refresh crashes it, also can do a ztf object search and use the search again
- MultiProductViewer: dp2, deep_coadd, variance, then show the color stretch dialog, and it get weird, yband - search lsst_tract=5063, lsst_patch=5
- MultiProductViewer: Service Descriptor UI: in cutout case hips should come up zoom so that the box is about 2/3 the size on the screen
- MultiProductViewer: trying to show a cube as a table and chart
- Tables: fixed: a table case when the undefined parameters are not correctly defaulting then causing the firefly crash

#### Testing
- https://data-int.lsst.cloud/portal/app/
- test all the above issues