### PR TITLE
Firefly-2063: update github workflow for standalone artifact

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -16,11 +16,15 @@ on:
         required: false
         default: false
         type: boolean
+      release_tag:
+        description: "Optional: Firefly release tag for standalone.zip artifact (e.g. release-xxxx.x.x)"
+        required: false
+        type: string
   release:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 jobs:
@@ -29,7 +33,7 @@ jobs:
 
     steps:
       # initial checkout to make local actions available
-      - name: Checkout Firefly
+      - name: Checkout Firefly for local actions
         uses: actions/checkout@v4
         with:
           path: firefly
@@ -47,11 +51,21 @@ jobs:
       # ------------------------------------------------------------
       # Checkout firefly (this repo)
       # ------------------------------------------------------------
-      - name: Checkout Firefly
+      - name: Checkout Firefly depth==1
         uses: actions/checkout@v4
+        if: github.event_name == 'release'
         with:
           ref: ${{ steps.resolve_tags.outputs.ref }}
           path: firefly
+          
+      - name: Checkout Firefly full depth
+        uses: actions/checkout@v4
+        if: github.event_name != 'release'
+        with:
+          ref: ${{ steps.resolve_tags.outputs.ref }}
+          path: firefly
+          fetch-depth: 0
+
 
       # ------------------------------------------------------------
       # Checkout Firefly online help
@@ -99,6 +113,39 @@ jobs:
             env=ops
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # ------------------------------------------------------------
+      # Export standalone.zip. Same build-args as the image build
+      # above, so the `builder` stage is a cache hit; only the extra
+      # `standalone-builder` layer (gradle standalone:zip) runs.
+      # ------------------------------------------------------------
+      - name: Build and export standalone.zip
+        if: github.event_name == 'release' || inputs.release_tag != ''
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: firefly/docker/Dockerfile
+          platforms: linux/amd64
+          target: standalone-zip
+          push: false
+          outputs: type=local,dest=./dist-zip
+          build-args: |
+            env=ops
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # ------------------------------------------------------------
+      # use gh (GitHub api) command to add standalone.zip
+      # to release artifacts
+      # using `gh release upload` requires setting `contents: write`
+      # ------------------------------------------------------------
+      - name: Add standalone.zip to release artifacts
+        if: github.event_name == 'release' || inputs.release_tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}"
+          gh release upload "$TAG" --repo "${{ github.repository }}"  ./dist-zip/standalone.zip --clobber
 
       # ------------------------------------------------------------
       # Package and push Helm chart to GHCR

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,6 +72,23 @@ RUN if [ -z "$checkoutFirefly" ] ; then echo skip checkout ; else gradle firefly
 RUN gradle -Penv=${env} -PBranchOverride=${BranchOverride} ${target}
 
 
+# =====================================
+# Stage: Standalone zip builder
+# =====================================
+FROM builder AS standalone-builder
+ARG env=local
+ARG BranchOverride=''
+RUN gradle -Penv=${env} -PBranchOverride=${BranchOverride} standalone:zip
+
+
+# ==============================
+# Stage: Standalone zip artifact: standalone.zip
+# ==============================
+FROM scratch AS standalone-zip
+ARG build_dir=firefly
+COPY --from=standalone-builder /opt/work/${build_dir}/build/dist/standalone.zip /
+
+
 # ==============================
 # Dev environment
 # ==============================

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/LsstHiPSListSource.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/visualize/hips/LsstHiPSListSource.java
@@ -21,9 +21,7 @@ public class LsstHiPSListSource implements HiPSMasterListSourceType {
             "lsst.hips.masterUrl",
             "https://irsa.ipac.caltech.edu/data/hips/list");
 
-    private static final String lsstMocListUrl = AppProperties.getProperty(
-            "lsst.moc.masterUrl",
-            null);
+    private static final String lsstMocListUrl = AppProperties.getProperty( "lsst.moc.masterUrl", null);
     static final Logger.LoggerImpl log = Logger.getLogger();
 
 
@@ -38,7 +36,7 @@ public class LsstHiPSListSource implements HiPSMasterListSourceType {
         }
     }
 
-    public List<HiPSMasterListEntry> getAdditionalMOCS_NEW(String source) {
+    public List<HiPSMasterListEntry> getAdditionalMOCS(String source) {
         try {
             if (lsstMocListUrl==null) return null;
             URL url= URLDownload.makeURL(lsstMocListUrl);
@@ -50,7 +48,7 @@ public class LsstHiPSListSource implements HiPSMasterListSourceType {
             var retList = new ArrayList<HiPSMasterListEntry>();
             String baseUrl= null;
             if (url.getQuery()==null) {
-                String s= lsstHipsListUrl.endsWith("/") ? lsstHipsListUrl.substring(0,lsstHipsListUrl.length()-1) : lsstHipsListUrl;
+                String s= lsstMocListUrl.endsWith("/") ? lsstMocListUrl.substring(0,lsstMocListUrl.length()-1) : lsstMocListUrl;
                 var endIdx= s.lastIndexOf("/");
                 baseUrl= endIdx>-1  ? s.substring(0, s.lastIndexOf("/")) : s;
             }

--- a/src/firefly/js/ui/HiPSImageSelect.jsx
+++ b/src/firefly/js/ui/HiPSImageSelect.jsx
@@ -182,8 +182,8 @@ const getTitle= () => getHighlightCell(TITLE_COL) || 'Blank HiPS';// blank hips 
 export const getHipsUrl= () => getHighlightCell(URL_COL) || BLANK_HIPS_URL;// blank hips is empty-space in the table
 
 function SourceSelect({moc=false, extraHiPSListName }) {
-    const mocSource= getAppOptions().hips?.adhocMocSource || 'Featured Sources';
-    const sourceOptions = moc && mocSource ?
+    const mocSource= getAppOptions().hips?.adhocMocSource || {label: 'Featured Sources', sources: []};
+    const sourceOptions = moc ?
             [{label : mocSource.label, value: 'adhoc' }] :
             defHiPSSources()?.map((oneSource) => ({label: oneSource.label, value: oneSource.source}));
     if (extraHiPSListName) {


### PR DESCRIPTION
#### [Firefly-2063](https://jira.ipac.caltech.edu/browse/FIREFLY-2063): update github workflow for standalone artifact


#### Testing - test with the actions tab.
- go to the 2026.1.5 release assets and remove `standalone.zip`
- go to actions tab, `Build and publish Firefly image`
- run this action with `FIREFLY-2063-workflow` 
   - git tag `FIREFLY-2063-workflow`
   - Docker image tag: blank
   - push to ghcr: unchecked
   - release tag for standalone: `release-2026.1.5`
- run will take about 15 minutes
- at the end goto the  2026.1.5 release assets and see `standalone.zip`