### PR TITLE
FIREFLY-1971: Add spectral lines plotting in the spectral charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mathjax-full": "~3.2.2",
     "md5": "~2.3.0",
     "moment": "~2.30",
-    "plotly.js-dist-min": "~3.1.0",
+    "plotly.js-dist-min": "~3.6.0",
     "point-in-polygon": "~1.1",
     "prismjs": "~1.30",
     "prop-types": "~15.8",

--- a/src/firefly/java/edu/caltech/ipac/firefly/resources/linelist_combined.csv
+++ b/src/firefly/java/edu/caltech/ipac/firefly/resources/linelist_combined.csv
@@ -1,0 +1,45 @@
+wavelength_um,species,transition,phase,origin,ref
+2.6259,H I,Br beta (6-4),gas,xlsx+calc,Lai+
+2.8730,H I,Pf 11 (11-5),gas,xlsx+calc,Lai+
+2.9600,NH3,N-H stretch (nu2),ice,xlsx,Gibbs
+3.0039,H2,v=1-0 O(4),gas,JWST-SpecTool,MEUDON
+3.0392,H I,Pf epsilon (10-5),gas,JWST-SpecTool,CLOUDY
+3.0500,H2O,O-H stretch,ice,xlsx,Gibbs/Lai+
+3.0984,O I,3P-3Do     1 - 1,gas,JWST-SpecTool,OTHERS
+3.2890,PAH,3.3um C-H aromatic,PAH,JWST-SpecTool/xlsx,Lai+/Tokunaga
+3.2970,H I,Pf delta (9-5),gas,JWST-SpecTool,CLOUDY
+3.4000,PAH,3.4um aliphatic C-H,PAH,JWST-SpecTool/xlsx,Lai+/Tokunaga
+3.4600,PAH,C-H band,PAH,JWST-SpecTool/xlsx,Lai+/Tokunaga
+3.4700,-CH2-/-CH3-,C-H stretch (aliphatic),ice,xlsx,Gibbs
+3.5100,PAH,C-H band,PAH,JWST-SpecTool/xlsx,Lai+/Tokunaga
+3.5300,CH3OH,C-H stretch,ice,xlsx,Gibbs
+3.6146,CH+,v=1-0 R(0),gas,JWST-SpecTool,OTHERS
+3.6876,CH+,v=1-0 P(1),gas,JWST-SpecTool,OTHERS
+3.7035,He I,3Po-3D      2 - 1,gas,JWST-SpecTool,CLOUDY
+3.7406,H I,Pf gamma (8-5),gas,JWST-SpecTool,CLOUDY
+3.8461,H2,v=0-0 S(13),gas,JWST-SpecTool,MEUDON
+3.9500,CH3OH/H2S,C-H / S-H stretch,ice,xlsx,Gibbs
+4.0523,H I,Br alpha (5-4),gas,JWST-SpecTool,CLOUDY
+4.0763,[Fe II],a6D-a4F   7/2 - 5/2,gas,JWST-SpecTool,CLOUDY
+4.0820,[Fe II],a6D-a4F   5/2 - 3/2,gas,JWST-SpecTool,CLOUDY
+4.1150,[Fe II],a6D-a4F   9/2 - 7/2,gas,JWST-SpecTool,CLOUDY
+4.1811,H2,v=0-0 S(11),gas,JWST-SpecTool,MEUDON
+4.2700,CO2,C-O stretch (nu3),ice,xlsx,Gibbs/Lai+
+4.2954,He I,3S-3Po     1 - 0,gas,JWST-SpecTool,CLOUDY
+4.3765,H I,Hu (12-6),gas,JWST-SpecTool,CLOUDY
+4.3800,13CO2,13C-O stretch,ice,xlsx,Gibbs
+4.4098,H2,v=0-0 S(10),gas,JWST-SpecTool,MEUDON
+4.5000,H2O,combination mode,ice,xlsx,Gibbs
+4.6077,[Fe II],a6D-a4F   5/2 - 5/2,gas,JWST-SpecTool,CLOUDY
+4.6200,XCN (OCN-),C=N stretch,ice,xlsx,Gibbs
+4.6493,CO,v=1-0 R(1),gas,JWST-SpecTool,OTHERS
+4.6538,H I,Pf beta (7-5),gas,JWST-SpecTool,CLOUDY
+4.6700,CO,12C-O stretch (solid),ice,xlsx,Gibbs/Lai+
+4.6742,CO,v=1-0 P(1),gas,JWST-SpecTool,OTHERS
+4.6946,H2,v=0-0 S(9),gas,JWST-SpecTool,MEUDON
+4.7200,Dust continuum,cloud-depth indicator,continuum,xlsx,Hora+
+4.7326,CO,v=2-1 P(1),gas,JWST-SpecTool,OTHERS
+4.7800,13CO,13C-O stretch,ice,xlsx,Gibbs
+4.8891,[Fe II],a6D-a4F   7/2 - 7/2,gas,JWST-SpecTool,CLOUDY
+4.9100,OCS,C-S stretch,ice,xlsx,Gibbs
+4.9908,CO,v=1-0 P(32),gas,JWST-SpecTool,OTHERS

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/SpectralLinesProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/SpectralLinesProcessor.java
@@ -1,0 +1,36 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+package edu.caltech.ipac.firefly.server.query;
+
+import edu.caltech.ipac.firefly.data.TableServerRequest;
+import edu.caltech.ipac.table.DataGroup;
+import edu.caltech.ipac.table.TableUtil;
+import edu.caltech.ipac.util.FileUtil;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Serves the recommended spectral line list (a fixed resource dataset) as a table.
+ */
+@SearchProcessorImpl(id = "spectralLines")
+public class SpectralLinesProcessor extends EmbeddedDbProcessor {
+    private static final String RESOURCE = "/edu/caltech/ipac/firefly/resources/linelist_combined.csv";
+
+    public DataGroup fetchDataGroup(TableServerRequest req) throws DataAccessException {
+        try (InputStream is = SpectralLinesProcessor.class.getResourceAsStream(RESOURCE)) {
+            if (is == null) throw new IOException("Resource not found: " + RESOURCE);
+
+            // readAnyFormat needs a File; copy the classpath resource to a temp file first
+            String ext = RESOURCE.substring(RESOURCE.lastIndexOf('.'));
+            File tempFile = createTempFile(req, ext);
+            FileUtil.writeToFile(is, tempFile, null);
+
+            return TableUtil.readAnyFormat(tempFile, 0, req);
+        } catch (IOException e) {
+            throw new DataAccessException("Unable to read spectral lines resource", e);
+        }
+    }
+}

--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -377,6 +377,61 @@ export function flattenAnnotations(annotations) {
     return [];
 }
 
+const SHAPE_HOVER_STEPS = 10; // points per line stacked along the shape's height, for a hover target that tracks the cursor vertically
+
+/**
+ * Builds companion hover trace(s) for Plotly shapes that carry a `hovertext`.
+ *
+ * Shapes themselves can't be hovered (no hovertext/hoverinfo support on shapes as of now unlike annotations; see
+ * plotly.js#4780: https://github.com/plotly/plotly.js/issues/4780), so this fakes it with a real scatter
+ * trace: a fully transparent, null-separated line per shape, on a fixed 'y2' axis (paired with the returned
+ * `layout.yaxis2`) so it stays aligned with the shape's fixed paper-relative span regardless of the real
+ * y-axis' zoom/pan.
+ *
+ * Not specific to any one feature — any shape with `hovertext` set gets a hover target this way. One trace is
+ * built per distinct `legendgroup` found among the hoverable shapes (and sharing that legendgroup + showlegend:false
+ * means toggling a shape's legend entry hides its hover trace along with it).
+ *
+ * NOTE: Only handles vertical, paper-height line shape geometry (`yref:'paper', y0:0, y1:1, x0=x1`);
+ * shapes of other types/positions are ignored.
+ *
+ * @param {Array<object>} shapes - candidate shapes, e.g. from layout.shapes
+ * @returns {{traces: Array<object>, layout: object}} traces to add to `data`, and the `layout` fragment
+ * (the 'y2' axis they're plotted on) to merge in alongside them — empty/{} when there's nothing hoverable
+ */
+export function makeShapeHoverTrace(shapes=[]) {
+    const hoverable = shapes.filter((s) => s?.type === 'line' && s.yref === 'paper' && s.hovertext);
+    if (hoverable.length === 0) return {traces: [], layout: {}};
+
+    const byGroup = new Map();
+    hoverable.forEach((s) => {
+        const group = s.legendgroup;
+        if (!byGroup.has(group)) byGroup.set(group, []);
+        byGroup.get(group).push(s);
+    });
+
+    const traces = Array.from(byGroup.entries()).map(([group, groupShapes]) => {
+        const x = [], y = [], hovertext = [];
+        groupShapes.forEach((s) => {
+            for (let i = 0; i < SHAPE_HOVER_STEPS; i++) {
+                x.push(s.x0);
+                y.push(i / (SHAPE_HOVER_STEPS - 1));
+                hovertext.push(s.hovertext);
+            }
+            x.push(null); y.push(null); hovertext.push(null);
+        });
+        return {
+            x, y, hovertext,
+            yaxis: 'y2',
+            type: 'scatter', mode: 'lines', hoverinfo: 'text',
+            line: {width: 10, color: 'rgba(0,0,0,0)'},
+            legendgroup: group, showlegend: false, name: '',
+        };
+    });
+
+    return {traces, layout: {yaxis2: {overlaying: 'y', range: [0, 1], visible: false, fixedrange: true}}};
+}
+
 export function updateSelection(chartId, selectInfo) {
     const {data, activeTrace=0} = getChartData(chartId);
 

--- a/src/firefly/js/charts/dataTypes/SpectrumUnitConversion.js
+++ b/src/firefly/js/charts/dataTypes/SpectrumUnitConversion.js
@@ -47,6 +47,32 @@ export function getUnitConvExpr({cname, from, to, alias, args=[]}) {
 }
 
 /**
+ * Converts a single numeric value from one unit to another, using the same conversion table as {@link getUnitConvExpr}.
+ * Unlike getUnitConvExpr, this returns a number rather than a SQL-like expression string.
+ * @param {number} value    the value to convert
+ * @param {string} from     from unit
+ * @param {string} to       to unit
+ * @returns {number|undefined} the converted value, or undefined if no conversion path exists between the units
+ */
+export function convertUnitValue(value, from, to) {
+    const {unit: fromKey, factor: fromFactor} = normalizeUnit(from);
+    const {unit: toKey, factor: toFactor} = normalizeUnit(to);
+
+    const formula = UnitXref?.[fromKey]?.[toKey]; // SQL-like expression string
+    if (!formula) return undefined;
+
+    // every UnitXref formula is one of: '%s', '%s * n', or '%s / n', apply the operator on number values
+    const [, op, n] = formula.match(/^%s(?:\s*([*/])\s*([\d.eE+-]+))?$/) ?? [];
+    let result = op === '*' ? value * Number(n) : op === '/' ? value / Number(n) : value;
+
+    // handle factors if present in the units
+    if (fromFactor) result *= Number(fromFactor);
+    if (toFactor) result /= Number(toFactor);
+
+    return result;
+}
+
+/**
  * returns an array of options for unit conversion.
  * @param {string} unit         the unit to get the conversion options for
  * @returns {Array<{value: string, label: LatexDelimited}>}

--- a/src/firefly/js/charts/ui/PlotlyChartArea.jsx
+++ b/src/firefly/js/charts/ui/PlotlyChartArea.jsx
@@ -5,7 +5,8 @@ import {PlotlyWrapper} from './PlotlyWrapper.jsx';
 import {showInfoPopup} from '../../ui/PopupUtil.jsx';
 
 import {dispatchChartHighlighted, dispatchChartUpdate, dispatchSetActiveTrace, getAnnotations, getChartData, usePlotlyReact} from '../ChartsCntlr.js';
-import {clearChartConn, flattenAnnotations, handleTableSourceConnections, isSpectralOrder, isScatter2d} from '../ChartUtil.js';
+import {clearChartConn, flattenAnnotations, handleTableSourceConnections, isSpectralOrder, isScatter2d,
+    makeShapeHoverTrace} from '../ChartUtil.js';
 import {useStoreConnector} from 'firefly/ui/SimpleComponent.jsx';
 import {Skeleton, useTheme} from '@mui/joy';
 
@@ -68,10 +69,16 @@ export function PlotlyChartArea({chartId, widthPx, heightPx, thumbnail}) {
             }
         }
     }
+
+    // hoverable shapes (e.g. spectral lines) can't show hovertext directly
+    // so build their companion hover trace(s) plus the axis layout they need
+    const {traces: hoverTraces, layout: hoverLayout} = makeShapeHoverTrace(layout.shapes);
+    pdata = pdata.concat(hoverTraces);
+
     const {chartWidth, chartHeight} = calculateChartSize(widthPx, heightPx, xyratio, stretch);
 
     const showlegend = data.length > 1;
-    const playout = cloneDeep(Object.assign({showlegend}, adjustLayout(layout, theme), {width: chartWidth, height: chartHeight, annotations}));
+    const playout = cloneDeep({showlegend, ...adjustLayout(layout, theme), width: chartWidth, height: chartHeight, annotations, ...hoverLayout});
 
     const style = {float: 'left'};
     if (chartWidth > widthPx || chartHeight > heightPx) {

--- a/src/firefly/js/charts/ui/options/SpectralLines.jsx
+++ b/src/firefly/js/charts/ui/options/SpectralLines.jsx
@@ -1,0 +1,181 @@
+import React, {useEffect} from 'react';
+import {get} from 'lodash';
+import {Stack} from '@mui/joy';
+import {SwitchInputField} from 'firefly/ui/SwitchInputField';
+import {CheckboxGroupInputField} from 'firefly/ui/CheckboxGroupInputField';
+import {CollapsibleGroup, CollapsibleItem} from 'firefly/ui/panel/CollapsiblePanel';
+import {useStoreConnector, useFieldValueOnly} from 'firefly/ui/SimpleComponent';
+import {getChartData} from '../../ChartsCntlr.js';
+import {isKnownRefPos} from 'firefly/voAnalyzer/SpectrumDM';
+import {canUnitConv, convertUnitValue} from '../../dataTypes/SpectrumUnitConversion.js';
+import {makeTblRequest} from 'firefly/tables/TableRequestUtil';
+import {dispatchTableFetch, dispatchTableUiUpdate, dispatchTableSelect} from 'firefly/tables/TablesCntlr';
+import {onTableLoaded, getTblById, getSelectedDataSync, getTblRowAsObj, splitVals} from 'firefly/tables/TableUtil';
+import {TablePanel} from 'firefly/tables/ui/TablePanel';
+
+const RECOMMENDED_LINES_TBL_ID = 'recommended-spectral-lines';
+const RECOMMENDED_LINES_TBL_UI_ID = `${RECOMMENDED_LINES_TBL_ID}-ui`;
+const WAVELENGTH_COL = 'wavelength_um';
+const LABEL_COL = 'species';
+const TRANSITION_COL = 'transition';
+const PHASE_COL = 'phase';
+const WAVELENGTH_COL_UNIT = 'um'; // unit of WAVELENGTH_COL's values; TODO: source it from table metadata if present
+
+const SPECTRAL_LINE_COLOR = 'gray';
+const SPECTRAL_LINE_FONT_FAMILY = "'SF Mono', ui-monospace, monospace";
+export const SPECTRAL_LINES_GROUP = 'lines';
+
+// Field keys and option values ---
+const ENABLED_KEY = 'spectralLines.enabled';
+const SOURCE_OPTIONS_KEY = 'spectralLines.sourceOptions'; // comma-separated checked values, e.g. CheckboxGroupInputField's value
+const SOURCE_RECOMMENDED = 'recommended';
+const SOURCE_UPLOAD = 'upload';
+
+/**
+ * Resolves the checked source options to the concrete tbl_id to read lines from.
+ * Note: only one table can be active for now — combining multiple checked sources (e.g. recommended + uploaded)
+ * into a single client-side tableModel is deferred to a later pass, once upload is implemented.
+ * @param {string} sourceOptions - comma-separated checked values from SOURCE_OPTIONS_KEY
+ * @returns {string|undefined} tbl_id
+ */
+export function sourceOptionToTblId(sourceOptions) {
+    return splitVals(sourceOptions).includes(SOURCE_RECOMMENDED) ? RECOMMENDED_LINES_TBL_ID : undefined;
+}
+
+/**
+ * Resolves a concrete lines-table tbl_id back to the checked source options it corresponds to.
+ * @param {string} linesTblId
+ * @returns {string} SOURCE_RECOMMENDED, or '' if none
+ */
+function tblIdToSourceOption(linesTblId) {
+    return linesTblId === RECOMMENDED_LINES_TBL_ID ? SOURCE_RECOMMENDED : '';
+}
+
+/**
+ * Builds Plotly vertical-line shapes for the currently selected (checked) rows of a given spectral lines table.
+ * @param {string} xUnit - unit of the chart's x-axis; wavelengths from the spectral lines table are converted to this
+ * @param {string} linesTblId - tbl_id of the spectral lines table; only selected rows are used
+ * @param {number} [redshift] - redshift of the spectrum in observed frame; 0 (default) for a
+ * spectrum already shown in rest frame.
+ * @returns {Array<object>} Plotly shape objects, one per selected row with a valid wavelength
+ */
+export function makeSpectralLineShapes(xUnit, linesTblId, redshift=0) {
+    // TODO: build shapes from an uploaded lines table once file upload + column mapping is implemented
+    if (linesTblId !== RECOMMENDED_LINES_TBL_ID) return [];
+
+    if (!canUnitConv({from: WAVELENGTH_COL_UNIT, to: xUnit})) return [];
+
+    const selectedLines = getSelectedDataSync(RECOMMENDED_LINES_TBL_ID);
+    const linesToPlot = [];
+    for (let rowIdx = 0; rowIdx < selectedLines.totalRows; rowIdx++) {
+        const row = getTblRowAsObj(selectedLines, rowIdx);
+        const lineWvl = row[WAVELENGTH_COL] * (1 + redshift); // redshift the rest-frame wavelength of a spectral line
+        const x = convertUnitValue(lineWvl, WAVELENGTH_COL_UNIT, xUnit);
+        if (!Number.isFinite(x)) continue; // skip rows with a missing/unparsable wavelength
+        linesToPlot.push({x, label: row[LABEL_COL], transition: row[TRANSITION_COL], phase: row[PHASE_COL]});
+    }
+
+    return linesToPlot.map(({x, label, transition, phase}, i) => ({
+        type: 'line',
+        x0: x, x1: x,
+        y0: 0, y1: 1,
+        xref: 'x', yref: 'paper',
+        line: {color: SPECTRAL_LINE_COLOR, width: 1, dash: 'dot'},
+        label: {
+            text: label,
+            textposition: 'end',
+            yanchor: 'bottom',
+            font: {size: 9.5, color: SPECTRAL_LINE_COLOR, family: SPECTRAL_LINE_FONT_FAMILY},
+            padding: 2,
+        },
+        hovertext: `<b>${label}</b>  λ ${x} ${xUnit}` +
+            (transition ? `<br>${transition}` : '') + (phase ? `<br>${phase}` : ''),
+        legendgroup: SPECTRAL_LINES_GROUP,
+        showlegend: i === 0, // legend entry goes only on the first shape item
+        name: 'Lines',
+    }));
+}
+
+/* fetches the recommended spectral lines table if not already loaded, then selects all its rows by default */
+async function ensureRecommendedLines() {
+    if (getTblById(RECOMMENDED_LINES_TBL_ID)) return;
+
+    const request = makeTblRequest(
+        'spectralLines', 'Spectral Lines', {},
+        {tbl_id: RECOMMENDED_LINES_TBL_ID}
+    );
+    dispatchTableFetch(request); // headless: doesn't render in results UI
+
+    // all lines are checked by default; set post-load since request.META_INFO.selectInfo can silently get lost in transit
+    const tableModel = await onTableLoaded(RECOMMENDED_LINES_TBL_ID);
+    dispatchTableSelect(RECOMMENDED_LINES_TBL_ID, {selectAll: true, exceptions: new Set(), rowCount: tableModel.totalRows});
+}
+
+export function SpectralLinesOptions({activeTrace, chartId}) {
+    useEffect(() => {
+        // pre-register tbl_ui_id so columns/columnWidths get populated once loaded (TablePanel mounts later, too late)
+        dispatchTableUiUpdate({tbl_ui_id: RECOMMENDED_LINES_TBL_UI_ID, tbl_id: RECOMMENDED_LINES_TBL_ID});
+        void ensureRecommendedLines();
+    }, []);
+
+    const {enabled: initialEnabled = false, source: initialTblId = RECOMMENDED_LINES_TBL_ID} =
+        useStoreConnector(() => get(getChartData(chartId), 'fireflyLayout.spectralLines')) ?? {};
+    const initialSourceOptions = tblIdToSourceOption(initialTblId);
+
+    // spectral lines need a redshift to correct against, which only exists when Spectral Frame options are shown (as opposed to read-only value)
+    const hasSpectralFrame = useStoreConnector(() =>
+        isKnownRefPos(getChartData(chartId)?.fireflyData?.[activeTrace]?.spectralFrame?.refPos),
+        [chartId, activeTrace]);
+    const isEnabledField = useFieldValueOnly(ENABLED_KEY, false);
+    const isEnabled = hasSpectralFrame && isEnabledField;
+
+    // TODO: combine different source tables to a client-side table
+    const sourceOptions = useFieldValueOnly(SOURCE_OPTIONS_KEY, initialSourceOptions);
+    const activeTblId = sourceOptionToTblId(sourceOptions);
+    const activeTblUiId = activeTblId && `${activeTblId}-ui`;
+
+    if (!hasSpectralFrame) return false;
+
+    return (
+        <Stack spacing={1} sx={{pr: 1}}>
+            <Stack direction='row' spacing={1.5} alignItems='baseline'>
+                <SwitchInputField fieldKey={ENABLED_KEY}
+                                  label='Spectral lines:'
+                                  initialState={{value: initialEnabled}}/>
+            </Stack>
+            {isEnabled && (
+                <Stack spacing={1}>
+                    <CheckboxGroupInputField fieldKey={SOURCE_OPTIONS_KEY}
+                                             label='Lines list:'
+                                             initialState={{value: initialSourceOptions}}
+                                             options={[
+                                                 {label: 'Recommended', value: SOURCE_RECOMMENDED},
+                                                 {label: 'Upload mine', value: SOURCE_UPLOAD, disabled: true}
+                                             ]}/>
+                    {/* TODO: "Upload mine" — file upload + column mapper */}
+                    {activeTblId && (
+                        <CollapsibleGroup>
+                            <CollapsibleItem componentKey={`${chartId}-spectralLines`} header='View/Edit Lines' isOpen={true}
+                                             slotProps={{header: {sx: {fontSize: 'sm'}}}}>
+                                <Stack sx={{height: 240}}>
+                                    <TablePanel
+                                        tbl_id={activeTblId}
+                                        tbl_ui_id={activeTblUiId}
+                                        border={false}
+                                        showToolbar={false}
+                                        showOptionButton={false}
+                                        showTypes={false}
+                                        showUnits={true}
+                                        selectable={true}
+                                        showSelectRowFilter={false}
+                                    />
+                                </Stack>
+                                {/* TODO: add "Add row" button with comma-delimited input to append custom lines */}
+                            </CollapsibleItem>
+                        </CollapsibleGroup>
+                    )}
+                </Stack>
+            )}
+        </Stack>
+    );
+}

--- a/src/firefly/js/charts/ui/options/SpectrumOptions.jsx
+++ b/src/firefly/js/charts/ui/options/SpectrumOptions.jsx
@@ -1,6 +1,6 @@
 import React, {useCallback} from 'react';
-import {get, range, isEqual} from 'lodash';
-import {getSpectrumDM, REF_POS} from '../../../voAnalyzer/SpectrumDM.js';
+import {get, omit, range, isEqual} from 'lodash';
+import {getSpectrumDM, REF_POS, isKnownRefPos} from '../../../voAnalyzer/SpectrumDM.js';
 
 import {getChartData} from '../../ChartsCntlr.js';
 import {getTblById} from '../../../tables/TableUtil.js';
@@ -32,6 +32,7 @@ import {RadioGroupInputField} from 'firefly/ui/RadioGroupInputField';
 import {Box, FormLabel, Stack, Typography} from '@mui/joy';
 import {CollapsibleGroup} from 'firefly/ui/panel/CollapsiblePanel';
 import {MathJax} from 'better-react-mathjax';
+import {SpectralLinesOptions, SPECTRAL_LINES_GROUP, makeSpectralLineShapes, sourceOptionToTblId} from './SpectralLines.jsx';
 
 
 export function SpectrumOptions ({activeTrace:pActiveTrace, tbl_id:ptbl_id, chartId, groupKey}) {
@@ -43,7 +44,7 @@ export function SpectrumOptions ({activeTrace:pActiveTrace, tbl_id:ptbl_id, char
     const {tbl_id} = getChartProps(chartId, ptbl_id, activeTrace);
     const {xErrArray, yErrArray, xMax, xMin, yMax, yMin, xUnit, yUnit} = getSpectrumProps(tbl_id);
 
-    const {Xunit, Yunit, SpectralFrame} = useSpectrumInputs({activeTrace, tbl_id, chartId, groupKey});
+    const {Xunit, Yunit, SpectralFrame, SpectralLines} = useSpectrumInputs({activeTrace, tbl_id, chartId, groupKey});
     const {UseSpectrum, X, Xmax, Xmin, Y, Ymax, Ymin, Yerrors, Xerrors} = useScatterInputs({activeTrace, tbl_id, chartId, groupKey});
     const {XaxisTitle, YaxisTitle} = useBasicOptions({activeTrace, tbl_id, chartId, groupKey});
 
@@ -82,6 +83,7 @@ export function SpectrumOptions ({activeTrace:pActiveTrace, tbl_id:ptbl_id, char
                         {xMin && <Xmin/>}
                         <Xunit/>
                         <SpectralFrame labelWidth={labelWidth}/>
+                        <SpectralLines/>
                     </GroupedStack>
                     <GroupedStack groupTitle='Y-axis'>
                         <Y label={axisColumnFieldLabel('Flux', yUnit)}/>
@@ -146,7 +148,9 @@ const getRedshiftCorrectedExpr = ({cname, spectralFrame, sfOption, redshift=unde
     const {refPos, redshift: customRedshift} = spectralFrame;
     const multiplyBy = refPos.toUpperCase() === REF_POS.CUSTOM ? ` * (1 + ${customRedshift ?? '0'})` : '';
     const divideBy = sfOption === 'rest' && redshift ? ` / (1 + ${redshift})` : '';
-    const expr = customRedshift!==redshift ? `"%s"${multiplyBy}${divideBy}` : '"%s"';
+    let expr = `"%s"${multiplyBy}${divideBy}`;
+    // multiplyBy = divideBy when correcting a spectrum with custom redshift to the rest frame
+    if (sfOption === 'rest' && customRedshift === redshift) expr = '"%s"';
     return sprintf(expr, cname);
 };
 
@@ -159,24 +163,27 @@ const getCombinedExpr = (cname, redshiftCorrParams, unitConvParams) => {
 };
 
 
+// build the redshift label for chart's X axis title from the matching redshift option's label
+const getRedshiftLabel = (fireflyData, activeTrace, redshiftOption) =>
+    getRedshiftOptions(fireflyData[activeTrace]).find((opt)=> opt.value===redshiftOption)
+        ?.label.replace(/ with confidence.*$/, '');  //don't need to show confidence in axis label
+
 const getRedshiftInfo = (inFields, path, fireflyData, activeTrace) => {
     // reduce the 3 spectral frame fields to obtain the info needed for redshift correction expression and for axis label
     const [sfOption, redshiftOption, userSpecifiedRedshift] = Object.values(SFOptionFieldKeys(activeTrace))
         .map((fieldKey) => get(inFields, path(fieldKey)));
 
+    // resolve the redshift number regardless of frame — spectral lines need it in observed frame too, not just rest
+    const redshift = redshiftOption==='userSpecified' ? userSpecifiedRedshift : redshiftOption;
+
     let sfLabel = 'Observed Frame';
-    let redshift, redshiftLabel='';
+    let redshiftLabel = '';
 
     if(sfOption==='rest') {
         sfLabel = 'Rest Frame';
-        redshift = redshiftOption;
-        redshiftLabel = getRedshiftOptions(fireflyData[activeTrace]).find((opt)=> opt.value===redshift)
-            ?.label.replace(/ with confidence.*$/, ''); //don't need to show confidence in axis label
-
-        if(redshiftOption==='userSpecified') {
-            redshift = userSpecifiedRedshift;
-            redshiftLabel = `Redshift = ${userSpecifiedRedshift}`;
-        }
+        redshiftLabel = redshiftOption==='userSpecified'
+            ? `Redshift = ${userSpecifiedRedshift}`
+            : getRedshiftLabel(fireflyData, activeTrace, redshiftOption);
     }
     else if(sfOption!=='observed') sfLabel = `${sfOption} Spectral Frame`;
 
@@ -303,6 +310,29 @@ export function submitChangesSpectrum({chartId, activeTrace, fields, tbl_id, ren
         });
     }
 
+    // handle spectral lines -----
+    const spectralLinesEnabled = toBoolean(fields['spectralLines.enabled']);
+    const spectralLinesTblId = sourceOptionToTblId(fields['spectralLines.sourceOptions']);
+    fields = omit(fields, ['spectralLines.enabled', 'spectralLines.sourceOptions']);
+
+    // persisted only so UI controls can seed their initial state from the chart data next time this dialog opens
+    fields = updateSet(fields, ['fireflyLayout.spectralLines.enabled'], spectralLinesEnabled);
+    fields = updateSet(fields, ['fireflyLayout.spectralLines.source'], spectralLinesTblId);
+
+    // replace only this feature's shapes, preserve others
+    const otherShapes = getChartData(chartId)?.layout?.shapes?.filter((s) => s.legendgroup !== SPECTRAL_LINES_GROUP) ?? [];
+    // lines are rest-frame (lab) wavelengths; when the spectrum itself is shown in observed frame (i.e. not
+    // already rest-frame corrected), shift the lines by the same redshift to match - no shift needed in rest frame
+    const {sfOption, redshift} = getRedshiftInfo(fields, (p) => [p], fireflyData, activeTrace);
+    const spectralLinesRedshift = sfOption === 'observed' ? (Number(redshift) || 0) : 0;
+    const spectralLineShapes = spectralLinesEnabled ? makeSpectralLineShapes(xUnit, spectralLinesTblId, spectralLinesRedshift) : [];
+    fields = updateSet(fields, ['layout.shapes'], [...otherShapes, ...spectralLineShapes]);
+
+    // always persist the full, correct value — don't rely on the key being absent, since a stale value from any
+    // earlier Apply would never get cleared otherwise
+    fields = updateSet(fields, ['layout.showlegend'], data.length > 1 || spectralLinesEnabled);
+    // -----
+
     // propagate all of the above field changes to change the state (i.e. chart data in store)
     submitChangesScatter({chartId, activeTrace, fields, tbl_id, renderTreeId});
 }
@@ -345,12 +375,14 @@ export const useSpectrumInputs = ({chartId, groupKey}, deps=[]) => {
         Xunit: useCallback((props={}) => <Units {...{activeTrace, axis: 'x', value: get(fireflyData, `${activeTrace}.xUnit`), ...props}}/>, deps),
         Yunit: useCallback((props={}) => <Units {...{activeTrace, axis: 'y', value: get(fireflyData, `${activeTrace}.yUnit`), ...props}}/>, deps),
         SpectralFrame: useCallback((props={}) => {
-            const allProps = {label: 'Spectral Frame:', ...props};
+            const allProps = {label: 'Spectral frame:', ...props};
             const sfRefPos = fireflyData[activeTrace].spectralFrame.refPos.toUpperCase();
-            return Object.values(REF_POS).includes(sfRefPos) //only show options when TOPOCENTER or CUSTOM
+            return isKnownRefPos(sfRefPos) //only show options when TOPOCENTER or CUSTOM
                 ? <SpectralFrameOptions groupKey={groupKey} activeTrace={activeTrace} refPos={sfRefPos} fireflyData={fireflyData} {...allProps}/>
                 : <ReadOnlyField value={sfRefPos} {...allProps}/>;
         }, deps),
+        SpectralLines: useCallback((props={}) =>
+            <SpectralLinesOptions activeTrace={activeTrace} chartId={chartId} {...props}/>, deps),
     };
 };
 
@@ -395,41 +427,39 @@ function getRedshiftOptions({target, derivedRedshift, spectralFrame}){ //TODO: m
     return options;
 }
 
-function SpectralFrameOptions ({groupKey, activeTrace, refPos, fireflyData, labelWidth, ...props}) {
+function SpectralFrameOptions ({groupKey, activeTrace, refPos, fireflyData, ...props}) {
     const {spectralFrameOption} = fireflyData[activeTrace];
     const spectralFrameOptions = [{label: 'Observed Frame', value: 'observed'}, {label: 'Rest Frame', value: 'rest'}];
     const redshiftOptions = getRedshiftOptions(fireflyData[activeTrace]);
     const defaultSFOption = refPos===REF_POS.TOPOCENTER ? 'observed' : 'rest';
 
-    const isRestFrameOption = useStoreConnector(()=>
+    const isRestFrame = useStoreConnector(()=>
         getFieldVal(groupKey, SFOptionFieldKeys(activeTrace).value)==='rest');
 
     const isUserSpecifiedOption = useStoreConnector(()=>
         getFieldVal(groupKey, SFOptionFieldKeys(activeTrace).redshift)==='userSpecified');
 
     return (
-        <Stack spacing={0.5}>
+        <Stack spacing={1}>
             <ListBoxInputField fieldKey={SFOptionFieldKeys(activeTrace).value}
                                options={spectralFrameOptions}
                                initialState={{value: spectralFrameOption?.value ?? defaultSFOption}}
                                slotProps={{input: {sx: {minWidth: '12rem'}}}}
                                {...props}/>
-            <Box sx={{
-                position: 'relative',
-                display: isRestFrameOption ? 'block' : 'none' //to keep the contained fields mounted because they are needed in spectrumReducer
-                }}>
+            <ReadOnlyField label={'Redshift correction of:'}
+                           value={isRestFrame ? 'Spectrum' : 'Spectral Lines'}/>
+            <Box sx={{position: 'relative', pl: 1}}>
                     <RadioGroupInputField fieldKey={SFOptionFieldKeys(activeTrace).redshift}
                                           options={redshiftOptions}
                                           initialState={{value: spectralFrameOption?.redshift}} //will select 1st option if undefined
                                           orientation={'vertical'}
-                                          sx={{ml: `calc(${labelWidth} + 1rem)`}} //add 1rem to offset right margin of labels
                     />
                     <ValidationField fieldKey={SFOptionFieldKeys(activeTrace).userSpecified}
-                                     sx={{position: 'absolute', bottom: 0, left: `calc(${labelWidth} + 9rem)`, width: '9rem', zIndex: 1}} //to align it with the last radio group option
+                                     sx={{position: 'absolute', bottom: 0, left: '9rem', width: '9rem', zIndex: 1}} //to align it with the last radio group option
                                      initialState={{value: spectralFrameOption?.userSpecified ?? '0'}}
                                      validator={(val) => isFloat('Redshift', val)}
                                      readonly={!isUserSpecifiedOption}
-                                     tooltip='Rest Frame Redshift'/>
+                                     tooltip='Redshift value'/>
             </Box>
         </Stack>
     );

--- a/src/firefly/js/ui/CheckboxGroupInputField.jsx
+++ b/src/firefly/js/ui/CheckboxGroupInputField.jsx
@@ -24,10 +24,10 @@ export function CheckboxGroupInputFieldView({fieldKey, onChange, label, tooltip:
                 {label && <FormLabel {...slotProps?.label}>{label}</FormLabel>}
                 {/*following should be nested in a <FormGroup/> once joy-ui exposes it: https://mui.com/material-ui/react-checkbox/#formgroup*/}
                 <Stack className='ff-Checkbox-container' spacing={orientation==='vertical'?1:2} direction={orientation==='vertical' ? 'column' : 'row'}>
-                    {options.map( ({value,label,tooltip}) => {
+                    {options.map( ({value,label,tooltip,...checkboxProps}) => {
                         const cb= (
                             <Checkbox {...{ className:'ff-Checkbox-item', size:'sm', name:fieldKey, key:value, value,
-                                          checked:isChecked(value,fieldValue), onChange, label, ...slotProps?.input}} />
+                                          checked:isChecked(value,fieldValue), onChange, label, ...checkboxProps, ...slotProps?.input}} />
                         );
                         return (
                             <FormControl key={value}>{
@@ -147,7 +147,8 @@ export const CheckboxGroupInputField = memo( (props) => {
 });
 
 CheckboxGroupInputField.propTypes= {
-    options: arrayOf(shape( { value: string, label: string, tooltip: string} )).isRequired,
+    // any other key (e.g. disabled) is passed through as-is to the underlying Checkbox
+    options: arrayOf(shape( { value: string.isRequired, label: string, tooltip: string} )).isRequired,
     alignment:  string,
     initialState: shape({
         value: string,

--- a/src/firefly/js/voAnalyzer/SpectrumDM.js
+++ b/src/firefly/js/voAnalyzer/SpectrumDM.js
@@ -74,6 +74,15 @@ export const REF_POS = {
     CUSTOM: 'CUSTOM'
 };
 
+/**
+ * @param {string} refPos - a spectral frame's reference position (any case)
+ * @returns {boolean} true if refPos is a known REF_POS (TOPOCENTER or CUSTOM) — i.e. there's an interactive
+ * spectral frame/redshift to work with, rather than some other fixed reference position
+ */
+export function isKnownRefPos(refPos) {
+    return Object.values(REF_POS).includes(refPos?.toUpperCase());
+}
+
 
 /**
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -6540,10 +6540,10 @@ pkginfo@^0.3.0:
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
   integrity sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==
 
-plotly.js-dist-min@~3.1.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/plotly.js-dist-min/-/plotly.js-dist-min-3.1.2.tgz#35491ea0d03b8f352968a10ddc07f0600261e1a8"
-  integrity sha512-GlgsV+1IMjPpyJWnWjHfD2SBczqke/JNPElLAZ5cUir3fz5D4WDcYyQFJLU60SjCvJXH+KTPp8SBuVIr084sOA==
+plotly.js-dist-min@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/plotly.js-dist-min/-/plotly.js-dist-min-3.6.0.tgz#7f07282d56305f84ce2b55bccc3e2cea8d51ecea"
+  integrity sha512-VR9jO2YdcEwbzVwtRyPE0eAieXFv1x5q6M9nnIgUS8FggahPrjiID6kzpnTYABwLX0gZkgEc0zxS6gQgVmgHzw==
 
 pn@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Fixes [FIREFLY-1971](https://jira.ipac.caltech.edu/browse/FIREFLY-1971)

**This pass focuses on plotting; the next pass will cover loading (separate dialog and configurable line groups on app level).**

Added a spectral lines overlay for spectrum charts — users can toggle a recommended line list and see the selected lines plotted as labeled, hoverable vertical lines, correctly unit- and redshift-corrected. 

- Recommended line list is served from a new `SpectralLinesProcessor` endpoint backed by a bundled CSV, loaded headlessly into a client-side table so it can be selected/filtered without appearing in the results UI
- Lines list uses a checkbox group (not single-select) so multiple sources can combine later — only "Recommended" is wired up, "Upload mine" is disabled pending the loading pass
- Bumped `plotly.js-dist-min` to `~3.6.0` for native shape labels, used to render each line's species text directly on the chart
- Added a `makeShapeHoverTrace` helper (`ChartUtil.js`) for spectral lines — a companion scatter trace per shape's `hovertext` since plotly doesn't support hover on shapes. I tried Plotly annotations for hover but they caused pan/zoom lags at realistic line counts. 
- "Redshift correction" options (previously Rest-Frame-only) are now always visible: in Rest Frame they still correct the spectrum (unchanged); in Observed Frame they now correct the lines' rest wavelengths to match the spectrum. A "Redshift Correction: Spectrum / Spectral Lines" label clarifies which

## Testing
https://firefly-1971-spectral-lines.irsakubedev.ipac.caltech.edu/firefly/


- Load a spectra from the ticket, toggle "Spectral lines" on, confirm lines plot with correct hover info, check if selection in table reflects correctly in the plot.
- Toggle Rest vs Observed Frame: spectrum shifts in Rest Frame, lines shift to match in Observed Frame; "Redshift correction" label switches accordingly
- Pan/zoom with several lines plotted without any lags
- Regression test:
    - redshift correction of spectrum (in rest frame) working as before (spitzer TOPOCENTER spectra, spitzer CUSTOM spectra)
    - other chart types, since `PlotlyChartArea.jsx`/`ChartUtil.js` and the `plotly.js` bump touch shared rendering code
