### PR TITLE
FIREFLY-2021: Improve job monitor UI

### DIFF
--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -94,12 +94,11 @@ export const fetchJobInfo = (jobId) => {
 
 export const loadAllJobs = () => {
     const url = getCmdSrvAsyncURL();
-    jsonFetch(url).then( ({jobs, overflow}) => {
-        if (jobs) {
-            // convert List<JobInfo> to Object<JobId, JobInfo>
-            const jobsMap = Object.fromEntries(jobs.map((j) => [j?.meta?.jobId, j]));
-            dispatchBgLoadJobs({jobs:jobsMap, overflow});
-        }
+    jsonFetch(url).then( ({jobs=[], overflow}) => {
+        // convert List<JobInfo> to Object<JobId, JobInfo>; always dispatch, even when there are zero jobs,
+        // so the store's jobs map goes from undefined ('not loaded yet') to {} ('loaded; none found')
+        const jobsMap = Object.fromEntries(jobs.map((j) => [j?.meta?.jobId, j]));
+        dispatchBgLoadJobs({jobs:jobsMap, overflow});
     });
 };
 

--- a/src/firefly/js/core/background/JobMonitor.jsx
+++ b/src/firefly/js/core/background/JobMonitor.jsx
@@ -1,11 +1,13 @@
 import React, {useContext, useEffect, useState} from 'react';
 import {object, string, shape} from 'prop-types';
-import {IconButton, Button, Sheet, Stack, Typography, ListItemDecorator, Tab} from '@mui/joy';
+import {IconButton, Button, Sheet, Skeleton, Stack, Typography, ListItemDecorator, Tab} from '@mui/joy';
 import moment from 'moment';
 
 import {Slot, useStoreConnector} from '../../ui/SimpleComponent';
 import {getBackgroundInfo, getJobInfo, getJobTitle, getMetadata, getPhaseTips, isActive, isArchived, isDone, isExecuting, isFail, isSearchJob, isSuccess, loadAllJobs, Phase, loadJobResult, fixTapResults, getProgressMsg} from './BackgroundUtil';
 import {TablePanel} from '../../tables/ui/TablePanel';
+import {OptionsFilterStats} from '../../tables/ui/TablePanelOptions';
+import {HeaderText} from '../../tables/ui/TableRenderer';
 import {getAppOptions} from '../AppDataCntlr';
 import {dispatchBgJobInfo, dispatchBgSetInfo, dispatchJobCancel, dispatchJobRemove, dispatchSetJobNotif} from './BackgroundCntlr';
 import {InputField} from '../../ui/InputField';
@@ -40,7 +42,9 @@ export const jobMonitorPath = '/jobMonitor';
 export const jobMonitorGroupKey = 'jobMonitor';
 export const useLocalTimeKey = 'useLocalTime';
 
-const jobIdColIdx = 7;  // the index of the jobId column in the table
+const jobIdColIdx = 7;   // the index of the jobId column in the table
+const jobHistoryTblId = 'JobHistoryTable';
+let seenJobIds = null;      // map of jobIds seen in the previous poll, used to detect newly submitted jobs
 
 export function JobMonitor({initArgs, help_id, slotProps, ...props}) {
     const pollInterval = getAppOptions()?.background?.historyPollInterval || 30000;       // every 30 seconds
@@ -60,7 +64,7 @@ export function JobMonitor({initArgs, help_id, slotProps, ...props}) {
     const titleProps = {...slotProps?.title, ...title};
     const tableProps = {...slotProps?.table, ...table};
     const width = useStoreConnector(() => {
-        const {columnWidths=[]} = getTableUiById('JobHistoryTable-ui') || {};
+        const {columnWidths=[]} = getTableUiById(`${jobHistoryTblId}-ui`) || {};
         return columnWidths.reduce((acc, val, idx) => idx < 8 ? acc + val : acc, 3);
 
     });
@@ -218,17 +222,28 @@ function Notification({email='', notifEnabled, ...props}) {
     );
 }
 
-function JobMonitorTable({help_id, ...props}) {
-    const jobMap = useStoreConnector(() => getBackgroundInfo()?.jobs || {});
+function JobMonitorTable({help_id, sx, ...props}) {
+    const jobMap = useStoreConnector(() => getBackgroundInfo()?.jobs);        // undefined until the first loadAllJobs() response arrives
     const useLocalTime = useStoreConnector(() => getFieldVal(jobMonitorGroupKey, useLocalTimeKey));
     const [hlJobId, setHlJobId] = useState();
+    const loading = !jobMap;
 
-    const tbl_id = 'JobHistoryTable';
+    const tbl_id = jobHistoryTblId;
     useEffect(() => {
-        const table = convertToTableModel(getMonitoredJob(jobMap), tbl_id, useLocalTime);
-        if (hlJobId) {
-            const highlightedRow = table.tableData.data.findIndex((row) => row[jobIdColIdx] === hlJobId);
-            if (highlightedRow >= 0) table.highlightedRow = highlightedRow; // set the highlighted row if the job is found
+        const jobs = getMonitoredJob(jobMap);
+        const jobIds = jobs.map((j) => j.meta?.jobId).filter(Boolean);
+
+        // only the newest job not present in the previous poll counts as "just submitted";
+        // skip detection on the very first (baseline) load so existing jobs aren't treated as new
+        const newJobId = (jobMap && seenJobIds) && jobIds.find((id) => !seenJobIds.has(id));
+        if (jobMap) seenJobIds = new Set(jobIds);
+        if (newJobId) setHlJobId(newJobId);
+
+        const table = convertToTableModel(jobs, tbl_id, useLocalTime);
+        const idToHighlight = newJobId || hlJobId;
+        if (idToHighlight) {
+            const highlightedRow = table.tableData.data.findIndex((row) => row[jobIdColIdx] === idToHighlight);
+            if (highlightedRow >= 0) table.highlightedRow = highlightedRow; // set the highlighted row if the job is found (and passes the current filter)
         }
         dispatchTableAddLocal(table, undefined, false);
     }, [jobMap, useLocalTime]); // refreshed only when jobMap changes
@@ -246,15 +261,19 @@ function JobMonitorTable({help_id, ...props}) {
 
     const renderers =  {
         Phase:    {cellRenderer: PhaseRenderer},
-        Control:  {cellRenderer: ControlRenderer},
+        Control:  {cellRenderer: ControlRenderer, headRenderer: ControlHeadRenderer},
     };
 
     return (
-        <Slot component={TablePanel} rowHeight={32} {...{tbl_id, help_id, renderers}}
-                    sx={{'& .fixedDataTableCellGroupLayout_cellGroup > :last-child': {borderRight: 'none'}}}
-                    {...{showToolbar: false, selectable:false, showFilters:true, showOptionButton:false}}
-                    slotProps={{...props}}
-        />
+        <Stack sx={{position: 'relative', height: 1, ...sx}}>
+            <Skeleton loading={loading} sx={sx}>
+                <Slot component={TablePanel} rowHeight={32} {...{tbl_id, help_id, renderers}}
+                            sx={{'& .fixedDataTableCellGroupLayout_cellGroup > :last-child': {borderRight: 'none'}, ...sx}}
+                            {...{showToolbar: false, selectable:false, showFilters:true, showOptionButton:false}}
+                            slotProps={{...props}}
+                />
+            </Skeleton>
+        </Stack>
     );
 }
 
@@ -267,6 +286,15 @@ function PhaseRenderer({cellInfo}) {
                             undefined;
     return (
             <Typography level='body-md' color={color} title={getPhaseTips(value)}>{value}</Typography>
+    );
+}
+
+function ControlHeadRenderer({col}) {
+    return (
+        <Stack alignItems='center' justifyContent='space-between' height={1} mt='1px'>
+            <HeaderText val={col?.label || col?.name} level='title-sm'/>
+            <OptionsFilterStats tbl_id={jobHistoryTblId}  alignSelf='start'/>
+        </Stack>
     );
 }
 
@@ -465,8 +493,8 @@ function convertToTableModel(jobs, tbl_id, useLocalTime) {
     const doFilter = columns[phaseIdx].enumVals?.includes(Phase.ARCHIVED);
 
     const totalRows = data.length;
-    const {origTableModel:prevTable, request:prevReq} = getTblById(tbl_id) || {};
-    const request = (prevTable?.totalRows < totalRows || !prevReq) ? defaultRequest(doFilter) : prevReq;  // if a new job is added or no previous request, use default
+    const {request: prevReq} = getTblById(tbl_id) || {};
+    const request = prevReq ?? defaultRequest(doFilter);      // preserve the user's sort/filter across polls; use default on first load
     let table = { tbl_id, request, totalRows, tableData: { columns, data }};
     if (request.sortInfo || request.filters) {
         table = processRequest(table, request);

--- a/src/firefly/js/core/background/JobMonitor.jsx
+++ b/src/firefly/js/core/background/JobMonitor.jsx
@@ -17,7 +17,7 @@ import {isDefined, updateSet} from '../../util/WebUtil';
 import {download} from '../../util/fetch';
 import {isJobInfoOpen, showJobInfo} from './JobInfo';
 import {dispatchHideDropDown, dispatchShowDropDown} from '../LayoutCntlr';
-import {getCellValue, getTableUiById, getTblById, processRequest, watchTableChanges} from '../../tables/TableUtil';
+import {ensureEnumVals, getCellValue, getTableUiById, getTblById, processRequest, watchTableChanges} from '../../tables/TableUtil';
 import {SORT_DESC, SortInfo} from '../../tables/SortInfo';
 import {workingIndicator} from '../../ui/Menu';
 import {dispatchHideDialog} from '../ComponentCntlr';
@@ -494,6 +494,8 @@ function convertToTableModel(jobs, tbl_id, useLocalTime) {
             job.phase,
             job.meta?.jobId         // remember to adjust jobIdColIdx if columns changed
         ]);
+
+    ensureEnumVals({tableData: {columns, data}});
 
     const phaseIdx = columns.findIndex((c) => c.name === 'Phase');
     const doFilter = columns[phaseIdx].enumVals?.includes(Phase.ARCHIVED);

--- a/src/firefly/js/core/background/JobMonitor.jsx
+++ b/src/firefly/js/core/background/JobMonitor.jsx
@@ -6,8 +6,7 @@ import moment from 'moment';
 import {Slot, useStoreConnector} from '../../ui/SimpleComponent';
 import {getBackgroundInfo, getJobInfo, getJobTitle, getMetadata, getPhaseTips, isActive, isArchived, isDone, isExecuting, isFail, isSearchJob, isSuccess, loadAllJobs, Phase, loadJobResult, fixTapResults, getProgressMsg} from './BackgroundUtil';
 import {TablePanel} from '../../tables/ui/TablePanel';
-import {OptionsFilterStats} from '../../tables/ui/TablePanelOptions';
-import {HeaderText} from '../../tables/ui/TableRenderer';
+import {ToolbarHorizontalSeparator} from '../../ui/ToolbarButton';
 import {getAppOptions} from '../AppDataCntlr';
 import {dispatchBgJobInfo, dispatchBgSetInfo, dispatchJobCancel, dispatchJobRemove, dispatchSetJobNotif} from './BackgroundCntlr';
 import {InputField} from '../../ui/InputField';
@@ -132,13 +131,15 @@ export function showMultiDownloads(job) {
 
 // ----------------------------------Start of private functions ------------------------------------------//
 
-function TitleSection({summary, notification, ...props}) {
-    const {jobs:jobMap={}, email, notifEnabled, overflow} = useStoreConnector(() => getBackgroundInfo());
-    const jobs = getMonitoredJob(jobMap);
+function TitleSection({notification, ...props}) {
+    const {email, notifEnabled} = useStoreConnector(() => getBackgroundInfo());
+    const {showEmail} = getAppOptions()?.background?.notification || {};
+
+    // mount empty Notification to syncs notifEnabled to the server on mount.
+    if (!showEmail) return <Notification {...{email, notifEnabled}}/>;
 
     return (
         <Stack component={Sheet} variant='soft' borderRadius={4} padding={1} spacing={1} {...props}>
-            <Slot component={JobSummary} jobs={jobs} overflow={overflow} slotProps={summary}/>
             <Slot component={Notification} {...{email, notifEnabled}} slotProps={notification}/>
         </Stack>
     );
@@ -156,7 +157,7 @@ function JobSummary({jobs, overflow, ...props}) {
         </Stack>
     );
     return (
-        <Stack direction='row' gap={5} justifyContent='space-between' {...props}>
+        <Stack direction='row' gap={5} justifyContent='space-between' alignItems='center' flexGrow={1} {...props}>
             <Typography level='title-md' color='primary'>Job Summary</Typography>
             <Stack direction='row' gap={10}>
                 <Entry label='Total' value={total + (overflow ? '(+)' : '')}/>
@@ -223,18 +224,17 @@ function Notification({email='', notifEnabled, ...props}) {
 }
 
 function JobMonitorTable({help_id, sx, ...props}) {
-    const jobMap = useStoreConnector(() => getBackgroundInfo()?.jobs);        // undefined until the first loadAllJobs() response arrives
+    const {jobs: jobMap, overflow} = useStoreConnector(() => getBackgroundInfo());        // jobMap undefined until the first loadAllJobs() response arrives
     const useLocalTime = useStoreConnector(() => getFieldVal(jobMonitorGroupKey, useLocalTimeKey));
     const [hlJobId, setHlJobId] = useState();
     const loading = !jobMap;
+    const jobs = getMonitoredJob(jobMap);
 
     const tbl_id = jobHistoryTblId;
     useEffect(() => {
-        const jobs = getMonitoredJob(jobMap);
         const jobIds = jobs.map((j) => j.meta?.jobId).filter(Boolean);
 
-        // only the newest job not present in the previous poll counts as "just submitted";
-        // skip detection on the very first (baseline) load so existing jobs aren't treated as new
+        // detect newJobId used for highlighting
         const newJobId = (jobMap && seenJobIds) && jobIds.find((id) => !seenJobIds.has(id));
         if (jobMap) seenJobIds = new Set(jobIds);
         if (newJobId) setHlJobId(newJobId);
@@ -261,16 +261,31 @@ function JobMonitorTable({help_id, sx, ...props}) {
 
     const renderers =  {
         Phase:    {cellRenderer: PhaseRenderer},
-        Control:  {cellRenderer: ControlRenderer, headRenderer: ControlHeadRenderer},
+        Control:  {cellRenderer: ControlRenderer},
     };
 
     return (
         <Stack sx={{position: 'relative', height: 1, ...sx}}>
             <Skeleton loading={loading} sx={sx}>
-                <Slot component={TablePanel} rowHeight={32} {...{tbl_id, help_id, renderers}}
+                <TablePanel rowHeight={32} tbl_id={tbl_id} help_id={help_id} renderers={renderers}
                             sx={{'& .fixedDataTableCellGroupLayout_cellGroup > :last-child': {borderRight: 'none'}, ...sx}}
-                            {...{showToolbar: false, selectable:false, showFilters:true, showOptionButton:false}}
-                            slotProps={{...props}}
+                            showToolbar={true}
+                            showTitle={false}
+                            leftButtons={[() => <JobSummary jobs={jobs} overflow={overflow}/>]}
+                            rightButtons={[() => <ToolbarHorizontalSeparator/>]}
+                            selectable={false}
+                            showFilters={true}
+                            showOptionButton={false}
+                            showPaging={false}
+                            showSave={false}
+                            showInfoButton={false}
+                            showSearchButton={false}
+                            showToggleTextView={false}
+                            showPropertySheetButton={false}
+                            showTypes={false}
+                            expandable={false}
+                            {...props}
+                            slotProps={{toolbar: {px: 1}}}
                 />
             </Skeleton>
         </Stack>
@@ -286,15 +301,6 @@ function PhaseRenderer({cellInfo}) {
                             undefined;
     return (
             <Typography level='body-md' color={color} title={getPhaseTips(value)}>{value}</Typography>
-    );
-}
-
-function ControlHeadRenderer({col}) {
-    return (
-        <Stack alignItems='center' justifyContent='space-between' height={1} mt='1px'>
-            <HeaderText val={col?.label || col?.name} level='title-sm'/>
-            <OptionsFilterStats tbl_id={jobHistoryTblId}  alignSelf='start'/>
-        </Stack>
     );
 }
 

--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -17,7 +17,7 @@ import {
 import {SelectInfo} from '../SelectInfo.js';
 import {FilterInfo} from '../FilterInfo.js';
 import {SortInfo} from '../SortInfo.js';
-import {CellWrapper, FixedCellWrapper, getPxWidth, HeaderCell, headerStyle, makeDefaultRenderer, SelectableCell, SelectableHeader} from './TableRenderer.js';
+import {calcHeaderHeight, CellWrapper, FixedCellWrapper, getPxWidth, HeaderCell, headerStyle, makeDefaultRenderer, SelectableCell, SelectableHeader} from './TableRenderer.js';
 import {useStoreConnector} from '../../ui/SimpleComponent.jsx';
 import {dispatchTableUiUpdate, TBL_UI_UPDATE} from '../TablesCntlr.js';
 import {Logger} from '../../util/Logger.js';
@@ -143,7 +143,7 @@ const BasicTableViewInternal = React.memo(({ selectable:selectableIn= false, sho
     const onFilter       = useCallback( doFilter.bind({callbacks, filterInfo}), [callbacks, filterInfo]);
     const onFilterSelected = useCallback( doFilterSelected.bind({callbacks, selectInfoCls}), [callbacks, selectInfoCls]);
 
-    const headerHeight = showHeader ? 19 + (showUnits && 15) + (showTypes && 14) + (showFilters && 25) : 0;
+    const headerHeight = calcHeaderHeight({showHeader, showUnits, showTypes, showFilters});
     const maxScrollWidth = tableRef.current?.getApi().getCellGroupWidth() || -1;
 
     const adjScrollTop = correctScrollTopIfNeeded(maxScrollWidth, scrollTop, width, height-headerHeight, rowHeight, hlRowIdx, triggeredBy);

--- a/src/firefly/js/tables/ui/TablePanel.jsx
+++ b/src/firefly/js/tables/ui/TablePanel.jsx
@@ -322,11 +322,11 @@ function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
 
     return (
         <Sheet component={Stack} variant='soft' className='FF-Table-Toolbar' direction='row'
-               sx={{justifyContent:'space-between', flexWrap:'wrap', width:1}}
-               {...slotProps?.toolbar}>
+               {...slotProps?.toolbar}
+               sx={{justifyContent:'space-between', flexWrap:'wrap', width:1, ...slotProps?.toolbar?.sx}}>
             <Stack direction='row' sx={{alignItems:'center', flexWrap:'wrap', flex:'1 1 0'}}>
                 <LeftToolBar {...{tbl_id, title, removable, showTitle, leftButtons}}/>
-                <Stack direction='row' spacing={1} sx={{flexGrow: 1, justifyContent:'center'}} >
+                <Stack direction='row' spacing={1} sx={{flexGrow: showPaging ? 1 : 0, justifyContent:'center'}} >
                     {showPaging && <PagingBar {...{currentPage, pageSize, showLoading, totalRows, callbacks:connector}} /> }
                     <OverflowMarker tbl_id={tbl_id}/>
                 </Stack>
@@ -345,8 +345,8 @@ function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
                                onClick={toggleFilter}/>
                 }
                 {showToggleTextView &&
-                    textView ? <TableViewButton onClick={toggleTextView}/>
-                             : <TextViewButton onClick={toggleTextView}/>
+                    (textView ? <TableViewButton onClick={toggleTextView}/>
+                              : <TextViewButton onClick={toggleTextView}/>)
                 }
                 {showSave &&
                 <SaveButton tip={TT_SAVE} onClick={showTableDownloadDialog({tbl_id, tbl_ui_id})}/>
@@ -374,7 +374,10 @@ function ToolBar({tbl_id, tbl_ui_id, connector, tblState, slotProps}) {
 
 
 function LeftToolBar({tbl_id, title, removable, showTitle, leftButtons=[]}) {
-    const style = {display: 'inline-flex', alignItems: 'center'};
+    // when there's no string title, leftButtons is the only content of this toolbar section -
+    // let it grow to fill the available space instead of shrink-wrapping to its own content.
+    const growLeftButtons = !showTitle && leftButtons?.length > 0;
+    const style = {display: 'inline-flex', alignItems: 'center', ...(growLeftButtons && {flexGrow: 1, width: '100%'})};
     const lbStyle = showTitle ? {...style, paddingLeft:10, alignSelf:'center'} : style;
 
     const doclinkUrl = getMetaEntry(tbl_id, META.doclink.url);
@@ -395,7 +398,7 @@ function LeftToolBar({tbl_id, title, removable, showTitle, leftButtons=[]}) {
     }
 
     return (
-        <Stack direction='row' sx={{flexWrap:'wrap'}} >
+        <Stack direction='row' sx={{flexWrap:'wrap', ...(growLeftButtons && {flexGrow: 1})}}>
             { showTitle && <Title {...{title, removable, tbl_id}}/>}
             {leftButtons && <Stack direction='row' spacing={1} style={lbStyle}>{leftButtons}</Stack>}
         </Stack>

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -142,7 +142,7 @@ TablePanelOptions.propTypes = {
     })
 };
 
-function OptionsFilterStats({tbl_id}) {
+export function OptionsFilterStats({tbl_id, iconButtonSize='34px', ...props}) {
 
     const filterCnt = useStoreConnector(() => getFilterCount(getTblById(tbl_id)));
     const clearFilters = () => dispatchTableFilter({tbl_id, filters: ''});;
@@ -150,8 +150,8 @@ function OptionsFilterStats({tbl_id}) {
     if (filterCnt === 0) return null;
     return (
         // wrapper stack added because ToolbarButton did not expose root
-        <Stack sx = {{[`& .${badgeClasses.root}`]: {margin: '1px 3px 0 0'}}}>
-            <ClearFilterButton iconButtonSize='34px' onClick={clearFilters}
+        <Stack sx={{[`& .${badgeClasses.root}`]: {margin: '1px 3px 0 0'}}} {...props}>
+            <ClearFilterButton iconButtonSize={iconButtonSize} onClick={clearFilters}
                                badgeCount={filterCnt}
                                tip = 'Remove all Column Options filters'
             />

--- a/src/firefly/js/tables/ui/TablePanelOptions.jsx
+++ b/src/firefly/js/tables/ui/TablePanelOptions.jsx
@@ -142,7 +142,7 @@ TablePanelOptions.propTypes = {
     })
 };
 
-export function OptionsFilterStats({tbl_id, iconButtonSize='34px', ...props}) {
+function OptionsFilterStats({tbl_id}) {
 
     const filterCnt = useStoreConnector(() => getFilterCount(getTblById(tbl_id)));
     const clearFilters = () => dispatchTableFilter({tbl_id, filters: ''});;
@@ -150,8 +150,8 @@ export function OptionsFilterStats({tbl_id, iconButtonSize='34px', ...props}) {
     if (filterCnt === 0) return null;
     return (
         // wrapper stack added because ToolbarButton did not expose root
-        <Stack sx={{[`& .${badgeClasses.root}`]: {margin: '1px 3px 0 0'}}} {...props}>
-            <ClearFilterButton iconButtonSize={iconButtonSize} onClick={clearFilters}
+        <Stack sx = {{[`& .${badgeClasses.root}`]: {margin: '1px 3px 0 0'}}}>
+            <ClearFilterButton iconButtonSize='34px' onClick={clearFilters}
                                badgeCount={filterCnt}
                                tip = 'Remove all Column Options filters'
             />

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -36,6 +36,29 @@ import {FilterButton} from 'firefly/visualize/ui/Buttons.jsx';
 
 export const headerStyle = {fontSize:'var(--joy-fontSize-sm)', fontWeight:'var(--joy-fontWeight-md)'};  // maybe faulty becuase it's translated from Typography title-sm, which is dynamic.
 
+/**
+ * Pixel heights of the rows making up a column header.  fixed-data-table needs the header's
+ * total height up front, so these must match what HeaderCell renders.  HeaderText's font size is
+ * pinned to headerFontSize so the text rows stay in sync; headers do not scale with the font .
+ */
+export const headerFontSize = 12.25;                                // Joy's fontSize.sm at firefly's root size
+export const headerLineHeight = Math.ceil(headerFontSize * 1.2);    // HeaderText uses lineHeight 1.2
+
+export const headerRowHeight = {
+    label:  22,
+    units:  headerLineHeight,
+    types:  headerLineHeight,
+    filter: 25,
+};
+
+export function calcHeaderHeight({showHeader=true, showUnits, showTypes, showFilters}={}) {
+    if (!showHeader) return 0;
+    return 2 + headerRowHeight.label
+        + (showUnits   ? headerRowHeight.units  : 0)
+        + (showTypes   ? headerRowHeight.types  : 0)
+        + (showFilters ? headerRowHeight.filter : 0);
+}
+
 const imageStubMap = {
     info: <img style={{width:'14px'}} src={infoIcon} alt='info'/>
 };
@@ -70,6 +93,18 @@ function SortSymbol({sortDir}) {
     );
 };
 
+
+// one row of the header stack; claims exactly `h` pixels and centers its content within it.
+function HeaderRow({h, sx, children, ...rest}) {
+    return (
+        <Stack {...rest}
+               sx={{flex: `0 0 ${h}px`, minHeight: 0, overflow: 'hidden',
+                    justifyContent: 'center', alignItems: 'center', ...sx}}>
+            {children}
+        </Stack>
+    );
+}
+
 export const HeaderCell = React.memo( ({col, showUnits, showTypes, showFilters, filterInfo, sortInfo, onSort, onFilter, sx={}, tbl_id}) => {
     const {label, name, desc, sortByCols, sortable} = col || {};
     const cdesc = desc || label || name;
@@ -81,26 +116,29 @@ export const HeaderCell = React.memo( ({col, showUnits, showTypes, showFilters, 
     const color = col.DERIVED_FROM ? 'warning' : undefined;
 
     const onClick = toBoolean(sortable, true) ? () => onSort(sortCol) : () => showInfoPopup('This column is not sortable');
-    const centerIt = {justifyContent:'center', alignItems:'center'};
 
-    sx = {py: '2px', ...sx};
+    sx = {height: 1, display: 'flex', flexDirection: 'column', ...sx};
     return (
         <Sheet variant='plain' sx={sx}>
-            <Stack width={1} height={1} {...centerIt}>
-                <Tooltip title={cdesc} sx={{maxWidth:'20em'}}>
-                    <Stack width={1} height={1} {...centerIt} className={clickable} onClick={onClick}>
-                        <Stack direction='row' {...centerIt}>
+            <Tooltip title={cdesc} sx={{maxWidth:'20em'}}>
+                <Stack className={clickable} onClick={onClick} sx={{flex:'0 0 auto', minHeight:0}}>
+                    <HeaderRow h={headerRowHeight.label}>
+                        <Stack direction='row' maxWidth={1} alignItems='center'>
                             <Stack textOverflow='ellipsis' overflow='hidden'>
                                 <HeaderText val={label || name} level='title-sm' color={color}/>
                             </Stack>
                             <SortSymbol sortDir={sortDir}/>
                         </Stack>
-                        { showUnits && <HeaderText val={unitsVal}/> }
-                        { showTypes && <HeaderText val={typeVal}/> }
-                    </Stack>
-                </Tooltip>
-                {showFilters && (<Filter {...{cname:name, onFilter, filterInfo, tbl_id}}/>)}
-            </Stack>
+                    </HeaderRow>
+                    { showUnits && <HeaderRow h={headerRowHeight.units}><HeaderText val={unitsVal}/></HeaderRow> }
+                    { showTypes && <HeaderRow h={headerRowHeight.types}><HeaderText val={typeVal}/></HeaderRow> }
+                </Stack>
+            </Tooltip>
+            {showFilters && (
+                <HeaderRow h={headerRowHeight.filter} sx={{alignItems:'stretch'}}>
+                    <Filter {...{cname:name, onFilter, filterInfo, tbl_id}}/>
+                </HeaderRow>
+            )}
         </Sheet>
     );
 });
@@ -108,7 +146,8 @@ export const HeaderCell = React.memo( ({col, showUnits, showTypes, showFilters, 
 export function HeaderText({val, level='body-sm', sx, ...rest}) {
     return (
         <Typography component='div' level={level} {...rest}
-                    sx={{lineHeight:1.2, height:'1.2em', whiteSpace:'nowrap', ...sx}}>
+                    sx={{fontSize: `${headerFontSize}px`, lineHeight: 1.2, height: `${headerLineHeight}px`,
+                         whiteSpace: 'nowrap', ...sx}}>
             {val || ''}
         </Typography>
     );
@@ -133,7 +172,7 @@ function Filter({cname, onFilter, filterInfo, tbl_id}) {
 
     const {name, filterable=true, enumVals} = col;
 
-    if (!filterable) return <div style={{height:19}} />;      // column is not filterable
+    if (!filterable) return null;      // column is not filterable
 
     const filterInfoCls = FilterInfo.parse(filterInfo);
 
@@ -219,13 +258,11 @@ function EnumSelect({col, tbl_id, filterInfoCls, onFilter}) {
 export function SelectableHeader ({checked, onSelectAll, showUnits, showTypes, showFilters, showSelectRowFilter=true,
                                       onFilterSelected, sx}) {
     return (
-        <Stack alignItems='center' height={1} justifyContent='space-between' py='2px' sx={sx}>
+        <Stack alignItems='center' height={1} justifyContent='space-between' pt='4px' pb='2px' sx={sx}>
             <Checkbox size='sm'
                 tabIndex={-1}
                 checked={checked}
                 onChange={(e) => onSelectAll(e.target.checked)}/>
-            {/*{showUnits && <Box height='1em'/>}*/}
-            {/*{showTypes && <Box height='1em'/>}*/}
             {showFilters && showSelectRowFilter && <FilterButton  iconButtonSize='28px'
                                  onClick={onFilterSelected}
                                  tip='Filter on selected rows'/>}


### PR DESCRIPTION
Ticket https://jira.ipac.caltech.edu/browse/FIREFLY-2021
- Preserve sort and filter state across automatic refreshes
- Add a clear filter button when filters are active
- Show a loading indicator while data is being refreshed
- Highlight newly added job after sort/filter is applied instead of always placing it at the top

Test: 
https://firefly-2021-job-monitor-update.irsakubedev.ipac.caltech.edu/applications/spherex/
https://firefly-2021-job-monitor-update.irsakubedev.ipac.caltech.edu/firefly/

Addressed the issues reported in the ticket:
- I was able to stop a job and then delete it successfully. Could you please test this again?
- Added a Clear Filters button next to the filter inputs. Let me know if you think it would be better placed elsewhere.
- Newly created jobs no longer automatically appear at the top of the table now that sort and filter state is preserved across refreshes. Instead, the new job is highlighted after the current sort and filter are applied. This behavior change should be documented if the previous behavior was documented.


Additional Changes after PR:

- Moved the **Job Summary** into the table toolbar, enabling use of the built-in **Filter** and **Clear Filter** actions.
- Removed data types from the table headers.
- Cleaned up the table header layout so header heights render consistently regardless of the show/hide options.

Test URL instances updated with the latest change.  Please test again.
