### PR TITLE
FIREFLY-2065: Don't correct scrollTop until table is rendered

### DIFF
--- a/src/firefly/js/tables/ui/BasicTableView.jsx
+++ b/src/firefly/js/tables/ui/BasicTableView.jsx
@@ -376,7 +376,8 @@ const TextView = ({columns, data, width, height}) => {
 
 function correctScrollTopIfNeeded(maxScrollWidth, scrollTop, width, height, rowHeight, hlRowIdx, triggeredBy) {
     const rowHpos = hlRowIdx * rowHeight;
-    if (triggeredBy === BY_TABLE) {     // FIREFLY-1729: don't correct scroll on column resize.
+    // don't correct scrollTop until table is rendered (height > 0).
+    if (triggeredBy === BY_TABLE && height > 0) {     // FIREFLY-1729: don't correct scroll on column resize.
         // delta is a workaround for the horizontal scrollbar hiding part of the last row when visible
         const delta = maxScrollWidth > width ? (.5*rowHeight) : 0;
 


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-2065

The fix is simple. There’s a low chance of regression issues.

Test: https://firefly-2065-bad-table-scrolltop-offset.irsakubedev.ipac.caltech.edu/firefly/
- Verify that TAP constraints table rendered correctly.
- Verify other tables rendered correctly as well.
