### PR TITLE
FIREFLY-2070: Ensure only single local result file are used.

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/DbFromFileProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/DbFromFileProcessor.java
@@ -74,13 +74,13 @@ public abstract class DbFromFileProcessor extends EmbeddedDbProcessor {
         String jobId = req.getJobId();
         if (isEmpty(jobId)) return null;
 
-        // a previously submitted job; try to get from cache
+        // a previously submitted job with local file result
         List<JobInfo.Result> results = ifNotNull(JobManager.getJobInfo(req.getJobId()))
                 .get(JobInfo::getResults);
-        if (results != null && !results.isEmpty()) {
+        if (results != null && results.size() == 1) {
             File rval = ifNotEmpty(results.getFirst().href())
                             .get(ServerContext::convertToFile);
-            if (rval != null && rval.canRead()) {       // if not found in cache, fetch from source
+            if (rval != null && rval.isFile() && rval.canRead()) {       // if not a readable file, then ignore.
                 return rval;
             }
         }


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/FIREFLY-2070

The Rubin TAP service may return multiple results, some of which contain invalid URIs. The current implementation uses the first result (e.g, `262`) as the lookup key, which can coincidentally match a sub-directory in the upload directory.

Update the logic to process only jobs that contain exactly one result URL, and verify that the referenced path both exists and is a regular file before using it.

Test: https://firefly-2070-uws-result-url.irsakubedev.ipac.caltech.edu/suit/