### PR TITLE
IRSA-7890: Add Firefly support for ipac:MultiSpectrum format

### DIFF
--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobInfo.java
@@ -72,6 +72,7 @@ public class JobInfo implements Serializable {
     public static final String USER_NAME = "userName";
     public static final String USER_EMAIL = "userEmail";
     public static final String SEND_NOTIF = "sendNotif";
+    public static final String MIME_TYPE = "mimeType";
 
     private String jobId;
     private String runId;
@@ -252,6 +253,7 @@ public class JobInfo implements Serializable {
         String runHost;     // the host where the job is running on
         String appUrl;      // the URL of the app that created this job
         boolean sendNotif;
+        String mimeType;    // overrides Result.mimeType.  the client maps this to a loader.
 
         // these are not sent to client
         String eventConnId;
@@ -288,6 +290,9 @@ public class JobInfo implements Serializable {
 
         public boolean getSendNotif() { return sendNotif; }
         public void setSendNotif(boolean flg) { this.sendNotif = flg; }
+
+        public String getMimeType() { return mimeType; }
+        public void setMimeType(String mimeType) { this.mimeType = mimeType; }
     }
 
     /**

--- a/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/core/background/JobUtil.java
@@ -264,6 +264,7 @@ public class JobUtil {
         applyIfNotEmpty(meta.getAppUrl(), v -> jsonMeta.put(APP_URL, v));
         applyIfNotEmpty(meta.getRunHost(), v -> jsonMeta.put(RUN_HOST, v));
         applyIfNotEmpty(meta.getSendNotif(), v -> jsonMeta.put(SEND_NOTIF, v));
+        applyIfNotEmpty(meta.getMimeType(), v -> jsonMeta.put(MIME_TYPE, v));
 
         if (!meta.getParameters().isEmpty()) jsonMeta.put(PARAMETERS, meta.getParameters());
 
@@ -307,6 +308,7 @@ public class JobUtil {
                 ifNotNull(ji.get(APP_URL)).apply(s -> rval.getMeta().setAppUrl(s.toString()));
                 ifNotNull(ji.get(RUN_HOST)).apply(s -> rval.getMeta().setRunHost(s.toString()));
                 ifNotNull(ji.get(SEND_NOTIF)).apply(o -> rval.getMeta().setSendNotif((Boolean) o));
+                ifNotNull(ji.get(MIME_TYPE)).apply(s -> rval.getMeta().setMimeType(s.toString()));
 
                 ifNotNull(toParameters(ji.get(PARAMETERS))).apply(p -> rval.getMeta().setParameters(p));
             }

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/MultiSpectrumProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/persistence/MultiSpectrumProcessor.java
@@ -57,6 +57,9 @@ public class MultiSpectrumProcessor extends EmbeddedDbProcessor {
     public static final String MULTI_SPECTRUM_SERVICE_UTYPE = MULTI_SPECTRUM_UTYPE + "-service";
     public static final String SPECTRUM_DATA_UTYPE = SPECTRADM_UTYPE + ".Data";   // utype for the spectrum data table
 
+    // Firefly-specific media type. The client maps it to a loader that reads the results through this processor
+    public static final String MULTI_SPECTRUM_MIME_TYPE = "application/x-votable+xml;content=multispectrum";
+
     public enum Mode { fetch,          // retrieve the MultiSpectrum table, return data product table
                         links,          // return links table to the spectrums
                         extract         // extract the spectrum from array data, then return a SpectralDM table.
@@ -238,26 +241,32 @@ public class MultiSpectrumProcessor extends EmbeddedDbProcessor {
         return isEmpty(s) ? "" : "\"" + s.replace("\"", "\\\"") + "\"";
     }
 
-    private String createLinksUrl(TableServerRequest treq, int rowIdx) {
-
+    /**
+     * Create a callback URL to this processor with the given request.
+     * @param request a request with the parameters to be passed to this processor.
+     * @return a URL string that can be used to call this processor with the given request.
+     */
+    private String createCallbackUrl(TableServerRequest request) {
         String baseUrl = ServerContext.getRequestOwner().getBaseUrl() + "CmdSrv/sync?cmd=tableSearch&FORMAT=votable&request=";
-        TableServerRequest request = (TableServerRequest) treq.cloneRequest();
         request.keepBaseParamOnly();
-        request.setParam(MODE, Mode.links.name());
-        request.setParam(SEL_ROW_IDX, rowIdx+"");
-
+        if (request.getMeta() != null) request.getMeta().clear();
         return baseUrl + QueryUtil.encode(JsonTableUtil.toJsonTableRequest(request).toJSONString());
     }
 
-    private String createSpectrumUrl(TableServerRequest treq, int selRow, int spectrIdx) {
-        String baseUrl = ServerContext.getRequestOwner().getBaseUrl() + "CmdSrv/sync?cmd=tableSearch&FORMAT=votable&request=";
+    private String createLinksUrl(TableServerRequest treq, int rowIdx) {
+
         TableServerRequest request = (TableServerRequest) treq.cloneRequest();
-        request.keepBaseParamOnly();
+        request.setParam(MODE, Mode.links.name());
+        request.setParam(SEL_ROW_IDX, rowIdx+"");
+        return createCallbackUrl(request);
+    }
+
+    private String createSpectrumUrl(TableServerRequest treq, int selRow, int spectrIdx) {
+        TableServerRequest request = (TableServerRequest) treq.cloneRequest();
         request.setParam(MODE, Mode.extract.name());
         request.setParam(SEL_ROW_IDX, selRow+"");
         request.setParam(SPECTR_IDX, spectrIdx+"");
-
-        return baseUrl + QueryUtil.encode(JsonTableUtil.toJsonTableRequest(request).toJSONString());
+        return createCallbackUrl(request);
     }
 
     private List<GroupInfo.RefInfo> getAllColRef(GroupInfo root) {

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/AsyncTapQuery.java
@@ -4,6 +4,7 @@
 package edu.caltech.ipac.firefly.server.query;
 
 import edu.caltech.ipac.firefly.core.background.Job;
+import edu.caltech.ipac.firefly.core.background.JobInfo;
 import edu.caltech.ipac.firefly.data.TableServerRequest;
 import edu.caltech.ipac.firefly.server.network.HttpServiceInput;
 import edu.caltech.ipac.firefly.server.util.Logger;
@@ -59,6 +60,11 @@ public class AsyncTapQuery extends UwsJobProcessor {
     public Job.Type getType() {
         return Job.Type.TAP;
     }
+
+    /**
+     * Skip sniffing to avoid unnecessary network calls.  Should display the returned table as-is.
+     */
+    protected void detectCustomMimeType(List<JobInfo.Result> results) {}
 
     public HttpServiceInput createInput(TableServerRequest request) throws DataAccessException {
         var serviceUrl = request.getParam(SVC_URL);

--- a/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
+++ b/src/firefly/java/edu/caltech/ipac/firefly/server/query/UwsJobProcessor.java
@@ -14,8 +14,10 @@ import edu.caltech.ipac.table.DataGroup;
 import edu.caltech.ipac.firefly.core.background.JobInfo;
 import edu.caltech.ipac.table.DataObject;
 import edu.caltech.ipac.table.DataType;
+import edu.caltech.ipac.table.TableMeta;
 import edu.caltech.ipac.table.io.VoTableReader;
 import edu.caltech.ipac.util.FileUtil;
+import edu.caltech.ipac.util.FormatUtil.Format;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -37,6 +39,8 @@ import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotEmpty;
 import static edu.caltech.ipac.firefly.core.Util.Opt.ifNotNull;
 import static edu.caltech.ipac.firefly.core.background.JobInfo.*;
 import static edu.caltech.ipac.firefly.core.background.JobManager.getJobInfo;
+import static edu.caltech.ipac.firefly.server.persistence.MultiSpectrumProcessor.MULTI_SPECTRUM_MIME_TYPE;
+import static edu.caltech.ipac.firefly.server.persistence.MultiSpectrumProcessor.MULTI_SPECTRUM_UTYPE;
 import static edu.caltech.ipac.firefly.server.SrvParam.PARAM_DELIM;
 import static edu.caltech.ipac.firefly.server.network.HttpServices.*;
 import static edu.caltech.ipac.firefly.server.query.DaliUtil.*;
@@ -249,8 +253,45 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
         if (jobInfo == null || jobInfo.getResults().isEmpty()) {
             throw createDax("UWS job completed without results", jobUrl, null);
         } else {
-            List<JobInfo.Result> results = jobInfo.getResults();
-            return convertResultsToObsCoreTable(results);
+            detectCustomMimeType(jobInfo);
+            return convertResultsToObsCoreTable(jobInfo);
+        }
+    }
+
+    /**
+     * Examines the results to determine whether a Firefly-specific media type is required.
+     */
+    protected void detectCustomMimeType(JobInfo jobInfo) {
+        JobInfo.Result result = jobInfo.getResults().stream()
+                                    .filter(r -> isUrl(r.href()))
+                                    .findFirst().orElse(null);
+        if (result == null) return;         // nothing we can read
+
+        String utype = getVotableUtype(result);
+        if (MULTI_SPECTRUM_UTYPE.equalsIgnoreCase(utype)) {
+            updateJob(ji -> ji.getMeta().setMimeType(MULTI_SPECTRUM_MIME_TYPE));
+        }
+    }
+
+    private static boolean isUrl(String href) {
+        return !isEmpty(href) && href.toLowerCase().startsWith("http");
+    }
+
+    /**
+     * Returns the UTYPE of the VOTable.
+     */
+    static String getVotableUtype(JobInfo.Result result) {
+        Format format = Format.fromMime(result.mimeType());
+        boolean maybeVoTable = format == Format.VO_TABLE ||
+                               format == Format.UNKNOWN;    // we don't know; worth checking
+        if (isEmpty(result.href()) || !maybeVoTable) return null;
+
+        try {
+            DataGroup[] tables = VoTableReader.voToDataGroups(result.href(), true, 0);  // headers of the first table only
+            return tables.length > 0 ? tables[0].getAttribute(TableMeta.UTYPE, null) : null;
+        } catch (Exception e) {
+            logger.debug("Unable to read the results at %s: %s".formatted(result.href(), e.getMessage()));
+            return null;
         }
     }
 
@@ -258,7 +299,8 @@ public class UwsJobProcessor extends EmbeddedDbProcessor {
 //  UWS utils
 //====================================================================
 
-    public DataGroup convertResultsToObsCoreTable(List<JobInfo.Result> results) {
+    public DataGroup convertResultsToObsCoreTable(JobInfo jobInfo) {
+        List<Result> results = jobInfo.getResults();
         DataGroup table = new DataGroup("UWS results", new DataType[]{
                 new DataType("dataproduct_type", String.class),
                 new DataType("access_url", String.class),

--- a/src/firefly/js/core/background/BackgroundConst.js
+++ b/src/firefly/js/core/background/BackgroundConst.js
@@ -1,0 +1,11 @@
+/*
+ * License information at https://github.com/Caltech-IPAC/firefly/blob/master/License.txt
+ */
+
+
+/** SearchProcessor ID of MultiSpectrumProcessor; transforms a MultiSpectrum table into an obs_core table with datalinks */
+export const MULTI_SPECTRUM_PROC_ID = 'multi_spectrum';
+export const MULTI_SPECTRUM_MIME_TYPE = 'application/x-votable+xml;content=multispectrum';  // mimeType for MultiSpectrum tables
+
+/** Firefly-specific media type indicating mixed content in a FITS file */
+export const MIXED_FITS_MIME_TYPE = 'application/x-fits;content=mixed';

--- a/src/firefly/js/core/background/BackgroundUtil.js
+++ b/src/firefly/js/core/background/BackgroundUtil.js
@@ -17,7 +17,9 @@ import {ServerParams} from '../../data/ServerParams.js';
 import * as SearchServices from '../../rpc/SearchServicesJson.js';
 import {logger} from '../../util/Logger';
 import * as TblUtil from 'firefly/tables/TableUtil';
-import {copyRequestOptions, getRequestFromJob, getTblId, makeFileRequest} from 'firefly/tables/TableRequestUtil';
+import {copyRequestOptions, getRequestFromJob, getTblId, makeFileRequest, makeTblRequest} from 'firefly/tables/TableRequestUtil';
+import {MIXED_FITS_MIME_TYPE, MULTI_SPECTRUM_MIME_TYPE, MULTI_SPECTRUM_PROC_ID} from './BackgroundConst.js';
+import {VO_TABLE_CONTENT_TYPE} from 'firefly/voAnalyzer/VoConst';
 import {dispatchTableRemove, dispatchTableSearch, dispatchTableUpdate} from 'firefly/tables/TablesCntlr';
 import WebPlotRequest, {TitleOptions} from 'firefly/visualize/WebPlotRequest';
 import {getAViewFromMultiView, getMultiViewRoot, IMAGE} from 'firefly/visualize/MultiViewCntlr';
@@ -314,7 +316,7 @@ export function fixTapResults(jobInfo) {
 export function loadJobResult({jobInfo, resultIdx}) {
     const {request, tbl_id, loader, href,  mimeType, id, size} = getMetadata({jobInfo, resultIdx});
     loader?.({jobInfo, request, href, mimeType, id, size});
-    if (loader !== loadTableResult) {
+    if (!loader?.createsTable) {        // this result is not a table, i.e. an image or a chart; drop the table the search created for it.
         dispatchTableRemove(tbl_id, true);
     }
 }
@@ -339,25 +341,32 @@ function parseHrefExtension(href) {
     }
 }
 
+// Returns the loader for the given media type, or undefined when it's not a type we know how to load.
 function  getMimeLoader(mimeType, href) {
     if (!mimeType && href) {
         const {ext} = parseHrefExtension(href) ?? {};
         if (FITS_EXTS.includes(ext)) {
             mimeType = 'application/fits';
         } else if (TABLE_EXTS.includes(ext)) {
-            mimeType = 'application/x-votable+xml';             // just to trigger table loader
+            mimeType = VO_TABLE_CONTENT_TYPE;
         }
     }
 
-    switch (String(mimeType).toLowerCase()) {
-        case 'application/x-fits; content=mixed':           // non-standard used by Firefly to indicate mixed content in a FITS file
+    // normalized mimeType so it matches against the known types
+    const nMimeType = String(mimeType).toLowerCase().replace(/\s+/g, '');
+    switch (nMimeType) {
+        case MIXED_FITS_MIME_TYPE:
             return loadMixedResult;
+        case MULTI_SPECTRUM_MIME_TYPE:
+            return loadMultiSpectrumResult;
         case 'application/fits':
         case 'application/x-fits':
         case 'image/fits':
             return loadImageResult;
+        case VO_TABLE_CONTENT_TYPE:
+            return loadTableResult;
         default:
-            return loadTableResult;         // default to table loader
+            return undefined;
     }
 }
 
@@ -367,29 +376,44 @@ const handleLayoutChanges = (jobInfo) => {
     if (submitTo)  dispatchFormSubmit({submitTo}); // if this is a routed app, submit the form to update the route
 };
 
-export function loadTableResult({jobInfo, request, href}) {
-    const {tbl_id} = getMetadata({jobInfo});
+export function loadTableResult({jobInfo, requestSupplier}) {
+    const {tbl_id, href, request} = getMetadata({jobInfo});
     if (!isURL(href)) {
         dispatchTableUpdate(TblUtil.createErrorTbl(tbl_id, `Invalid result URL: ${href}`));
     }
 
-    const tblRequest= makeFileRequest(null, href, null, {tbl_id});
+    const tblRequest= requestSupplier?.(jobInfo) || makeFileRequest(null, href, null, {tbl_id});
     copyRequestOptions(request, tblRequest);
 
     const {tbl_ui_id} = getTableUiByTblId(tbl_id) || {};        // re-use existing table UI if exists
     dispatchTableSearch(tblRequest, {tbl_ui_id});
     handleLayoutChanges(jobInfo);
 }
+loadTableResult.createsTable = true;
+
+// Load a MultiSpectrum table result, transforming it into an obs_core table with datalinks to each spectrum.
+export function loadMultiSpectrumResult({jobInfo}) {
+
+    loadTableResult({jobInfo, requestSupplier: (ji) => {
+            const {tbl_id, href} = getMetadata({jobInfo: ji});
+            return makeTblRequest(MULTI_SPECTRUM_PROC_ID, null, {source: href}, {tbl_id});
+    }});
+}
+loadMultiSpectrumResult.createsTable = true;
+
 
 export function getMetadata({jobInfo, resultIdx=0}) {
     const request = getRequestFromJob(jobInfo?.meta?.jobId);  // the request is initiated from Firefly
     const tbl_id = getTblId(request);
     const submitTo = request?.META_INFO?.form_submitTo;
     const results = jobInfo?.results || [];
-    const metaMimeType = jobInfo?.meta?.mimeType;
+    const metaMimeType = jobInfo?.meta?.mimeType;       // job-level override;
     const {href, mimeType, id, size} = results[resultIdx];
     const loader = getMimeLoader(metaMimeType || mimeType, href);
-    return {tbl_id, request, submitTo, href, loader, results, mimeType, id, size};
+    if (metaMimeType && !loader) {
+        logger.warn(`No loader for declared result media type: ${metaMimeType}; loading it as a plain table`);
+    }
+    return {tbl_id, request, submitTo, href, loader: loader ?? loadTableResult, results, mimeType, id, size};
 }
 
 export function loadMixedResult({jobInfo, href}) {


### PR DESCRIPTION
Ticket: https://jira.ipac.caltech.edu/browse/IRSA-7890
Additional changes here: https://github.com/IPAC-SW/irsa-ife/pull/475


- Detect and set the UWS result with a custom MIME type to indicate that it’s a MultiSpectrum.
- Move the loading logic to the client, which will transform the table into one row per spectrum.
Currently, it only looks for MultiSpectrum, but the framework is intended to add additional custom formats in the future.

SPHEREx UI: https://irsa-7890-spherex-sptool-transform.irsakubedev.ipac.caltech.edu/applications/spherex/
- Go to the `Spectrophotometry Tool` and submit a job.
- Wait for the job to complete (it may take a while).
- Once the job is complete, view the results.

However, since the functionality has been moved to Firefly, you can now upload any completed job to have it visualized in the client.

Here’s an example of a completed job URL: 
https://irsadev.ipac.caltech.edu/api/spherex/spectrophotometry/async/6e78b1ae-942a-4f6f-a363-d7a7c8c3515a

Upload this URL to Firefly or the SPHEREx UI.
Firefly URL: https://irsa-7890-spherex-sptool-transform.irsakubedev.ipac.caltech.edu/firefly/
