### PR TITLE
FIREFLY-2083: Change default "do it" button text for HiPS to Load

### DIFF
--- a/src/firefly/js/visualize/ui/HiPSSearchPanel.jsx
+++ b/src/firefly/js/visualize/ui/HiPSSearchPanel.jsx
@@ -20,7 +20,7 @@ export function HiPSSearchPanel({initArgs= {}, name:groupKey = 'HiPSSearchPanel'
     return (
         <FieldGroup groupKey={groupKey} keepState={true} sx={{width: 1, height: 1}}>
             <Box width={1} height={1}>
-                <FormPanel onSuccess={(request) => doSearch(request)} cancelText='' help_id = 'basics.searching.hips'
+                <FormPanel onSuccess={(request) => doSearch(request)} cancelText='' completeText='Load' help_id = 'basics.searching.hips'
                             slotProps={{
                                 completeBtn: {
                                     getDoOnClickFunc: (clickFunc) => (clickFuncRef.clickFunc= clickFunc),


### PR DESCRIPTION
[FIREFLY-2083](https://jira.ipac.caltech.edu/browse/FIREFLY-2083)

Note that, if I've understood the code correctly, this PR will *not* change the behavior of the IRSA Viewer "legacy" image search tab, where "Search" also appears regardless of the actual operation being performed.  It might be more complicated to fix there: for the original, mainstream "retrieve FITS images from IRSA collections" the "Search" text is good, but for HiPS and for "use my image" I think "Load" is also a better verb.  But on the IRSA Viewer tab that would require the "do it" button's label to change depending on the radio-button selections, so that might be more controversial and/or harder to code.