### PR TITLE
Firefly-2079: Fixed: Statistics dialog fails to come up when selected region contains only NaNs

### DIFF
--- a/src/firefly/js/visualize/ui/CtxToolbarFunctions.js
+++ b/src/firefly/js/visualize/ui/CtxToolbarFunctions.js
@@ -121,6 +121,7 @@ function tabulateStatics(wpResult, cc) {
     const bandData = {};
 
     function getOneStatSet(b) {
+        if (!b.MEAN || !b.STDEV || !b.INTEGRATED_FLUX) return;
 
         const tblData = {};
 
@@ -163,7 +164,7 @@ function tabulateStatics(wpResult, cc) {
         return tblData;
     }
 
-    if (bands.hasOwnProperty(noBand)) {
+    if (bands[noBand]) {
         bandData[noBand] = getOneStatSet(bands[noBand]);
     } else {
         const bandName = ['Blue', 'Red', 'Green'];

--- a/src/firefly/js/visualize/ui/ImageStatsPopup.jsx
+++ b/src/firefly/js/visualize/ui/ImageStatsPopup.jsx
@@ -7,11 +7,12 @@ import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import CompleteButton from '../../ui/CompleteButton.jsx';
 import DialogRootContainer from '../../ui/DialogRootContainer.jsx';
+import {showInfoPopup} from '../../ui/PopupUtil';
 import {
     dispatchAttachLayerToPlot, dispatchCreateDrawLayer, dispatchDestroyDrawLayer, dispatchDetachLayerFromPlot,
     dispatchModifyCustomField
 } from '../DrawLayerDispatch';
-import {getDrawLayerByType, isDrawLayerAttached } from '../PlotViewUtil.js';
+import {currentP, getDrawLayerByType, isDrawLayerAttached, isThreeColor} from '../PlotViewUtil.js';
 import {Tabs, Tab} from '../../ui/panel/TabPanel.jsx';
 
 
@@ -50,11 +51,23 @@ function destroyDrawLayer(plotId)
  */
 
 export function showImageAreaStatsPopup(popTitle, statsResult, plotId) {
-    var popupStats = statsResult.hasOwnProperty(noBand) ?
-                    <ImageStats statsResult={statsResult[noBand]} plotId={plotId}/> :
-                    <ImageStatsTab statsResult={statsResult} plotId={plotId}/>;
 
-    var popup = (<PopupPanel title={popTitle}
+    if (Object.values(statsResult).some( (t) => !t)) {
+        const msg= isThreeColor(currentP(plotId).pv)
+            ? 'Could not compute statistics: most likely selected area of one or more bands have no valid (non-NaN) pixels'
+            : 'Could not compute statistics, most likely selected area has no valid (non-NaN) pixels';
+            showInfoPopup(
+                <Typography sx={{whiteSpace: 'nowrap'}}> {msg} </Typography>,
+                popTitle, { '.FF-Popup-Content': {maxWidth:'50em'} }
+            );
+        return;
+    }
+
+    const popupStats = statsResult[noBand]
+        ? <ImageStats statsResult={statsResult[noBand]} plotId={plotId}/>
+        : <ImageStatsTab statsResult={statsResult} plotId={plotId}/>;
+
+    const popup = (<PopupPanel title={popTitle}
                              closeCallback={() => destroyDrawLayer(plotId)}>
                     {popupStats}
                  </PopupPanel>);


### PR DESCRIPTION
### [Firefly-2079](https://jira.ipac.caltech.edu/browse/FIREFLY-2079): Fixed: Statistics dialog fails to come up when selected region contains only NaNs

 - including a little code cleanup

#### Testing
- https://firefly-2079-stats.irsakubedev.ipac.caltech.edu/firefly
   - Go to upload tab
   - choose upload and enter the url below
      - `http://web.ipac.caltech.edu/staff/roby/many-images/_data_SOFIA_FIFI-LS_L4_2016-07-05_FI_F316_p3993_g10_F0316_FI_IFS_04015210_BLU_WXY_600284-700065.fits`
    - take the defaults and load the image
    - on the imag,e NaN pixels show up redish, the first image will be all NaNs
    - goto plane 3 which will have a mix of NaNs and non-NaNs
    - using the selection tool choose an area with a mix of both, choose the statistics button <img width="29" height="31" alt="Screenshot 2026-08-19 at 4 19 16 PM" src="https://github.com/user-attachments/assets/ff3aabc8-802d-4dc2-939b-c6542f52820b" />
    - you should see stats
    - now choose an area with only NaNs and click the the statistics button again. It should show an error.
