### PR TITLE
Firefly-2073: Fixed typo in TAP error string

### DIFF
--- a/src/firefly/js/ui/tap/SpatialSearch.jsx
+++ b/src/firefly/js/ui/tap/SpatialSearch.jsx
@@ -583,7 +583,7 @@ function getPolygonUserArea(polygonCornersStr='', adqlCoordSys, worldSys, useSIA
     }, []);
 
     if (newCorners?.length < 3 || newCorners?.length > 15) {
-        errList.addError('too few or too many corner specified');
+        errList.addError('too few or too many corners specified');
         valid= false;
     }
 


### PR DESCRIPTION
[FIREFLY-2073](https://jira.ipac.caltech.edu/browse/FIREFLY-2073): Typo in polygon-entry validation error message

- Resolves the ticket by correcting the grammar in the string

Testing:
https://firefly-2073-error-message-typo.irsakubedev.ipac.caltech.edu/firefly

1. Navigate to the TAP view in firefly
2. Select Shape Type: Polygon
3. Input only two coordinate pairs, e.g. 10 10, 20 20
4. Validate the corrected string displays: "too few or too many corners specified"
