### PR TITLE
Firefly-2072: fix Use Image Search (ObsTAP) toggle not turning off

### DIFF
--- a/src/firefly/js/ui/tap/TapViewType.jsx
+++ b/src/firefly/js/ui/tap/TapViewType.jsx
@@ -194,8 +194,8 @@ function BasicUI(props) {
         }
         else {
             const foundSchema= schemaOptions.find( (s) => {
-                if (schemaOptions.length===2) return s.value?.upperCase() === 'TAP_SCHEMA';
-                else return s.value?.upperCase() !== 'TAP_SCHEMA' && s.value!=='ivoa';
+                if (schemaOptions.length===2) return s.value?.toUpperCase() === 'TAP_SCHEMA';
+                else return s.value?.toUpperCase() !== 'TAP_SCHEMA' && s.value!=='ivoa';
             });
             if (foundSchema) setSchemaName(foundSchema.value);
         }


### PR DESCRIPTION
[FIREFLY-2072](https://jira.ipac.caltech.edu/browse/FIREFLY-2072): can't turn off obstap

Description:

The toggle currently throws a type error due to a call to ".upperCase()", meaning it does not deselect. The fix edits the call to .toUpperCase().

Testing:

- Build: https://firefly-2072-use-image-search-toggle.irsakubedev.ipac.caltech.edu/firefly

1. From the Tables (TAP) view, toggle the Use Image Search (ObsTAP) button. It should activate and deactivate as expected.