### PR TITLE
FIREFLY-2057: disable contextual font ligatures

### DIFF
--- a/src/firefly/html/css/global.css
+++ b/src/firefly/html/css/global.css
@@ -22,6 +22,14 @@
 @def toolbarGroupColor    rgba(0,0,0,.51);
 */
 
+/*
+ * Disable contextual ligatures. The form controls are listed to account for the browser's font shorthand reset.
+ */
+:root,
+button, input, select, textarea, optgroup {
+    font-variant-ligatures: no-contextual;
+}
+
 .rootStyle {
     /*background-color: #e3e3e3;*/
     padding: 0 1px 0 1px;


### PR DESCRIPTION
[Firefly-2057](https://jira.ipac.caltech.edu/browse/FIREFLY-2057): Minor display bug in TAP list of 2MASS catalogs

Description:

The font styling we're using is including contextual ligatures (e.g. it will read 2x3 and redraw it as arithmetic). We disable this on the root element and also list the form inputs separately, because the browser can undo it on those (i.e. reapply the treatment).

Testing:

- Build: https://firefly-2057-disable-font-contextual-alternates.irsakubedev.ipac.caltech.edu/firefly

1. Navigate to the Tables (TAP) view.
2. Select Project: 2mass.
3. Expand the Tables selection menu. 
4. We should see the x as a plain character in the string "pt_src_6x2"

Before:

<img width="1887" height="963" alt="before" src="https://github.com/user-attachments/assets/45345227-bbd7-436d-9216-aae5986d60c4" />

After:

<img width="1925" height="992" alt="after" src="https://github.com/user-attachments/assets/582027ce-9eeb-4b42-88e1-afd48c19a6e1" />