### PR TITLE
FIREFLY-2094: Support pre-assigned colors and order for grouped charts 

### DIFF
--- a/src/firefly/js/charts/ChartUtil.js
+++ b/src/firefly/js/charts/ChartUtil.js
@@ -28,7 +28,7 @@ import {dispatchChartHighlighted, dispatchChartSelect, dispatchChartUpdate, disp
 } from './ChartsCntlr.js';
 import {Expression} from '../util/expr/Expression.js';
 import {quoteNonAlphanumeric} from '../util/expr/Variable.js';
-import {flattenObject} from '../util/WebUtil.js';
+import {flattenObject, sortByConfig} from '../util/WebUtil.js';
 import {SelectInfo} from '../tables/SelectInfo.js';
 import {getTraceTSEntries as histogramTSGetter} from './dataTypes/FireflyHistogram.js';
 import {getTraceTSEntries as heatmapTSGetter} from './dataTypes/FireflyHeatmap.js';
@@ -39,6 +39,7 @@ import {toRGBA as colorToRGBA} from '../util/Color.js';
 import {MetaConst} from '../data/MetaConst';
 import {ALL_COLORSCALE_NAMES, colorscaleNameToVal} from './Colorscale.js';
 import {getColValidator} from './ui/ColumnOrExpression.jsx';
+import {getEnumConfigForColumn} from '../ui/tap/DataServicesOptions.js';
 
 export const DEFAULT_ALPHA = 0.5;
 
@@ -476,12 +477,15 @@ export function makeScatterGroupByChanges({chartId, tbl_id, activeTrace=0, group
         };
     }
 
+    const enumConfig = getEnumConfigForColumn(tbl_id, groupCol.name);
+    const orderedValues = enumConfig?.order ? sortByConfig(groupValues, enumConfig.order) : groupValues;
+
     const groupData = [];
     const groupFireflyData = [];
-    groupValues.forEach((value, idx) => {
+    orderedValues.forEach((value, idx) => {
         const trace = simpleCloneDeep(baseData);
         const fd = simpleCloneDeep(baseFirefly);
-        const color = toRGBA(TRACE_COLORS[idx % TRACE_COLORS.length]);
+        const color = toRGBA(enumConfig?.palette?.[value] ?? TRACE_COLORS[idx % TRACE_COLORS.length]);
 
         set(trace, 'name', value);
         set(trace, 'showlegend', true);
@@ -1147,7 +1151,9 @@ export function applyDefaults(chartData={}, resetColor = true) {
             getNextTraceColorscale(true);
         }
 
-        type && Object.entries(getDefaultColorAttributes(d, type, idx)).forEach(([k, v]) => set(chartData, k, v));
+        const groupBy = chartData?.fireflyData?.[idx]?.groupBy || d?.firefly?.groupBy;
+        const traceTblId = d.tbl_id || d?.firefly?.tbl_id || chartData?.fireflyData?.[idx]?.tbl_id;
+        type && Object.entries(getDefaultColorAttributes(d, type, idx, groupBy, traceTblId)).forEach(([k, v]) => set(chartData, k, v));
 
         // default dragmode is select if box selection is supported
         type && !chartData.layout.dragmode && (chartData.layout.dragmode = isBoxSelectionSupported(type) ? 'select' : 'zoom');
@@ -1347,19 +1353,28 @@ export const colorsOnTypes = {
     others: [['marker.color']]
 };
 
+function getPreassignedGroupColor(tbl_id, groupBy) {
+    if (!groupBy?.column) return undefined;
+    const hex = getEnumConfigForColumn(tbl_id, groupBy.column)?.palette?.[groupBy.value];
+    return hex && toRGBA(hex);
+}
+
 /**
  * This function is used to apply color attributes to a new chart
  * @param traceData
  * @param type
  * @param idx
+ * @param groupBy - optional object containing column and value that this trace is grouped by,
+ *                  e.g. from FireflySpectrum's order-based auto-grouping or the manual scatter Group By feature
+ * @param tbl_id - table this trace's data comes from, used to look up a preassigned group color
  * @returns {{}} an object with color attributes
  */
-function getDefaultColorAttributes(traceData, type, idx) {
+function getDefaultColorAttributes(traceData, type, idx, groupBy, tbl_id) {
     if (!type) return {};
     const colorSettingObj = {};
 
     const colorAttributes = Object.keys(colorsOnTypes).includes(type) ? colorsOnTypes[type] : colorsOnTypes.others;
-    const color = getNextTraceColor();
+    const color = getPreassignedGroupColor(tbl_id, groupBy) ?? getNextTraceColor();
     colorAttributes[0].filter((att) => att.endsWith('color')).forEach((att) => {
         if (!get(traceData, att)) {
             colorSettingObj[`data.${idx}.${att}`] = color;

--- a/src/firefly/js/charts/dataTypes/FireflySpectrum.js
+++ b/src/firefly/js/charts/dataTypes/FireflySpectrum.js
@@ -10,7 +10,9 @@ import {getDataChangesForMappings, getResetAxesChanges, getOriginalRowIndexes, i
 import {addOtherChanges, createChartTblRequest, getTraceTSEntries as genericTSGetter} from './FireflyGenericData.js';
 
 import {quoteNonAlphanumeric} from '../../util/expr/Variable.js';
+import {sortByConfig} from '../../util/WebUtil.js';
 import {getXLabel, getYLabel} from './SpectrumUnitConversion.js';
+import {getEnumConfigForColumn} from '../../ui/tap/DataServicesOptions.js';
 
 export const spectrumType = 'spectrum';
 
@@ -111,7 +113,10 @@ export function spectrumPlot({tbl_id, spectrumDM}) {
     if (spectralAxis.order) {
         const orderCol = getColumn(tableModel, spectralAxis.order);
         const orig = data.pop();
-        orderCol?.enumVals?.split(',').forEach((v) => {
+        const enumConfig = getEnumConfigForColumn(tbl_id, spectralAxis.order);
+        const orderValues = orderCol?.enumVals?.split(',') ?? [];
+        const orderedValues = enumConfig?.order ? sortByConfig(orderValues, enumConfig.order) : orderValues;
+        orderedValues.forEach((v) => {
             const order = cloneDeep(orig);
             set(order, 'name', v);
             set(order, 'mode', 'lines+markers');

--- a/src/firefly/js/tables/ui/TableRenderer.js
+++ b/src/firefly/js/tables/ui/TableRenderer.js
@@ -12,7 +12,7 @@ import {cleanHtml, COL_TYPE, formatValue, getCellValue, getColumn, getColumnIdx,
 import {SortInfo} from '../SortInfo.js';
 import {InputField} from '../../ui/InputField.jsx';
 import {SORT_ASC, UNSORTED} from '../SortInfo';
-import {copyToClipboard, encodeUrlString, toBoolean} from '../../util/WebUtil.js';
+import {copyToClipboard, encodeUrlString, sortByConfig, toBoolean} from '../../util/WebUtil.js';
 
 import ASC_ICO from 'html/images/sort_asc.gif';
 import DESC_ICO from 'html/images/sort_desc.gif';
@@ -24,6 +24,7 @@ import {dispatchValueChange} from '../../fieldGroup/FieldGroupCntlr.js';
 import {useStoreConnector} from './../../ui/SimpleComponent.jsx';
 import {applyLinkSub, applyTokenSub} from '../../voAnalyzer/VoCoreUtils.js';
 import {showInfoPopup} from '../../ui/PopupUtil.jsx';
+import {getEnumConfigForColumn} from '../../ui/tap/DataServicesOptions.js';
 import {dispatchTableUpdate} from '../TablesCntlr.js';
 import {dispatchShowDialog} from '../../core/ComponentCntlr.js';
 import {PopupPanel} from '../../ui/PopupPanel.jsx';
@@ -206,7 +207,9 @@ function EnumSelect({col, tbl_id, filterInfoCls, onFilter}) {
     const {name, enumVals} = col || {};
     const groupKey = 'TableRenderer_enum';
     const fieldKey = tbl_id + '-' + name;
-    const options = splitVals(enumVals)                             // split by comma(,) ignoring those in single-quotes
+    const enumConfig = getEnumConfigForColumn(tbl_id, name);
+    const rawValues = splitVals(enumVals);                          // split by comma(,) ignoring those in single-quotes
+    const options = (enumConfig?.order ? sortByConfig(rawValues, enumConfig.order) : rawValues)
         .map( (s) => {
             const value = s === '' ? '%EMPTY' : s;                  // because CheckboxGroupInputField does not support '' as an option, use '%EMPTY' as substitute
             let label = value;

--- a/src/firefly/js/ui/tap/DataServicesOptions.js
+++ b/src/firefly/js/ui/tap/DataServicesOptions.js
@@ -2,7 +2,6 @@ import {isObject} from 'lodash';
 import {getAppOptions} from '../../core/AppDataCntlr';
 import {MetaConst} from '../../data/MetaConst';
 import {getMetaEntry, getObjectMetaEntry} from '../../tables/TableUtil';
-import {getServiceMetaOptions} from './SiaUtil';
 
 const dsOps= () => getAppOptions().dataServiceOptions ?? {};
 
@@ -35,6 +34,18 @@ export function getDataServiceOptionByTable(key, tableOrId, defVal=undefined) {
     const entry= getObjectMetaEntry(tableOrId, MetaConst.DATA_SERVICE_OPTIONS)?.[key];
     if (entry) return entry;
     return getDataServiceOption(key, getMetaEntry(tableOrId,MetaConst.DATA_SERVICE_ID), defVal);
+}
+
+/**
+ * Get the `enumConfig` (preassigned order/color palette for an enum-like column, e.g. a photometric
+ * band) for a table, if one is configured via dataServiceOptions and applies to the given column.
+ * @param {TableModel|String} tableOrId - the table model or table id
+ * @param {String} columnName - the column being grouped/enumerated
+ * @return {{columnNames: String[], order: String[], palette: Object}|undefined}
+ */
+export function getEnumConfigForColumn(tableOrId, columnName) {
+    const enumConfig = getDataServiceOptionByTable('enumConfig', tableOrId);
+    return enumConfig?.columnNames?.includes(columnName) ? enumConfig : undefined;
 }
 
 export function getDataServiceOptionsFallback(dataServiceId, hostname) {

--- a/src/firefly/js/util/WebUtil.js
+++ b/src/firefly/js/util/WebUtil.js
@@ -1060,3 +1060,18 @@ export function createBackgroundRunner({
 }
 
 export const varStr = (str) => '${' + str + '}';
+
+/**
+ * Sort a list of enum-like values according to a preassigned display order (e.g. from an `enumConfig`),
+ * pushing any values not found in `order` to the end.
+ * @param {String[]} values - the values to sort, e.g. the distinct values present in a table's column
+ * @param {String[]} order - the desired order of those values
+ * @return {String[]}
+ */
+export function sortByConfig(values, order) {
+    const rank = (v) => {
+        const i = order.indexOf(v);
+        return i === -1 ? Number.MAX_SAFE_INTEGER : i;
+    };
+    return [...values].sort((a, b) => rank(a) - rank(b));
+}


### PR DESCRIPTION
**Ticket**: [FIREFLY-2094](https://jira.ipac.caltech.edu/browse/FIREFLY-2094)
- Added the ability to set colors/order for grouped traces via `dataServiceOptions`
- The changes in `Firefly.js` are strictly for testing purposes, added hardcoded colors and orders in the `enumConfig` in Firefly.js's `dataServiceOptions` (for the 2 test files). This will be removed before this PR is merged 
    - I also locally tested this in `euclid.js` and uploaded files on `Euclid` to get similar results - so this should work similarly for Rubin as well.
- The reason for 2 different test files below, and similar code changes in 2 different areas of code as well are because: 
   - we need to handle the path where a spectra is grouped by a column by default when you load it
   - and also the 2nd case when a chart has the `Group By` functionality manually turned on after the chart loads with `Group By` initially set to `None` (this is in `makeScatterGroupByChanges` function)

**Testing**: 
- **Firefly**: https://firefly-2094-preassigned-group-colors.irsakubedev.ipac.caltech.edu/firefly
- Use the 2 files in the ticket for testing
  - when uploading both files, select the option to `Attempt to interpret tables as spectra`
  - The `DO_Tau_SH_SPECTRA.tbl` file will result in the spectra being automatically grouped by `order` column
     - the traces should follow the `'u', 'g', 'r', 'i', 'z', 'y'`  specified 
     - and the same for colors specified as well.
  - For the `table_ForcedSource-time-series.vot` file, enable `Group By` by `band` column, also change Y-axis to `psfDiffFlux` for a better view
     - the traces here should also follow the order specified in Firefly.js file .. `'1819', '15', '12', '1112'`,  and so on...
     - again, colors will also follow the list of specified colors.
- feel free to use any other chart/spectra files to test this functionality (and for any columns not hardcoded in `firefly.js`, it should all just follow default order/color mapping) 
- Also, load a chart (either via TAP search or file upload) and test the `Group By` functionality from the previous PR as well, to make sure it works as expected. 
