### PR TITLE
FIREFLY-2096: Fix API export bug (fixes storybook) 

### DIFF
--- a/component-library/build.gradle
+++ b/component-library/build.gradle
@@ -34,6 +34,8 @@ task buildLib(dependsOn: [loadConfig, installDeps]) {
     description = 'Build the component library (Vite).'
     group = 'build'
     inputs.dir  'src'
+    inputs.dir  "${rootDir}/src/firefly/js"
+    inputs.dir  "${rootDir}/src/firefly/html"
     inputs.file 'vite.config.js'
     inputs.file 'package.json'
     outputs.dir libDistDir
@@ -68,6 +70,8 @@ task buildStories(dependsOn: [loadConfig, installDeps]) {
     description = 'Build the Storybook static site.'
     group = 'build'
     inputs.dir  'src'
+    inputs.dir  "${rootDir}/src/firefly/js"
+    inputs.dir  "${rootDir}/src/firefly/html"
     inputs.dir  'stories'
     inputs.dir  '.storybook'
     inputs.file 'vite.config.js'

--- a/src/firefly/js/api/ApiBuild.js
+++ b/src/firefly/js/api/ApiBuild.js
@@ -54,7 +54,6 @@ import {buildHighLevelApi} from './ApiHighlevelBuild.js';
 // Parts of the lowlevel api
 import * as ApiUtil from './ApiUtil.js';
 import * as ApiUtilChart from './ApiUtilChart.jsx';
-import moreChartApi from './ApiUtilChart.jsx';
 import * as ApiUtilImage from './ApiUtilImage.jsx';
 import * as ApiUtilTable from './ApiUtilTable.jsx';
 import {buildViewerApi} from './ApiViewer.js';
@@ -218,7 +217,7 @@ export function buildLowlevelAPI() {
         WorkspacePickerPopup: fieldGroupWrap(WorkspacePickerPopup)
     };
 
-    const util= Object.assign({}, ApiUtil, {image:ApiUtilImage}, {chart:{...ApiUtilChart, ...moreChartApi}}, {table:ApiUtilTable}, {data:{}} );
+    const util= Object.assign({}, ApiUtil, {image:ApiUtilImage}, {chart:{...ApiUtilChart}}, {table:ApiUtilTable}, {data:{}} );
 
     return { action, ui, util };
 }

--- a/src/firefly/js/api/ApiUtilChart.jsx
+++ b/src/firefly/js/api/ApiUtilChart.jsx
@@ -5,17 +5,19 @@
 
 export * from '../charts/ChartUtil.js';
 
-
-
-// because util functions were defined in the wrong module, we'll have to
-// sort out those, then export it here.
-import * as Cntlr from '../charts/ChartsCntlr.js';
-
-const more = Object.fromEntries(
-    Object.entries(Cntlr)
-        .filter(([, value]) => typeof value === 'function')
-        .filter(([key]) => /^(get|has|set|reset|remove)/.test(key.trim()))
-);
-
-export default more;
-
+// These functions are implemented in ChartsCntlr but exposed here as part of
+// the public chart API. Keep the exports explicit to avoid eagerly enumerating
+// the ChartsCntlr namespace during its circular dependency with ChartUtil (todo: refactor to remove circular dependency)
+export {
+    getAnnotations,
+    getTraceSymbol,
+    hasUpperLimits,
+    hasLowerLimits,
+    resetChart,
+    getChartData,
+    getErrors,
+    getExpandedChartProps,
+    getChartIdsForTable,
+    getChartIdsInGroup,
+    removeChartsInGroup,
+} from '../charts/ChartsCntlr.js';


### PR DESCRIPTION
**Ticket**: [FIREFLY-2096](https://jira.ipac.caltech.edu/browse/FIREFLY-2096) 
- See ticket for description of bug, and to test bug in the UI
- This PR fixes the Storybook chart initialization error
  - `ApiUtilChart.jsx`: Replaces eager ChartsCntlr namespace enumeration with explicit chart API re-exports, avoiding the circular-dependency initialization error (should refactor the circular dependency between `ChartsCntlr` -> `ChartUtil` later) 
  - `build.gradle`: Adds shared Firefly JS/HTML directories as build inputs so Storybook rebuilds when shared source changes (this is just so you can test firefly changes within storybook in your local dev environment)

**Testing**: 
- **Firefly Component Library (Storybook)**: https://firefly-2096-storybook-bug.irsakubedev.ipac.caltech.edu/firefly/component-library/
  - should work as expected, the bug from the ticket should be fixed (compare against the version on irsacloud / fireflydev) 