### PR TITLE
FIREFLY-2080: Timseries bug fixes

### DIFF
--- a/src/firefly/js/templates/lightcurve/LcManager.js
+++ b/src/firefly/js/templates/lightcurve/LcManager.js
@@ -41,6 +41,7 @@ export const LC = {
     POWER_CNAME: 'Power',            // power column
     PEAK_CNAME: 'Peak',              // peak column
     PHASE_CNAME: 'phase',
+    PERIOD_FKEY: 'period',           // fieldKey for period in the FG_PERIOD_FINDER field group
 
     IMG_VIEWER_ID: 'lc_image_viewer',
     MAX_IMAGE_CNT: 7,
@@ -574,6 +575,8 @@ function handleTableLoad(layoutInfo, action) {
 
             layoutInfo = handleTableActive(layoutInfo, action);     // because table_active happened before loaded.. we'll handle it here.
         }
+        // populate the period field from the default-highlighted row as soon as the periodogram/peak table first loads
+        updatePeriodFieldFromTable(tbl_id);
     }
     if([LC.RAW_TABLE, LC.PHASE_FOLDED].includes(tbl_id)) {
         const {highlightedRow} = getTblById(tbl_id) || {};
@@ -645,22 +648,31 @@ function handleTableHighlight(layoutInfo, action) {
     }
 
     // update period field when it's selected from a table with period.
-    if (tbl_id === LC.PERIODOGRAM_TABLE || tbl_id === LC.PEAK_TABLE) {
-        const per = getPeriodFromTable(tbl_id);
-        if (per) {
-            dispatchValueChange({
-                fieldKey: (LC.PERIOD_CNAME).toLowerCase(),
-                groupKey: LC.FG_PERIOD_FINDER,
-                value: `${parseFloat(per)}`
-            });
-        }
-    }
+    updatePeriodFieldFromTable(tbl_id);
 
     // ensure the highlighted row of the raw and phase-folded tables are in sync.
     keepHighlightedRowSynced(tbl_id, highlightedRow);
 
     return layoutInfo;
     //return Object.assign({}, layoutInfo);
+}
+
+/**
+ * @summary update the period field from the periodogram/peak table's currently highlighted row.
+ * Shared by the initial table load (default-highlighted row) and by explicit row-highlight changes,
+ * so the period field stays in sync whether the user clicks a row or when the table first loads.
+ * @param {string} tbl_id
+ */
+function updatePeriodFieldFromTable(tbl_id) {
+    if (tbl_id !== LC.PERIODOGRAM_TABLE && tbl_id !== LC.PEAK_TABLE) return;
+    const per = getPeriodFromTable(tbl_id);
+    if (per) {
+        dispatchValueChange({
+            fieldKey: LC.PERIOD_FKEY,
+            groupKey: LC.FG_PERIOD_FINDER,
+            value: `${parseFloat(per)}`
+        });
+    }
 }
 
 /**

--- a/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
+++ b/src/firefly/js/templates/lightcurve/LcPeriodPlotly.jsx
@@ -58,7 +58,7 @@ const fKeyDef = {
     min: {fkey: 'periodMin', label: 'Period Min (day)'},
     max: {fkey: 'periodMax', label: 'Period Max (day)'},
     tz: {fkey: 'tzero', label: 'Zero Point Time'},
-    period: {fkey: 'period', label: 'Period (day)'},
+    period: {fkey: LC.PERIOD_FKEY, label: 'Period (day)'},
     tzmax: {fkey: 'tzeroMax', label: ''},
     uploadedfile: {fkey: 'uploadedFile', label: ''},
 };
@@ -92,7 +92,7 @@ const defValues= {
     [fKeyDef.max.fkey]: Object.assign(getTypeData(fKeyDef.max.fkey, '', 'minimum period in days', 0),
         {validator: null}),
     [fKeyDef.period.fkey]: Object.assign(getTypeData(fKeyDef.period.fkey, '', '', `${fKeyDef.period.label}:`, labelWidth-10),
-        {validator: null}),
+        {validator: null, nullAllowed: false}),
     [fKeyDef.uploadedfile.fkey]: Object.assign(getTypeData(fKeyDef.uploadedfile.fkey, '', 'Uploaded Filename', 0))
 };
 
@@ -734,6 +734,10 @@ const LcPFReducer= (initState) => {
                 switch (action.type) {
                     case FieldGroupCntlr.MOUNT_FIELD_GROUP:
                         initPeriodValues(inFields);
+                        // enforce nullAllowed for period field to be false, so that user must enter a value for period
+                        if (inFields[fKeyDef.period.fkey]?.nullAllowed !== false) {
+                            inFields = updateSet(inFields, [fKeyDef.period.fkey, 'nullAllowed'], false);
+                        }
                         break;
                     case FieldGroupCntlr.VALUE_CHANGE:
                         let period = getValidValueFrom(inFields, fKeyDef.period.fkey);
@@ -961,7 +965,7 @@ function setPFTableSuccess() {
  */
 function setPFTableFail() {
     return () => {
-        return showInfoPopup('Phase folding parameter setting error');
+        return showInfoPopup('Period value is required, enter one manually or use the slider or periodogram table to populate the input field.', 'Error');
     };
 }
 

--- a/src/firefly/js/templates/lightcurve/LcResult.jsx
+++ b/src/firefly/js/templates/lightcurve/LcResult.jsx
@@ -338,7 +338,7 @@ function updateFullRawTable(callback) {
                 {fieldKey: 'flux', value: get(layoutInfo, [LC.MISSION_DATA, LC.META_FLUX_CNAME])},
                 {fieldKey: 'periodMin', value: `${min}`},
                 {fieldKey: 'periodMax', value: `${max}`},
-                {fieldKey: 'period', value: `${period}`},
+                {fieldKey: LC.PERIOD_FKEY, value: `${period}`},
                 {fieldKey: 'tzero', value: `${tzero}`},
                 {fieldKey: 'tzeroMax', value: `${tzeroMax}`}];
 

--- a/src/firefly/js/templates/lightcurve/LcViewer.jsx
+++ b/src/firefly/js/templates/lightcurve/LcViewer.jsx
@@ -205,11 +205,7 @@ export const UploadPanel = ({initArgs,name= 'LCUpload'}) =>{
                        completeText='Upload'>
                 <FileDropZone {...{
                     dropEvent, setDropEvent,
-                    setLoadingOp: () => {
-                        setUploadContainer('isLocal');
-                        const newEv = {type: 'drop', dataTransfer: {files: Array.from(dropEvent.dataTransfer.files)}};
-                        setDropEvent(newEv);
-                    },
+                    setLoadingOp: () => setUploadContainer('isLocal'),
                 }}>
                     <Stack {...{width:1, alignItems:'center'}}>
                         <Stack {...{ml:0, mt:4, spacing:3}}>


### PR DESCRIPTION
**Ticket**: [FIREFLY-2080](https://jira.ipac.caltech.edu/browse/FIREFLY-2080?atlLinkOrigin=c2xhY2staW50ZWdyYXRpb258aXNzdWU%3D)
- The period field is a required input field, the input can't be null/empty 
- Drag/Drop on timeseries was broken (try it on ops/dev/test, and click upload, you'll get stuck on the page)

**Testing**: 
- **IRSAViewer / Timeseries**: https://firefly-2080-timeseries-bug.irsakubedev.ipac.caltech.edu/irsaviewer/timeseries
  - use the file in the ticket, upload, click on Period Finder 
     - attempt to drag & drop the file, this was broken earlier, but is fixed in this PR. 
  - Click "Accept" when the period input field (`Enter manually`) is empty
      - you should see an error message (let me know if you would like to suggest better error message text here) 
 - Click on `Calculate Periodogram`
    - The resulting Periodogram table's default elected row's (first row) `Period` value should automatically be populated in the input field
    - clicking on different rows of the `Periodogram`/`Peaks` table should populate the `Period` values from those rows into the input field
 - Clicking around on slider should also populate the corresponding values on to the input field (like before)    